### PR TITLE
deployment: add gRPC powered deployment manifest

### DIFF
--- a/deployment/deployment-grpc-v2/01-common.yaml
+++ b/deployment/deployment-grpc-v2/01-common.yaml
@@ -1,0 +1,1 @@
+../common/common.yaml

--- a/deployment/deployment-grpc-v2/02-contour.yaml
+++ b/deployment/deployment-grpc-v2/02-contour.yaml
@@ -1,0 +1,60 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  labels:
+    app: contour
+  name: contour
+  namespace: heptio-contour
+spec:
+  selector:
+    matchLabels:
+      app: contour
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: contour
+    spec:
+      containers:
+      - image: docker.io/envoyproxy/envoy-alpine:latest
+        name: envoy
+        ports:
+        - containerPort: 8080
+          name: http
+        command: ["envoy"]
+        args: ["-c", "/config/contour.yaml", "--service-cluster", "cluster0", "--service-node", "node0", "-l", "info"]
+        volumeMounts:
+        - name: contour-config
+          mountPath: /config
+      - image: docker.io/davecheney/contour:latest
+        imagePullPolicy: Always
+        name: contour
+        command: ["contour"]
+        args: ["serve", "--incluster"]
+      initContainers:
+      - image: docker.io/davecheney/contour:latest
+        imagePullPolicy: Always
+        name: envoy-initconfig
+        command: ["contour"]
+        args: ["bootstrap", "/config/contour.yaml"]
+        volumeMounts:
+        - name: contour-config
+          mountPath: /config
+      volumes:
+      - name: contour-config
+        emptyDir: {}
+      dnsPolicy: ClusterFirst
+      serviceAccountName: contour
+      terminationGracePeriodSeconds: 30
+      # The affinity stanza below tells Kubernetes to try hard not to place 2 of
+      # these pods on the same node.
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: contour
+              topologyKey: kubernetes.io/hostname
+---

--- a/deployment/deployment-grpc-v2/02-rbac.yaml
+++ b/deployment/deployment-grpc-v2/02-rbac.yaml
@@ -1,0 +1,1 @@
+../common/rbac.yaml

--- a/deployment/deployment-grpc-v2/02-service.yaml
+++ b/deployment/deployment-grpc-v2/02-service.yaml
@@ -1,0 +1,1 @@
+../common/service.yaml


### PR DESCRIPTION
Updates #8

This is a very alpha configuration for connecting Contour and Envoy over
gRPC.

If you want to play with this, make sure you delete your existing
contour deployment as (at least with 1.7.6) editing a deployment does
not appear to save changes to the initContainer section.

Signed-off-by: Dave Cheney <dave@cheney.net>