### PR TITLE
internal/contour: truncate object names to 60 characters

### DIFF
--- a/internal/contour/cds_test.go
+++ b/internal/contour/cds_test.go
@@ -57,6 +57,31 @@ func TestServiceToClusters(t *testing.T) {
 			ServiceName:      "default/simple/6502",
 		}},
 	}, {
+		name: "long namespace and service name",
+		s: &v1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "tiny-cog-department-test-instance",
+				Namespace: "beurocratic-company-test-domain-1",
+			},
+			Spec: v1.ServiceSpec{
+				Selector: map[string]string{
+					"app": "simple",
+				},
+				Ports: []v1.ServicePort{{
+					Protocol:   "TCP",
+					Port:       80,
+					TargetPort: intstr.FromInt(6502),
+				}},
+			},
+		},
+		want: []envoy.Cluster{{
+			Name:             "beurocratic-company-test-domain-1/tiny-cog-depa-52e801/80",
+			Type:             "sds",
+			ConnectTimeoutMs: 250,
+			LBType:           "round_robin",
+			ServiceName:      "beurocratic-company-test-domain-1/tiny-cog-department-test-instance/6502", // ServiceName is not subject to the 60 char limit
+		}},
+	}, {
 		name: "single named service port",
 		s: &v1.Service{
 			ObjectMeta: metav1.ObjectMeta{

--- a/internal/contour/json.go
+++ b/internal/contour/json.go
@@ -16,11 +16,14 @@
 package contour
 
 import (
+	"crypto/sha256"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/pprof"
 	"strconv"
+	"strings"
 
 	"k8s.io/api/core/v1"
 	"k8s.io/api/extensions/v1beta1"
@@ -182,4 +185,52 @@ func (a *jsonAPI) writeJSON(w io.Writer, v interface{}) {
 	if err := enc.Encode(v); err != nil {
 		a.Errorf("failed to encode JSON: %v", err)
 	}
+}
+
+// hashname takes a lenth l and a varargs of strings s and returns a string whose length
+// which does not exceed l. Internally s is joined with strings.Join(s, "/"). If the
+// combined length exceeds l then hashname truncates each element in s, starting from the
+// end using a hash derived from the contents of s (not the current element). This process
+// continues until the length of s does not exceed l, or all elements have been truncated.
+// In which case, the entire string is replaced with a hash not exceeding the length of l.
+func hashname(l int, s ...string) string {
+	const shorthash = 6 // the length of the shorthash
+
+	r := strings.Join(s, "/")
+	if l > len(r) {
+		// we're under the limit, nothing to do
+		return r
+	}
+	hash := fmt.Sprintf("%x", sha256.Sum256([]byte(r)))
+	for n := len(s) - 1; n >= 0; n-- {
+		s[n] = truncate(l/len(s), s[n], hash[:shorthash])
+		r = strings.Join(s, "/")
+		if l > len(r) {
+			return r
+		}
+	}
+	// truncated everything, but we're still too long
+	// just return the hash truncated to l.
+	return hash[:min(len(hash), l)]
+}
+
+// truncate truncates s to l length by replacing the
+// end of s with -suffix.
+func truncate(l int, s, suffix string) string {
+	if l >= len(s) {
+		// under the limit, nothing to do
+		return s
+	}
+	if l <= len(suffix) {
+		// easy case, just return the start of the suffix
+		return suffix[:min(l, len(suffix))]
+	}
+	return s[:l-len(suffix)-1] + "-" + suffix
+}
+
+func min(a, b int) int {
+	if a > b {
+		return b
+	}
+	return a
 }

--- a/internal/contour/rds.go
+++ b/internal/contour/rds.go
@@ -41,7 +41,7 @@ func IngressToVirtualHosts(i *v1beta1.Ingress) ([]*envoy.VirtualHost, error) {
 	// validateIngress ensures this.
 	if i.Spec.Backend != nil {
 		v := envoy.VirtualHost{
-			Name: i.Namespace + "/" + i.Name,
+			Name: hashname(60, i.Namespace, i.Name),
 		}
 		v.AddDomain("*")
 		v.AddRoute(envoy.Route{
@@ -53,7 +53,7 @@ func IngressToVirtualHosts(i *v1beta1.Ingress) ([]*envoy.VirtualHost, error) {
 	var vhosts []*envoy.VirtualHost
 	for _, rule := range i.Spec.Rules {
 		v := envoy.VirtualHost{
-			Name: i.Namespace + "/" + i.Name + "/" + rule.Host,
+			Name: hashname(60, i.Namespace, i.Name, rule.Host),
 		}
 		v.AddDomain(rule.Host)
 		if rule.IngressRuleValue.HTTP == nil {
@@ -95,7 +95,7 @@ func validateIngress(i *v1beta1.Ingress) error {
 
 // ingressBackendToClusterName renders a cluster name from an Ingress and an IngressBackend.
 func ingressBackendToClusterName(i *v1beta1.Ingress, b *v1beta1.IngressBackend) string {
-	return i.ObjectMeta.Namespace + "/" + b.ServiceName + "/" + b.ServicePort.String()
+	return hashname(60, i.ObjectMeta.Namespace, b.ServiceName, b.ServicePort.String())
 }
 
 // pathToRoute converts a HTTPIngressPath to a partial envoy.Route.


### PR DESCRIPTION
Fixes #25

Envoy requires Name fields to be 60 characters or less. Rather than
doing the simple thing and using hashes as UUIDs everywhere, this PR
tries hard to preserve as much of the original name as possible, while
progressively truncating the longest fields to stay under the 60 char
limit.

Signed-off-by: Dave Cheney <dave@cheney.net>