### PR TITLE
internal/envoy: add various gRPC v2 caches

### DIFF
--- a/internal/envoy/cache.go
+++ b/internal/envoy/cache.go
@@ -1,0 +1,274 @@
+// Copyright © 2017 Heptio
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package envoy
+
+import (
+	"sort"
+
+	v2 "github.com/envoyproxy/go-control-plane/api"
+)
+
+// ClusterCache represents a cache of computed *v2.Cluster objects.
+type ClusterCache interface {
+	// Values returns a copy of the contents of the cache.
+	Values() []*v2.Cluster
+
+	// Add adds an entry to the cache. If a Cluster with the same
+	// name exists, it is replaced.
+	Add(*v2.Cluster)
+
+	// Remove removes the named entry from the cache. If the entry
+	// is not present in the cache, the operation is a no-op.
+	Remove(string)
+}
+
+// NewClusterCache returns a new ClusterCache.
+func NewClusterCache() ClusterCache {
+	cc := make(clusterCache, 1)
+	cc <- nil // prime cache
+	return cc
+}
+
+// clusterCache is a thread safe, atomic, copy on write cache of *v2.Cluster objects.
+type clusterCache chan []*v2.Cluster
+
+func (cc clusterCache) Values() []*v2.Cluster {
+	v := <-cc
+	r := make([]*v2.Cluster, len(v))
+	copy(r, v)
+	cc <- v
+	return r
+}
+
+// with executes f with the value of the stored in the cache.
+// the value returned from f replaces the contents in the cache.
+func (cc clusterCache) with(f func([]*v2.Cluster) []*v2.Cluster) {
+	v := <-cc
+	v = f(v)
+	// TODO(dfc) Add and Remove do not (currently) affect the sort order
+	// so it might be possible to avoid always sorting.
+	sort.Sort(clusterByName(v))
+	cc <- v
+}
+
+// TODO(dfc) make Add variadic to support atomic addition of several clusters
+// also niladic Add can be used as a no-op notify for watchers.
+func (cc clusterCache) Add(c *v2.Cluster) {
+	cc.with(func(in []*v2.Cluster) []*v2.Cluster {
+		sort.Sort(clusterByName(in))
+		i := sort.Search(len(in), func(i int) bool { return in[i].Name >= c.Name })
+		if i < len(in) && in[i].Name == c.Name {
+			// c is already present, replace
+			in[i] = c
+			return in
+		}
+		// c is not present, append and sort
+		in = append(in, c)
+		sort.Sort(clusterByName(in))
+		return in
+	})
+}
+
+func (cc clusterCache) Remove(name string) {
+	cc.with(func(in []*v2.Cluster) []*v2.Cluster {
+		sort.Sort(clusterByName(in))
+		i := sort.Search(len(in), func(i int) bool { return in[i].Name >= name })
+		if i < len(in) && in[i].Name == name {
+			// c is present, remove
+			in = append(in[:i], in[i+1:]...)
+		}
+		return in
+	})
+}
+
+type clusterByName []*v2.Cluster
+
+func (c clusterByName) Len() int {
+	return len(c)
+}
+
+func (c clusterByName) Swap(i, j int) {
+	c[i], c[j] = c[j], c[i]
+}
+
+func (c clusterByName) Less(i, j int) bool {
+	return c[i].Name < c[j].Name
+}
+
+// ClusterLoadAssignemntCache represents a cache of computed *v2.ClusterLoadAssignment objects.
+type ClusterLoadAssignmentCache interface {
+	// Values returns a copy of the contents of the cache.
+	Values() []*v2.ClusterLoadAssignment
+
+	// Add adds an entry to the cache. If a ClusterLoadAssignment with the same
+	// name exists, it is replaced.
+	Add(*v2.ClusterLoadAssignment)
+
+	// Remove removes the named entry from the cache. If the entry
+	// is not present in the cache, the operation is a no-op.
+	Remove(string)
+}
+
+// NewClusterLoadAssignmentCache returns a new ClusterLoadAssignmentCache.
+func NewClusterLoadAssignmentCache() ClusterLoadAssignmentCache {
+	c := make(clusterLoadAssignmentCache, 1)
+	c <- nil // prime cache
+	return c
+}
+
+// clusterLoadAssignmentCache is a thread safe, atomic, copy on write cache of v2.ClusterLoadAssignment objects.
+type clusterLoadAssignmentCache chan []*v2.ClusterLoadAssignment
+
+func (c clusterLoadAssignmentCache) Values() []*v2.ClusterLoadAssignment {
+	v := <-c
+	r := make([]*v2.ClusterLoadAssignment, len(v))
+	copy(r, v)
+	c <- v
+	return r
+}
+
+// with executes f with the value of the stored in the cache.
+// the value returned from f replaces the contents in the cache.
+func (c clusterLoadAssignmentCache) with(f func([]*v2.ClusterLoadAssignment) []*v2.ClusterLoadAssignment) {
+	v := <-c
+	v = f(v)
+	// TODO(dfc) Add and Remove do not (currently) affect the sort order
+	// so it might be possible to avoid always sorting.
+	sort.Sort(clusterLoadAssignmentsByName(v))
+	c <- v
+}
+
+// TODO(dfc) make Add variadic to support atomic addition of several clusters
+// also niladic Add can be used as a no-op notify for watchers.
+func (c clusterLoadAssignmentCache) Add(e *v2.ClusterLoadAssignment) {
+	c.with(func(in []*v2.ClusterLoadAssignment) []*v2.ClusterLoadAssignment {
+		sort.Sort(clusterLoadAssignmentsByName(in))
+		i := sort.Search(len(in), func(i int) bool { return in[i].ClusterName >= e.ClusterName })
+		if i < len(in) && in[i].ClusterName == e.ClusterName {
+			in[i] = e
+			return in
+		}
+		in = append(in, e)
+		sort.Sort(clusterLoadAssignmentsByName(in))
+		return in
+	})
+}
+
+func (c clusterLoadAssignmentCache) Remove(name string) {
+	c.with(func(in []*v2.ClusterLoadAssignment) []*v2.ClusterLoadAssignment {
+		sort.Sort(clusterLoadAssignmentsByName(in))
+		i := sort.Search(len(in), func(i int) bool { return in[i].ClusterName >= name })
+		if i < len(in) && in[i].ClusterName == name {
+			// c is present, remove
+			in = append(in[:i], in[i+1:]...)
+		}
+		return in
+	})
+}
+
+type clusterLoadAssignmentsByName []*v2.ClusterLoadAssignment
+
+func (c clusterLoadAssignmentsByName) Len() int           { return len(c) }
+func (c clusterLoadAssignmentsByName) Swap(i, j int)      { c[i], c[j] = c[j], c[i] }
+func (c clusterLoadAssignmentsByName) Less(i, j int) bool { return c[i].ClusterName < c[j].ClusterName }
+
+// ListenerCache is a thread safe, atomic, copy on write cache of v2.Listener objects.
+type ListenerCache chan []*v2.Listener
+
+func (lc ListenerCache) Values() []*v2.Listener {
+	v := <-lc
+	r := make([]*v2.Listener, len(v))
+	copy(r, v)
+	lc <- v
+	return r
+}
+
+// VirtualHostCache represents a cache of computed *v2.VirtualHost objects.
+type VirtualHostCache interface {
+	// Values returns a copy of the contents of the cache.
+	Values() []*v2.VirtualHost
+
+	// Add adds an entry to the cache. If a VirtualHost with the same
+	// name exists, it is replaced.
+	Add(*v2.VirtualHost)
+
+	// Remove removes the named entry from the cache. If the entry
+	// is not present in the cache, the operation is a no-op.
+	Remove(string)
+}
+
+// NewVirtualHostCache returns a new VirtualHostCache.
+func NewVirtualHostCache() VirtualHostCache {
+	v := make(virtualHostCache, 1)
+	v <- nil // prime cache
+	return v
+}
+
+// VirtualHostCache is a thread safe, atomic, copy on write cache of v2.VirtualHost objects.
+type virtualHostCache chan []*v2.VirtualHost
+
+func (vc virtualHostCache) Values() []*v2.VirtualHost {
+	v := <-vc
+	r := make([]*v2.VirtualHost, len(v))
+	copy(r, v)
+	vc <- v
+	return r
+}
+
+// with executes f with the value of the stored in the cache.
+// the value returned from f replaces the contents in the cache.
+func (vc virtualHostCache) with(f func([]*v2.VirtualHost) []*v2.VirtualHost) {
+	v := <-vc
+	v = f(v)
+	// TODO(dfc) Add and Remove do not (currently) affect the sort order
+	// so it might be possible to avoid always sorting.
+	sort.Sort(virtualHostsByName(v))
+	vc <- v
+}
+
+// TODO(dfc) make Add variadic to support atomic addition of several clusters
+// also niladic Add can be used as a no-op notify for watchers.
+func (vc virtualHostCache) Add(r *v2.VirtualHost) {
+	vc.with(func(in []*v2.VirtualHost) []*v2.VirtualHost {
+		sort.Sort(virtualHostsByName(in))
+		i := sort.Search(len(in), func(i int) bool { return in[i].Name >= r.Name })
+		if i < len(in) && in[i].Name == r.Name {
+			// c is already present, replace
+			in[i] = r
+			return in
+		}
+		// c is not present, append and sort
+		in = append(in, r)
+		sort.Sort(virtualHostsByName(in))
+		return in
+	})
+}
+
+func (vc virtualHostCache) Remove(name string) {
+	vc.with(func(in []*v2.VirtualHost) []*v2.VirtualHost {
+		sort.Sort(virtualHostsByName(in))
+		i := sort.Search(len(in), func(i int) bool { return in[i].Name >= name })
+		if i < len(in) && in[i].Name == name {
+			// c is present, remove
+			in = append(in[:i], in[i+1:]...)
+		}
+		return in
+	})
+}
+
+type virtualHostsByName []*v2.VirtualHost
+
+func (v virtualHostsByName) Len() int           { return len(v) }
+func (v virtualHostsByName) Swap(i, j int)      { v[i], v[j] = v[j], v[i] }
+func (v virtualHostsByName) Less(i, j int) bool { return v[i].Name < v[j].Name }

