### PR TITLE
internal/envoy: support multiple ingresses per vhost

### DIFF
--- a/internal/envoy/translator.go
+++ b/internal/envoy/translator.go
@@ -242,7 +242,7 @@ func (t *Translator) addIngress(i *v1beta1.Ingress) {
 	defer t.VirtualHostCache.Notify()
 	if i.Spec.Backend != nil {
 		v := v2.VirtualHost{
-			Name:    hashname(60, i.Namespace, i.Name),
+			Name:    "*",
 			Domains: []string{"*"},
 			Routes: []*v2.Route{{
 				Match:  prefixmatch("/"), // match all
@@ -255,7 +255,7 @@ func (t *Translator) addIngress(i *v1beta1.Ingress) {
 
 	for _, rule := range i.Spec.Rules {
 		v := v2.VirtualHost{
-			Name:    hashname(60, i.Namespace, i.Name, rule.Host),
+			Name:    hashname(60, rule.Host),
 			Domains: []string{rule.Host},
 		}
 		if rule.IngressRuleValue.HTTP == nil {
@@ -274,12 +274,12 @@ func (t *Translator) addIngress(i *v1beta1.Ingress) {
 func (t *Translator) removeIngress(i *v1beta1.Ingress) {
 	defer t.VirtualHostCache.Notify()
 	if i.Spec.Backend != nil {
-		t.VirtualHostCache.Remove(hashname(60, i.Namespace, i.Name))
+		t.VirtualHostCache.Remove("*")
 		return
 	}
 
 	for _, rule := range i.Spec.Rules {
-		t.VirtualHostCache.Remove(hashname(60, i.Namespace, i.Name, rule.Host))
+		t.VirtualHostCache.Remove(hashname(60, rule.Host))
 	}
 }
 

--- a/internal/envoy/translator_test.go
+++ b/internal/envoy/translator_test.go
@@ -330,7 +330,7 @@ func TestTranslatorAddIngress(t *testing.T) {
 			},
 		},
 		want: []*v2.VirtualHost{{
-			Name:    "default/simple",
+			Name:    "*",
 			Domains: []string{"*"},
 			Routes: []*v2.Route{{
 				Match:  prefixmatch("/"),
@@ -367,7 +367,7 @@ func TestTranslatorAddIngress(t *testing.T) {
 			},
 		},
 		want: []*v2.VirtualHost{{
-			Name:    "default/correct",
+			Name:    "*",
 			Domains: []string{"*"},
 			Routes: []*v2.Route{{
 				Match:  prefixmatch("/"), // match all
@@ -389,7 +389,7 @@ func TestTranslatorAddIngress(t *testing.T) {
 			},
 		},
 		want: []*v2.VirtualHost{{
-			Name:    "default/httpbin/httpbin.org",
+			Name:    "httpbin.org",
 			Domains: []string{"httpbin.org"},
 			Routes: []*v2.Route{{
 				Match:  prefixmatch("/"), // match all
@@ -418,7 +418,7 @@ func TestTranslatorAddIngress(t *testing.T) {
 			},
 		},
 		want: []*v2.VirtualHost{{
-			Name:    "default/httpbin/httpbin.org",
+			Name:    "httpbin.org",
 			Domains: []string{"httpbin.org"},
 			Routes: []*v2.Route{{
 				Match:  prefixmatch("/ip"), // if the field does not contact any regex characters, we treat it as a prefix
@@ -447,7 +447,7 @@ func TestTranslatorAddIngress(t *testing.T) {
 			},
 		},
 		want: []*v2.VirtualHost{{
-			Name:    "default/httpbin/httpbin.org",
+			Name:    "httpbin.org",
 			Domains: []string{"httpbin.org"},
 			Routes: []*v2.Route{{
 				Match:  regexmatch("/get.*"),
@@ -469,7 +469,7 @@ func TestTranslatorAddIngress(t *testing.T) {
 			},
 		},
 		want: []*v2.VirtualHost{{
-			Name:    "default/httpbin/httpbin.org",
+			Name:    "httpbin.org",
 			Domains: []string{"httpbin.org"},
 			Routes: []*v2.Route{{
 				Match:  prefixmatch("/"),
@@ -501,7 +501,7 @@ func TestTranslatorAddIngress(t *testing.T) {
 			},
 		},
 		want: []*v2.VirtualHost{{
-			Name:    "default/httpbin/httpbin.org",
+			Name:    "httpbin.org",
 			Domains: []string{"httpbin.org"},
 			Routes: []*v2.Route{{
 				Match:  prefixmatch("/peter"),
@@ -529,14 +529,14 @@ func TestTranslatorAddIngress(t *testing.T) {
 			},
 		},
 		want: []*v2.VirtualHost{{
-			Name:    "default/httpbin/admin.httpbin.org",
+			Name:    "admin.httpbin.org",
 			Domains: []string{"admin.httpbin.org"},
 			Routes: []*v2.Route{{
 				Match:  prefixmatch("/"),
 				Action: clusteraction("default/paul/paul"),
 			}},
 		}, {
-			Name:    "default/httpbin/httpbin.org",
+			Name:    "httpbin.org",
 			Domains: []string{"httpbin.org"},
 			Routes: []*v2.Route{{
 				Match:  prefixmatch("/"),
@@ -552,14 +552,14 @@ func TestTranslatorAddIngress(t *testing.T) {
 			},
 			Spec: v1beta1.IngressSpec{
 				Rules: []v1beta1.IngressRule{{
-					Host:             "my-very-very-long-service-host-name.my.domainname",
+					Host:             "my-very-very-long-service-host-name.subdomain.boring-dept.my.company",
 					IngressRuleValue: ingressrulevalue(backend("my-service-name", intstr.FromInt(80))),
 				}},
 			},
 		},
 		want: []*v2.VirtualHost{{
-			Name:    "default/my-service-name/my-very-very--c4d2d4",
-			Domains: []string{"my-very-very-long-service-host-name.my.domainname"},
+			Name:    "d31bb322ca62bb395acad00b3cbf45a3aa1010ca28dca7cddb4f7db786fa",
+			Domains: []string{"my-very-very-long-service-host-name.subdomain.boring-dept.my.company"},
 			Routes: []*v2.Route{{
 				Match:  prefixmatch("/"),
 				Action: clusteraction("default/my-service-name/80"),
@@ -594,7 +594,10 @@ func TestTranslatorRemoveIngress(t *testing.T) {
 						Namespace: "default",
 					},
 					Spec: v1beta1.IngressSpec{
-						Backend: backend("backend", intstr.FromInt(80)),
+						Rules: []v1beta1.IngressRule{{
+							Host:             "httpbin.org",
+							IngressRuleValue: ingressrulevalue(backend("peter", intstr.FromInt(80))),
+						}},
 					},
 				})
 			},
@@ -604,7 +607,10 @@ func TestTranslatorRemoveIngress(t *testing.T) {
 					Namespace: "default",
 				},
 				Spec: v1beta1.IngressSpec{
-					Backend: backend("backend", intstr.FromInt(80)),
+					Rules: []v1beta1.IngressRule{{
+						Host:             "httpbin.org",
+						IngressRuleValue: ingressrulevalue(backend("peter", intstr.FromInt(80))),
+					}},
 				},
 			},
 			want: []*v2.VirtualHost{},
@@ -617,7 +623,10 @@ func TestTranslatorRemoveIngress(t *testing.T) {
 						Namespace: "default",
 					},
 					Spec: v1beta1.IngressSpec{
-						Backend: backend("backend", intstr.FromInt(80)),
+						Rules: []v1beta1.IngressRule{{
+							Host:             "httpbin.org",
+							IngressRuleValue: ingressrulevalue(backend("peter", intstr.FromInt(80))),
+						}},
 					},
 				})
 			},
@@ -627,16 +636,19 @@ func TestTranslatorRemoveIngress(t *testing.T) {
 					Namespace: "default",
 				},
 				Spec: v1beta1.IngressSpec{
-					Backend: backend("rofl", intstr.FromInt(80)),
+					Rules: []v1beta1.IngressRule{{
+						Host:             "example.org",
+						IngressRuleValue: ingressrulevalue(backend("peter", intstr.FromInt(80))),
+					}},
 				},
 			},
 			want: []*v2.VirtualHost{
 				&v2.VirtualHost{
-					Name:    "default/simple",
-					Domains: []string{"*"},
+					Name:    "httpbin.org",
+					Domains: []string{"httpbin.org"},
 					Routes: []*v2.Route{{
 						Match:  prefixmatch("/"),
-						Action: clusteraction("default/backend/80"),
+						Action: clusteraction("default/peter/80"),
 					}},
 				},
 			},


### PR DESCRIPTION
Updates #89

To support the definition of the vhost across multiple ingress objects,
we remove the component of the VirtualHost's (envoy side) name that
referred to the name and the namespace of the object, as it could be
potentially more than one.

Signed-off-by: Dave Cheney <dave@cheney.net>