### PR TITLE
internal/json: rename internal/contour to internal/json

### DIFF
--- a/cmd/contour/contour.go
+++ b/cmd/contour/contour.go
@@ -29,9 +29,9 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 
 	"github.com/gorilla/handlers"
-	"github.com/heptio/contour/internal/contour"
 	"github.com/heptio/contour/internal/envoy"
 	"github.com/heptio/contour/internal/grpc"
+	"github.com/heptio/contour/internal/json"
 	"github.com/heptio/contour/internal/k8s"
 	"github.com/heptio/contour/internal/log/stdlog"
 	"github.com/heptio/contour/internal/workgroup"
@@ -67,7 +67,7 @@ func main() {
 		client := newClient(*kubeconfig, *inCluster)
 
 		// REST v1 support
-		ds := contour.DataSource{
+		ds := json.DataSource{
 			Logger: logger.WithPrefix("DataSource"),
 		}
 
@@ -84,7 +84,7 @@ func main() {
 
 		g.Add(func(stop <-chan struct{}) {
 			logger := logger.WithPrefix("JSONAPI")
-			api := contour.NewJSONAPI(logger, &ds)
+			api := json.NewAPI(logger, &ds)
 			if *debug {
 				// enable request logging if --debug enabled
 				api = handlers.LoggingHandler(os.Stdout, api)
@@ -123,9 +123,7 @@ func main() {
 // If the path ends in .json, the configuration file will be in v1 JSON format.
 // If the path ends in .yaml, the configuration file will be in v2 YAML format.
 func writeBootstrapConfig(path string) {
-	config := envoy.ConfigWriter{
-		AdminAddress: "0.0.0.0",
-	}
+	config := envoy.ConfigWriter{}
 	f, err := os.Create(path)
 	check(err)
 	switch filepath.Ext(path) {

--- a/internal/json/cache.go
+++ b/internal/json/cache.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package contour
+package json
 
 import (
 	"sort"

--- a/internal/json/cds.go
+++ b/internal/json/cds.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package contour
+package json
 
 import (
 	"strconv"

--- a/internal/json/cds_test.go
+++ b/internal/json/cds_test.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package contour
+package json
 
 import (
 	"reflect"

--- a/internal/json/json.go
+++ b/internal/json/json.go
@@ -11,9 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package contour implements a REST API server for Envoy's RDS/SDS/CDS v1 JSON API
-// and a gRPC API server for the xDS vs gRPC API.
-package contour
+// Package json implements a REST API server for Envoy's RDS/SDS/CDS v1 JSON API.
+package json
 
 import (
 	"crypto/sha256"
@@ -35,9 +34,9 @@ import (
 	"github.com/heptio/contour/internal/log"
 )
 
-// NewJSONAPI returns a http.Handler which responds to the Envoy CDS,
+// NewAPI returns a http.Handler which responds to the Envoy CDS,
 // RDS, and SDS v1 REST API calls.
-func NewJSONAPI(l log.Logger, ds *DataSource) http.Handler {
+func NewAPI(l log.Logger, ds *DataSource) http.Handler {
 	r := mux.NewRouter()
 	a := &jsonAPI{
 		Handler:    r,

--- a/internal/json/json_test.go
+++ b/internal/json/json_test.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package contour
+package json
 
 import (
 	"net/http"
@@ -374,7 +374,7 @@ func TestAPIServer(t *testing.T) {
 				ds.AddIngress(i)
 			}
 			var w discardWriter
-			api := NewJSONAPI(stdlog.New(w, w, 0), &ds)
+			api := NewAPI(stdlog.New(w, w, 0), &ds)
 			got := request(t, tc.path, api)
 			if tc.want != got {
 				t.Fatalf("%q: expected: %q, got %q", tc.path, tc.want, got)

--- a/internal/json/rds.go
+++ b/internal/json/rds.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package contour
+package json
 
 import (
 	"strings"

--- a/internal/json/rds_test.go
+++ b/internal/json/rds_test.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package contour
+package json
 
 import (
 	"reflect"

--- a/internal/json/sds.go
+++ b/internal/json/sds.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package contour
+package json
 
 import (
 	"github.com/heptio/contour/internal/envoy"

--- a/internal/json/sds_test.go
+++ b/internal/json/sds_test.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package contour
+package json
 
 import (
 	"reflect"


### PR DESCRIPTION
Rename internal/contour (which only contains the JSON xDS API) to
internal/json which more accurately reflects its contents.

Signed-off-by: Dave Cheney <dave@cheney.net>