--- a/internal/envoy/cache_test.go
+++ b/internal/envoy/cache_test.go
@@ -1,0 +1,383 @@
+// Copyright © 2017 Heptio
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package envoy
+
+import (
+	"reflect"
+	"testing"
+
+	v2 "github.com/envoyproxy/go-control-plane/api"
+)
+
+func TestNewClusterCacheReturnsAnEmptySlice(t *testing.T) {
+	cc := NewClusterCache()
+	got := cc.Values()
+	want := make([]*v2.Cluster, 0)
+	if !reflect.DeepEqual(got, want) {
+		// Values should return a []*v2.Cluster{} not nil
+		t.Fatal("NewClusterCache().Values(): got: %#v, want: %#v", got, want)
+	}
+}
+
+func TestClusterCacheValuesReturnsACopyOfItsInternalSlice(t *testing.T) {
+	cc := NewClusterCache()
+	c := &v2.Cluster{
+		Name: "alpha",
+	}
+	cc.Add(c)
+
+	v1 := cc.Values()
+	v2 := cc.Values()
+
+	if &v1[0] == &v2[0] {
+		// the address of the 0th element of the values slice should not be the same
+		// if it is, then we don't have a copy.
+		t.Fatalf("ClusterCache, consecutive calls to Values return the same backing slice: got: %p, want: %p", &v1[0], &v2[0])
+	}
+}
+
+func TestClusterCacheValuesReturnsTheSameContents(t *testing.T) {
+	cc := NewClusterCache()
+	c := &v2.Cluster{
+		Name: "alpha",
+	}
+	cc.Add(c)
+
+	v1 := cc.Values()
+	v2 := cc.Values()
+
+	if v1[0] != v2[0] {
+		// the value of the 0th element, a pointer to a v2.Cluster should be the same
+		t.Fatalf("ClusterCache, consecutive calls to Values returned different slice contents: got: %p, want: %p", v1[0], v2[0])
+	}
+}
+
+func TestClusterCacheAddInsertsTwoElementsInSortOrder(t *testing.T) {
+	cc := NewClusterCache()
+	c1 := &v2.Cluster{
+		Name: "beta",
+	}
+	cc.Add(c1)
+	c2 := &v2.Cluster{
+		Name: "alpha",
+	}
+	cc.Add(c2)
+	got := cc.Values()
+	want := []*v2.Cluster{{
+		Name: "alpha",
+	}, {
+		Name: "beta",
+	}}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("ClusterCache.Add/Values returned elements missing or out of order, got: %v, want: %v", got, want)
+	}
+}
+
+func TestClusterCacheAddOverwritesElementsWithTheSameName(t *testing.T) {
+	cc := NewClusterCache()
+	c1 := &v2.Cluster{
+		Name: "alpha",
+		Type: 1,
+	}
+	cc.Add(c1)
+	c2 := &v2.Cluster{
+		Name: "alpha",
+		Type: 2,
+	}
+	cc.Add(c2)
+	got := cc.Values()
+	want := []*v2.Cluster{
+		c2,
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("ClusterCache.Add/Values returned a stale element, got: %v, want: %v", got, want)
+	}
+}
+
+func TestClusterCacheAddIsCopyOnWrite(t *testing.T) {
+	cc := NewClusterCache()
+	c1 := &v2.Cluster{
+		Name: "alpha",
+	}
+	cc.Add(c1)
+	v1 := cc.Values()
+
+	c2 := &v2.Cluster{
+		Name: "beta",
+	}
+	cc.Add(c2)
+	v2 := cc.Values()
+
+	if reflect.DeepEqual(v1, v2) {
+		t.Fatalf("ClusterCache.Add affected the contents of a previous call to Values")
+	}
+}
+
+func TestClusterCacheRemove(t *testing.T) {
+	cc := NewClusterCache()
+	c1 := &v2.Cluster{
+		Name: "alpha",
+	}
+	cc.Add(c1)
+	cc.Remove("alpha")
+	got := cc.Values()
+	want := []*v2.Cluster{}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("ClusterCache.Remove: got: %v, want: %v", got, want)
+	}
+}
+
+func TestNewClusterLoadAssignmentCacheReturnsAnEmptySlice(t *testing.T) {
+	cc := NewClusterLoadAssignmentCache()
+	got := cc.Values()
+	want := make([]*v2.ClusterLoadAssignment, 0)
+	if !reflect.DeepEqual(got, want) {
+		// Values should return a []*v2.ClusterLoadAssignment{} not nil
+		t.Fatal("NewClusterLoadAssignmentCache().Values(): got: %#v, want: %#v", got, want)
+	}
+}
+
+func TestClusterLoadAssignmentCacheValuesReturnsACopyOfItsInternalSlice(t *testing.T) {
+	cc := NewClusterLoadAssignmentCache()
+	c := &v2.ClusterLoadAssignment{
+		ClusterName: "alpha",
+	}
+	cc.Add(c)
+
+	v1 := cc.Values()
+	v2 := cc.Values()
+
+	if &v1[0] == &v2[0] {
+		// the address of the 0th element of the values slice should not be the same
+		// if it is, then we don't have a copy.
+		t.Fatalf("ClusterLoadAssignmentCache, consecutive calls to Values return the same backing slice: got: %p, want: %p", &v1[0], &v2[0])
+	}
+}
+
+func TestClusterLoadAssignmentCacheValuesReturnsTheSameContents(t *testing.T) {
+	cc := NewClusterLoadAssignmentCache()
+	c := &v2.ClusterLoadAssignment{
+		ClusterName: "alpha",
+	}
+	cc.Add(c)
+
+	v1 := cc.Values()
+	v2 := cc.Values()
+
+	if v1[0] != v2[0] {
+		// the value of the 0th element, a pointer to a v2.ClusterLoadAssignment should be the same
+		t.Fatalf("ClusterLoadAssignmentCache, consecutive calls to Values returned different slice contents: got: %p, want: %p", v1[0], v2[0])
+	}
+}
+
+func TestClusterLoadAssignmentCacheAddInsertsTwoElementsInSortOrder(t *testing.T) {
+	cc := NewClusterLoadAssignmentCache()
+	c1 := &v2.ClusterLoadAssignment{
+		ClusterName: "beta",
+	}
+	cc.Add(c1)
+	c2 := &v2.ClusterLoadAssignment{
+		ClusterName: "alpha",
+	}
+	cc.Add(c2)
+	got := cc.Values()
+	want := []*v2.ClusterLoadAssignment{{
+		ClusterName: "alpha",
+	}, {
+		ClusterName: "beta",
+	}}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("ClusterLoadAssignmentCache.Add/Values returned elements missing or out of order, got: %v, want: %v", got, want)
+	}
+}
+
+func TestClusterLoadAssignmentCacheAddOverwritesElementsWithTheSameName(t *testing.T) {
+	cc := NewClusterLoadAssignmentCache()
+	c1 := &v2.ClusterLoadAssignment{
+		ClusterName: "alpha",
+		Policy: &v2.ClusterLoadAssignment_Policy{
+			DropOverload: 0.0,
+		},
+	}
+	cc.Add(c1)
+	c2 := &v2.ClusterLoadAssignment{
+		ClusterName: "alpha",
+		Policy: &v2.ClusterLoadAssignment_Policy{
+			DropOverload: 1.0,
+		},
+	}
+	cc.Add(c2)
+	got := cc.Values()
+	want := []*v2.ClusterLoadAssignment{
+		c2,
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("ClusterLoadAssignmentCache.Add/Values returned a stale element, got: %v, want: %v", got, want)
+	}
+}
+
+func TestClusterLoadAssignmentCacheAddIsCopyOnWrite(t *testing.T) {
+	cc := NewClusterLoadAssignmentCache()
+	c1 := &v2.ClusterLoadAssignment{
+		ClusterName: "alpha",
+	}
+	cc.Add(c1)
+	v1 := cc.Values()
+
+	c2 := &v2.ClusterLoadAssignment{
+		ClusterName: "beta",
+	}
+	cc.Add(c2)
+	v2 := cc.Values()
+
+	if reflect.DeepEqual(v1, v2) {
+		t.Fatalf("ClusterLoadAssignmentCache.Add affected the contents of a previous call to Values")
+	}
+}
+
+func TestClusterLoadAssignmentCacheRemove(t *testing.T) {
+	cc := NewClusterLoadAssignmentCache()
+	c1 := &v2.ClusterLoadAssignment{
+		ClusterName: "alpha",
+	}
+	cc.Add(c1)
+	cc.Remove("alpha")
+	got := cc.Values()
+	want := []*v2.ClusterLoadAssignment{}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("ClusterLoadAssignmentCache.Remove: got: %v, want: %v", got, want)
+	}
+}
+
+func TestNewVirtualHostCacheReturnsAnEmptySlice(t *testing.T) {
+	cc := NewVirtualHostCache()
+	got := cc.Values()
+	want := make([]*v2.VirtualHost, 0)
+	if !reflect.DeepEqual(got, want) {
+		// Values should return a []*v2.VirtualHost{} not nil
+		t.Fatal("NewVirtualHostCache().Values(): got: %#v, want: %#v", got, want)
+	}
+}
+
+func TestVirtualHostCacheValuesReturnsACopyOfItsInternalSlice(t *testing.T) {
+	cc := NewVirtualHostCache()
+	c := &v2.VirtualHost{
+		Name: "alpha",
+	}
+	cc.Add(c)
+
+	v1 := cc.Values()
+	v2 := cc.Values()
+
+	if &v1[0] == &v2[0] {
+		// the address of the 0th element of the values slice should not be the same
+		// if it is, then we don't have a copy.
+		t.Fatalf("VirtualHostCache, consecutive calls to Values return the same backing slice: got: %p, want: %p", &v1[0], &v2[0])
+	}
+}
+
+func TestVirtualHostCacheValuesReturnsTheSameContents(t *testing.T) {
+	cc := NewVirtualHostCache()
+	c := &v2.VirtualHost{
+		Name: "alpha",
+	}
+	cc.Add(c)
+
+	v1 := cc.Values()
+	v2 := cc.Values()
+
+	if v1[0] != v2[0] {
+		// the value of the 0th element, a pointer to a v2.VirtualHost should be the same
+		t.Fatalf("VirtualHostCache, consecutive calls to Values returned different slice contents: got: %p, want: %p", v1[0], v2[0])
+	}
+}
+
+func TestVirtualHostCacheAddInsertsTwoElementsInSortOrder(t *testing.T) {
+	cc := NewVirtualHostCache()
+	c1 := &v2.VirtualHost{
+		Name: "beta",
+	}
+	cc.Add(c1)
+	c2 := &v2.VirtualHost{
+		Name: "alpha",
+	}
+	cc.Add(c2)
+	got := cc.Values()
+	want := []*v2.VirtualHost{{
+		Name: "alpha",
+	}, {
+		Name: "beta",
+	}}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("VirtualHostCache.Add/Values returned elements missing or out of order, got: %v, want: %v", got, want)
+	}
+}
+
+func TestVirtualHostCacheAddOverwritesElementsWithTheSameName(t *testing.T) {
+	cc := NewVirtualHostCache()
+	c1 := &v2.VirtualHost{
+		Name: "alpha",
+		Domains: []string{
+			"example.com",
+		},
+	}
+	cc.Add(c1)
+	c2 := &v2.VirtualHost{
+		Name: "alpha",
+		Domains: []string{
+			"heptio.com",
+		},
+	}
+	cc.Add(c2)
+	got := cc.Values()
+	want := []*v2.VirtualHost{
+		c2,
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("VirtualHostCache.Add/Values returned a stale element, got: %v, want: %v", got, want)
+	}
+}
+
+func TestVirtualHostCacheAddIsCopyOnWrite(t *testing.T) {
+	cc := NewVirtualHostCache()
+	c1 := &v2.VirtualHost{
+		Name: "alpha",
+	}
+	cc.Add(c1)
+	v1 := cc.Values()
+
+	c2 := &v2.VirtualHost{
+		Name: "beta",
+	}
+	cc.Add(c2)
+	v2 := cc.Values()
+
+	if reflect.DeepEqual(v1, v2) {
+		t.Fatalf("VirtualHostCache.Add affected the contents of a previous call to Values")
+	}
+}
+
+func TestVirtualHostCacheRemove(t *testing.T) {
+	cc := NewVirtualHostCache()
+	c1 := &v2.VirtualHost{
+		Name: "alpha",
+	}
+	cc.Add(c1)
+	cc.Remove("alpha")
+	got := cc.Values()
+	want := []*v2.VirtualHost{}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("VirtualHostCache.Remove: got: %v, want: %v", got, want)
+	}
+}


### PR DESCRIPTION
Add caches for

- Cluster
- ClusterLoadAssignment
- VirtualHost
- Listener

Signed-off-by: Dave Cheney <dave@cheney.net>