### PR TITLE
internal/grpc: move grpc API server code to its own package

### DIFF
--- a/cmd/contour/contour.go
+++ b/cmd/contour/contour.go
@@ -31,6 +31,7 @@ import (
 	"github.com/gorilla/handlers"
 	"github.com/heptio/contour/internal/contour"
 	"github.com/heptio/contour/internal/envoy"
+	"github.com/heptio/contour/internal/grpc"
 	"github.com/heptio/contour/internal/k8s"
 	"github.com/heptio/contour/internal/log/stdlog"
 	"github.com/heptio/contour/internal/workgroup"
@@ -108,7 +109,7 @@ func main() {
 				logger.Errorf("could not listen on %s: %v", V2_API_ADDRESS, err)
 				return // TODO(dfc) should return the error not log it
 			}
-			s := contour.NewGRPCAPI(logger, t)
+			s := grpc.NewAPI(logger, t)
 			logger.Infof("started")
 			defer logger.Infof("stopped")
 			s.Serve(l)
@@ -122,7 +123,9 @@ func main() {
 // If the path ends in .json, the configuration file will be in v1 JSON format.
 // If the path ends in .yaml, the configuration file will be in v2 YAML format.
 func writeBootstrapConfig(path string) {
-	config := envoy.ConfigWriter{}
+	config := envoy.ConfigWriter{
+		AdminAddress: "0.0.0.0",
+	}
 	f, err := os.Create(path)
 	check(err)
 	switch filepath.Ext(path) {

--- a/internal/grpc/grpc.go
+++ b/internal/grpc/grpc.go
@@ -11,7 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package contour
+// Package grpc provides a gRPC implementation of the Envoy v2 xDS API.
+package grpc
 
 import (
 	"context"
@@ -78,8 +79,8 @@ type VirtualHostCache interface {
 	Register(chan int, int)
 }
 
-// NewGPRCAPI returns a *grpc.Server which responds to the Envoy v2 xDS gRPC API.
-func NewGRPCAPI(l log.Logger, t *envoy.Translator) *grpc.Server {
+// NewAPI returns a *grpc.Server which responds to the Envoy v2 xDS gRPC API.
+func NewAPI(l log.Logger, t *envoy.Translator) *grpc.Server {
 	g := grpc.NewServer()
 	s := newgrpcServer(l, t)
 	v2.RegisterClusterDiscoveryServiceServer(g, s)

--- a/internal/grpc/grpc_test.go
+++ b/internal/grpc/grpc_test.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package contour
+package grpc
 
 import (
 	"context"
@@ -156,7 +156,7 @@ func TestGRPCStreaming(t *testing.T) {
 	for name, fn := range tests {
 		t.Run(name, func(t *testing.T) {
 			tr = envoy.NewTranslator(log)
-			srv := NewGRPCAPI(log, tr)
+			srv := NewAPI(log, tr)
 			var err error
 			l, err = net.Listen("tcp", "127.0.0.1:0")
 			check(t, err)
@@ -234,7 +234,7 @@ func TestGRPCFetching(t *testing.T) {
 	for name, fn := range tests {
 		t.Run(name, func(t *testing.T) {
 			tr := envoy.NewTranslator(log)
-			srv := NewGRPCAPI(log, tr)
+			srv := NewAPI(log, tr)
 			var err error
 			l, err = net.Listen("tcp", "127.0.0.1:0")
 			check(t, err)


### PR DESCRIPTION
Move grpc api server code to its own package.

Signed-off-by: Dave Cheney <dave@cheney.net>