### PR TITLE
internal/contour: remove unused gRPCAPI contour.DataSource param

### DIFF
--- a/cmd/contour/contour.go
+++ b/cmd/contour/contour.go
@@ -96,7 +96,7 @@ func main() {
 				logger.Errorf("could not listen on %s: %v", V2_API_ADDRESS, err)
 				return // TODO(dfc) should return the error not log it
 			}
-			s := contour.NewGRPCAPI(logger, &ds)
+			s := contour.NewGRPCAPI(logger)
 			s.Serve(l)
 		})
 

--- a/internal/contour/grpc.go
+++ b/internal/contour/grpc.go
@@ -24,10 +24,9 @@ import (
 )
 
 // NewGPRCAPI returns a *grpc.Server which responds to the Envoy v2 xDS gRPC API.
-func NewGRPCAPI(l log.Logger, ds *DataSource) *grpc.Server {
+func NewGRPCAPI(l log.Logger) *grpc.Server {
 	a := &grpcAPI{
-		Logger:     l,
-		DataSource: ds,
+		Logger: l,
 	}
 	s := grpc.NewServer()
 	v2.RegisterClusterDiscoveryServiceServer(s, a)
@@ -39,7 +38,6 @@ func NewGRPCAPI(l log.Logger, ds *DataSource) *grpc.Server {
 
 type grpcAPI struct {
 	log.Logger
-	*DataSource
 }
 
 func (g *grpcAPI) FetchClusters(_ context.Context, req *v2.DiscoveryRequest) (*v2.DiscoveryResponse, error) {

--- a/internal/contour/grpc_test.go
+++ b/internal/contour/grpc_test.go
@@ -39,19 +39,8 @@ func TestGRPCAPIFetchClusters(t *testing.T) {
 	l := stdlog.New(w, w, 0)
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			var ds DataSource
-			for _, s := range tc.services {
-				ds.AddService(s)
-			}
-			for _, e := range tc.endpoints {
-				ds.AddEndpoints(e)
-			}
-			for _, i := range tc.ingresses {
-				ds.AddIngress(i)
-			}
 			api := &grpcAPI{
-				Logger:     l,
-				DataSource: &ds,
+				Logger: l,
 			}
 			got, err := api.FetchClusters(context.TODO(), &tc.req)
 			checkErr(t, err)


### PR DESCRIPTION
This param doesn't make sense in a push populated cache, it'll be
replaced with a v2 version soon.

Signed-off-by: Dave Cheney <dave@cheney.net>