### PR TITLE
internal/envoy: split xDS caches into their own types

### DIFF
--- a/internal/envoy/cluster.go
+++ b/internal/envoy/cluster.go
@@ -1,0 +1,20 @@
+// Copyright © 2017 Heptio
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package envoy
+
+// ClusterCache manage the contents of the gRPC SDS cache.
+type ClusterCache struct {
+	clusterCache
+	Cond
+}

--- a/internal/envoy/clusterloadassignnent.go
+++ b/internal/envoy/clusterloadassignnent.go
@@ -1,0 +1,20 @@
+// Copyright © 2017 Heptio
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package envoy
+
+// ClusterLoadAssignmentCache manage the contents of the gRPC EDS cache.
+type ClusterLoadAssignmentCache struct {
+	clusterLoadAssignmentCache
+	Cond
+}

--- a/internal/envoy/listener.go
+++ b/internal/envoy/listener.go
@@ -1,0 +1,95 @@
+// Copyright © 2017 Heptio
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package envoy
+
+import (
+	v2 "github.com/envoyproxy/go-control-plane/api"
+	"github.com/golang/protobuf/ptypes/struct" // package name is structpb
+)
+
+// ListenerCache manages the contents of the gRPC LDS cache.
+type ListenerCache struct {
+	listenerCache
+	Cond
+}
+
+func defaultListener() *v2.Listener {
+	const (
+		router     = "envoy.router"
+		httpFilter = "envoy.http_connection_manager"
+		accessLog  = "envoy.file_access_log"
+	)
+
+	sv := func(s string) *structpb.Value {
+		return &structpb.Value{Kind: &structpb.Value_StringValue{StringValue: s}}
+	}
+	bv := func(b bool) *structpb.Value {
+		return &structpb.Value{Kind: &structpb.Value_BoolValue{BoolValue: b}}
+	}
+	st := func(m map[string]*structpb.Value) *structpb.Value {
+		return &structpb.Value{Kind: &structpb.Value_StructValue{StructValue: &structpb.Struct{Fields: m}}}
+	}
+	lv := func(v ...*structpb.Value) *structpb.Value {
+		return &structpb.Value{Kind: &structpb.Value_ListValue{ListValue: &structpb.ListValue{Values: v}}}
+	}
+	l := &v2.Listener{
+		Name: "ingress_http", // TODO(dfc) should come from the name of the service port
+		Address: &v2.Address{
+			Address: &v2.Address_SocketAddress{
+				SocketAddress: &v2.SocketAddress{
+					Protocol: v2.SocketAddress_TCP,
+					Address:  "0.0.0.0",
+					PortSpecifier: &v2.SocketAddress_PortValue{
+						PortValue: 8080,
+					},
+				},
+			},
+		},
+		FilterChains: []*v2.FilterChain{{
+			Filters: []*v2.Filter{{
+				Name: httpFilter,
+				Config: &structpb.Struct{
+					Fields: map[string]*structpb.Value{
+						"codec_type":  sv("http1"),        // let's not go crazy now
+						"stat_prefix": sv("ingress_http"), // TODO(dfc) should this come from pod.Name?
+						"rds": st(map[string]*structpb.Value{
+							"route_config_name": sv("ingress_http"), // TODO(dfc) needed for grpc?
+							"config_source": st(map[string]*structpb.Value{
+								"api_config_source": st(map[string]*structpb.Value{
+									"api_type": sv("grpc"),
+									"cluster_name": lv(
+										sv("xds_cluster"),
+									),
+								}),
+							}),
+						}),
+						"http_filters": lv(
+							st(map[string]*structpb.Value{
+								"name": sv(router),
+							}),
+						),
+						"access_log": st(map[string]*structpb.Value{
+							"name": sv(accessLog),
+							"config": st(map[string]*structpb.Value{
+								"path": sv("/dev/stdout"),
+							}),
+						}),
+						"use_remote_address": bv(true), // TODO(jbeda) should this ever be false?
+					},
+				},
+			}},
+		}},
+	}
+	return l
+}

--- a/internal/envoy/virtualhost.go
+++ b/internal/envoy/virtualhost.go
@@ -1,0 +1,85 @@
+// Copyright © 2017 Heptio
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package envoy
+
+import (
+	"strings"
+
+	v2 "github.com/envoyproxy/go-control-plane/api"
+	"k8s.io/api/extensions/v1beta1"
+)
+
+// VirtualHostCache manage the contents of the gRPC RDS cache.
+type VirtualHostCache struct {
+	virtualHostCache
+	Cond
+}
+
+// ingressBackendToClusterName renders a cluster name from an Ingress and an IngressBackend.
+func ingressBackendToClusterName(i *v1beta1.Ingress, b *v1beta1.IngressBackend) string {
+	return hashname(60, i.ObjectMeta.Namespace, b.ServiceName, b.ServicePort.String())
+}
+
+// pathToRoute converts a HTTPIngressPath to a partial v2.RouteMatch.
+func pathToRouteMatch(p v1beta1.HTTPIngressPath) *v2.RouteMatch {
+	if p.Path == "" {
+		// If the Path is empty, the k8s spec says
+		// "If unspecified, the path defaults to a catch all sending
+		// traffic to the backend."
+		// We map this it a catch all prefix route.
+		return prefixmatch("/") // match all
+	}
+	// TODO(dfc) handle the case where p.Path does not start with "/"
+	if strings.IndexAny(p.Path, `[(*\`) == -1 {
+		// Envoy requires that regex matches match completely, wheres the
+		// HTTPIngressPath.Path regex only requires a partial match. eg,
+		// "/foo" matches "/" according to k8s rules, but does not match
+		// according to Envoy.
+		// To deal with this we handle the simple case, a Path without regex
+		// characters as a Envoy prefix route.
+		return prefixmatch(p.Path)
+	}
+	// At this point the path is a regex, which we hope is the same between k8s
+	// IEEE 1003.1 POSIX regex, and Envoys Javascript regex.
+	return regexmatch(p.Path)
+}
+
+// prefixmatch returns a RouteMatch for the supplied prefix.
+func prefixmatch(prefix string) *v2.RouteMatch {
+	return &v2.RouteMatch{
+		PathSpecifier: &v2.RouteMatch_Prefix{
+			Prefix: prefix,
+		},
+	}
+}
+
+// regexmatch returns a RouteMatch for the supplied regex.
+func regexmatch(regex string) *v2.RouteMatch {
+	return &v2.RouteMatch{
+		PathSpecifier: &v2.RouteMatch_Regex{
+			Regex: regex,
+		},
+	}
+}
+
+// clusteraction returns a Route_Route action for the supplied cluster.
+func clusteraction(cluster string) *v2.Route_Route {
+	return &v2.Route_Route{
+		Route: &v2.RouteAction{
+			ClusterSpecifier: &v2.RouteAction_Cluster{
+				Cluster: cluster,
+			},
+		},
+	}
+}


### PR DESCRIPTION
Signed-off-by: Dave Cheney <dave@cheney.net>