### PR TITLE
internal/log: insert prefix in correct location

### DIFF
--- a/internal/log/stdlog/stdlog.go
+++ b/internal/log/stdlog/stdlog.go
@@ -72,11 +72,25 @@ func (l *infoLogger) V(v int) log.InfoLogger {
 }
 
 func (l *infoLogger) WithPrefix(prefix string) log.Logger {
-	ll := *l.Logger // TODO(dfc) gross!!!
-	ll.SetPrefix(prefix)
-	return &infoLogger{
-		errorLogger: l.errorLogger,
-		Logger:      &ll,
-		v:           l.v,
+	return &prefixLogger{
+		infoLogger: l,
+		prefix:     prefix,
 	}
+}
+
+type prefixLogger struct {
+	*infoLogger
+	prefix string
+}
+
+func (l *prefixLogger) Infof(format string, args ...interface{}) {
+	l.Output(2, fmt.Sprintf(l.prefix+": "+format, args...))
+}
+
+func (l *prefixLogger) Error(args ...interface{}) {
+	l.errorLogger.Output(2, fmt.Sprintln(append([]interface{}{l.prefix + ":"}, args...)...))
+}
+
+func (l *prefixLogger) Errorf(format string, args ...interface{}) {
+	l.errorLogger.Output(2, fmt.Sprintf(l.prefix+": "+format, args...))
 }

--- a/internal/log/stdlog/stdlog_test.go
+++ b/internal/log/stdlog/stdlog_test.go
@@ -14,10 +14,117 @@
 package stdlog
 
 import (
+	"bytes"
 	"os"
+	"testing"
 
 	"github.com/heptio/contour/internal/log"
 )
 
-var root log.Logger = New(os.Stdout, os.Stderr, 0)
-var info log.InfoLogger = root.V(99)
+func TestNew(t *testing.T) {
+	var _ log.Logger = New(os.Stdout, os.Stderr, 0)
+}
+
+func TestV(t *testing.T) {
+	var root log.Logger = New(os.Stdout, os.Stderr, 0)
+	var _ log.InfoLogger = root.V(99)
+}
+
+func TestInfof(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	const NOFLAGS = 1 << 16
+	var root log.Logger = New(&stdout, &stderr, NOFLAGS)
+	root.Infof("stdout %q", "%")
+
+	const want = "stdout \"%\"\n"
+	if stdout.String() != want {
+		t.Fatalf("expected %q, got %q", want, stdout.String())
+	}
+
+	if stderr.String() != "" {
+		t.Fatalf("expected %q, got %q", "", stderr.String())
+	}
+}
+
+func TestError(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	const NOFLAGS = 1 << 16
+	var root log.Logger = New(&stdout, &stderr, NOFLAGS)
+	root.Error("stderr %q", "%")
+
+	if stdout.String() != "" {
+		t.Fatalf("expected %q, got %q", "", stdout.String())
+	}
+
+	const want = "stderr %q %\n"
+	if stderr.String() != want {
+		t.Fatalf("expected %q, got %q", want, stderr.String())
+	}
+}
+
+func TestErrorf(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	const NOFLAGS = 1 << 16
+	var root log.Logger = New(&stdout, &stderr, NOFLAGS)
+	root.Errorf("stderr %q", "%")
+
+	if stdout.String() != "" {
+		t.Fatalf("expected %q, got %q", "", stdout.String())
+	}
+
+	const want = "stderr \"%\"\n"
+	if stderr.String() != want {
+		t.Fatalf("expected %q, got %q", want, stderr.String())
+	}
+}
+
+func TestPrefixInfof(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	const NOFLAGS = 1 << 16
+	var root log.Logger = New(&stdout, &stderr, NOFLAGS)
+	var log = root.WithPrefix("prefix")
+	log.Infof("stdout %q", "%")
+
+	const want = "prefix: stdout \"%\"\n"
+	if stdout.String() != want {
+		t.Fatalf("expected %q, got %q", want, stdout.String())
+	}
+
+	if stderr.String() != "" {
+		t.Fatalf("expected %q, got %q", "", stderr.String())
+	}
+}
+
+func TestPrefixError(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	const NOFLAGS = 1 << 16
+	var root log.Logger = New(&stdout, &stderr, NOFLAGS)
+	var log = root.WithPrefix("prefix")
+	log.Error("stderr %q", "%")
+
+	if stdout.String() != "" {
+		t.Fatalf("expected %q, got %q", "", stdout.String())
+	}
+
+	const want = "prefix: stderr %q %\n"
+	if stderr.String() != want {
+		t.Fatalf("expected %q, got %q", want, stderr.String())
+	}
+}
+
+func TestPrefixErrorf(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	const NOFLAGS = 1 << 16
+	var root log.Logger = New(&stdout, &stderr, NOFLAGS)
+	var log = root.WithPrefix("prefix")
+	log.Errorf("stderr %q", "%")
+
+	if stdout.String() != "" {
+		t.Fatalf("expected %q, got %q", "", stdout.String())
+	}
+
+	const want = "prefix: stderr \"%\"\n"
+	if stderr.String() != want {
+		t.Fatalf("expected %q, got %q", want, stderr.String())
+	}
+}


### PR DESCRIPTION
stdlog.SetPrefix places the prefix at the front of the log line, not the
log message, which is not what we want.

Fix this and add some tests for the various Info/Error/Errorf methods.

Signed-off-by: Dave Cheney <dave@cheney.net>