### PR TITLE
internal/envoy: add envoy.Cond type

### DIFF
--- a/internal/envoy/cond.go
+++ b/internal/envoy/cond.go
@@ -1,0 +1,59 @@
+// Copyright © 2017 Heptio
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package envoy
+
+import "sync"
+
+// Cond implements a condition variable, a rendezvous point for goroutines
+// waiting for or announcing the occurence of an event.
+//
+// Unlike sync.Cond, Cond communciates with waiters via channels registered by
+// the waiters. This permits goroutines to wait on Cond events using select.
+type Cond struct {
+	mu      sync.Mutex
+	waiters []chan int
+	last    int
+}
+
+// Register registers ch to receive a value when Notify is called.
+// The value of last is the count of the times Notify has been called on this Cond.
+// It functions of a sequence counter, if the value of last supplied to Register
+// is less than the Conds internal counter, then the caller has missed at least
+// one notification and will fire immediately.
+//
+// Sends by the broadcaster to ch must not block, therefor ch must have a capacity
+// of at least 1.
+func (c *Cond) Register(ch chan int, last int) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if last < c.last {
+		// notify this channel immediately
+		ch <- c.last
+		return
+	}
+	c.waiters = append(c.waiters, ch)
+}
+
+// Notify notifies all registered waiters that an event has occured.
+func (c *Cond) Notify() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.last++
+
+	for _, ch := range c.waiters {
+		ch <- c.last
+	}
+	c.waiters = c.waiters[:0]
+}

--- a/internal/envoy/cond_test.go
+++ b/internal/envoy/cond_test.go
@@ -1,0 +1,57 @@
+// Copyright © 2017 Heptio
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package envoy
+
+import "testing"
+
+func TestCondRegisterBeforeNotifyShouldNotBroadcast(t *testing.T) {
+	var c Cond
+	ch := make(chan int, 1)
+	c.Register(ch, 0)
+	select {
+	case <-ch:
+		t.Fatal("ch was notified before broadcast")
+	default:
+	}
+}
+
+func TestCondRegisterAfterNotifyShouldBroadcast(t *testing.T) {
+	var c Cond
+	ch := make(chan int, 1)
+	c.Notify()
+	c.Register(ch, 0)
+	select {
+	case v := <-ch:
+		if v != 1 {
+			t.Fatal("ch was notified with the wrong sequence number", v)
+		}
+	default:
+		t.Fatal("ch was not notified on registration")
+	}
+}
+
+func TestCondRegisterAfterNotifyWithCorrectSequenceShouldNotBroadcast(t *testing.T) {
+	var c Cond
+	ch := make(chan int, 1)
+	c.Notify()
+	c.Register(ch, 0)
+	seq := <-ch
+
+	c.Register(ch, seq)
+	select {
+	case v := <-ch:
+		t.Fatal("ch was notified immediately with seq", v)
+	default:
+	}
+}

--- a/internal/envoy/example_test.go
+++ b/internal/envoy/example_test.go
@@ -1,0 +1,46 @@
+// Copyright © 2017 Heptio
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package envoy_test
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/heptio/contour/internal/envoy"
+)
+
+func ExampleCond() {
+	ctx, _ := context.WithTimeout(context.Background(), 1*time.Second)
+	ch := make(chan int, 1)
+	last := 0
+	var c envoy.Cond
+	go func() {
+		for {
+			time.Sleep(100 * time.Millisecond)
+			c.Notify()
+		}
+	}()
+
+	for {
+		c.Register(ch, last)
+		select {
+		case last = <-ch:
+			fmt.Println("notification received:", last)
+		case <-ctx.Done():
+			fmt.Println("timeout")
+			return
+		}
+	}
+}


### PR DESCRIPTION
Add a select friendly condition type to be used for notification of
cache changes to gRPC streamers.

Signed-off-by: Dave Cheney <dave@cheney.net>