### PR TITLE
internal/envoy: add listenerCache

### DIFF
--- a/internal/envoy/translator.go
+++ b/internal/envoy/translator.go
@@ -21,6 +21,7 @@ import (
 
 	v2 "github.com/envoyproxy/go-control-plane/api"
 	"github.com/golang/protobuf/ptypes/duration"
+	"github.com/golang/protobuf/ptypes/struct" // package name is structpb
 
 	"github.com/heptio/contour/internal/log"
 	"k8s.io/api/core/v1"
@@ -35,6 +36,9 @@ func NewTranslator(log log.Logger) *Translator {
 	}
 	t.ClusterCache.init()
 	t.ClusterLoadAssignmentCache.init()
+	t.ListenerCache.init()
+	t.ListenerCache.Add(defaultListener()) // insert default listerner
+	t.ListenerCache.Notify()               // bump version to notify streamers
 	t.VirtualHostCache.init()
 	return t
 }
@@ -49,6 +53,10 @@ type Translator struct {
 	}
 	ClusterLoadAssignmentCache struct {
 		clusterLoadAssignmentCache
+		Cond
+	}
+	ListenerCache struct {
+		listenerCache
 		Cond
 	}
 	VirtualHostCache struct {
@@ -392,4 +400,74 @@ func clusteraction(cluster string) *v2.Route_Route {
 			},
 		},
 	}
+}
+
+func defaultListener() *v2.Listener {
+	const (
+		router     = "envoy.router"
+		httpFilter = "envoy.http_connection_manager"
+		accessLog  = "envoy.file_access_log"
+	)
+
+	sv := func(s string) *structpb.Value {
+		return &structpb.Value{Kind: &structpb.Value_StringValue{StringValue: s}}
+	}
+	bv := func(b bool) *structpb.Value {
+		return &structpb.Value{Kind: &structpb.Value_BoolValue{BoolValue: b}}
+	}
+	st := func(m map[string]*structpb.Value) *structpb.Value {
+		return &structpb.Value{Kind: &structpb.Value_StructValue{StructValue: &structpb.Struct{Fields: m}}}
+	}
+	lv := func(v ...*structpb.Value) *structpb.Value {
+		return &structpb.Value{Kind: &structpb.Value_ListValue{ListValue: &structpb.ListValue{Values: v}}}
+	}
+	l := &v2.Listener{
+		Name: "ingress_http", // TODO(dfc) should come from the name of the service port
+		Address: &v2.Address{
+			Address: &v2.Address_SocketAddress{
+				SocketAddress: &v2.SocketAddress{
+					Protocol: v2.SocketAddress_TCP,
+					Address:  "0.0.0.0",
+					PortSpecifier: &v2.SocketAddress_PortValue{
+						PortValue: 8080,
+					},
+				},
+			},
+		},
+		FilterChains: []*v2.FilterChain{{
+			Filters: []*v2.Filter{{
+				Name: httpFilter,
+				Config: &structpb.Struct{
+					Fields: map[string]*structpb.Value{
+						"codec_type":  sv("http1"),        // let's not go crazy now
+						"stat_prefix": sv("ingress_http"), // TODO(dfc) should this come from pod.Name?
+						"rds": st(map[string]*structpb.Value{
+							"route_config_name": sv("ingress_http"), // TODO(dfc) needed for grpc?
+							"config_source": st(map[string]*structpb.Value{
+								"api_config_source": st(map[string]*structpb.Value{
+									"api_type": sv("grpc"),
+									"cluster_name": lv(
+										sv("xds_cluster"),
+									),
+								}),
+							}),
+						}),
+						"http_filters": lv(
+							st(map[string]*structpb.Value{
+								"name": sv(router),
+							}),
+						),
+						"access_log": st(map[string]*structpb.Value{
+							"name": sv(accessLog),
+							"config": st(map[string]*structpb.Value{
+								"path": sv("/dev/stdout"),
+							}),
+						}),
+						"use_remote_address": bv(true), // TODO(jbeda) should this ever be false?
+					},
+				},
+			}},
+		}},
+	}
+	return l
 }


### PR DESCRIPTION
Make LDS use a real listernerCache in preparation for SSL support (which
needs to create dynamic listeners).

Add tests, and move the `defaultListener` setup to internal/envoy.

Signed-off-by: Dave Cheney <dave@cheney.net>