### PR TITLE
internal/contour: move translator to internal/contour

### DIFF
--- a/cmd/contour/contour.go
+++ b/cmd/contour/contour.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 
 	"github.com/gorilla/handlers"
+	"github.com/heptio/contour/internal/contour"
 	"github.com/heptio/contour/internal/envoy"
 	"github.com/heptio/contour/internal/grpc"
 	"github.com/heptio/contour/internal/json"
@@ -72,7 +73,7 @@ func main() {
 		}
 
 		// gRPC v2 support
-		t := envoy.NewTranslator(logger.WithPrefix("translator"))
+		t := contour.NewTranslator(logger.WithPrefix("translator"))
 
 		var g workgroup.Group
 

--- a/internal/contour/cache.go
+++ b/internal/contour/cache.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package envoy
+package contour
 
 import (
 	"sort"

--- a/internal/contour/cache_test.go
+++ b/internal/contour/cache_test.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package envoy
+package contour
 
 import (
 	"reflect"

--- a/internal/contour/cluster.go
+++ b/internal/contour/cluster.go
@@ -11,10 +11,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package envoy
+package contour
 
-// ClusterLoadAssignmentCache manage the contents of the gRPC EDS cache.
-type ClusterLoadAssignmentCache struct {
-	clusterLoadAssignmentCache
+// ClusterCache manage the contents of the gRPC SDS cache.
+type ClusterCache struct {
+	clusterCache
 	Cond
 }

--- a/internal/contour/clusterloadassignnent.go
+++ b/internal/contour/clusterloadassignnent.go
@@ -11,10 +11,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package envoy
+package contour
 
-// ClusterCache manage the contents of the gRPC SDS cache.
-type ClusterCache struct {
-	clusterCache
+// ClusterLoadAssignmentCache manage the contents of the gRPC EDS cache.
+type ClusterLoadAssignmentCache struct {
+	clusterLoadAssignmentCache
 	Cond
 }

--- a/internal/contour/cond.go
+++ b/internal/contour/cond.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package envoy
+package contour
 
 import "sync"
 

--- a/internal/contour/cond_test.go
+++ b/internal/contour/cond_test.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package envoy
+package contour
 
 import "testing"
 

--- a/internal/contour/example_test.go
+++ b/internal/contour/example_test.go
@@ -11,21 +11,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package envoy_test
+package contour_test
 
 import (
 	"context"
 	"fmt"
 	"time"
 
-	"github.com/heptio/contour/internal/envoy"
+	"github.com/heptio/contour/internal/contour"
 )
 
 func ExampleCond() {
 	ctx, _ := context.WithTimeout(context.Background(), 1*time.Second)
 	ch := make(chan int, 1)
 	last := 0
-	var c envoy.Cond
+	var c contour.Cond
 	go func() {
 		for {
 			time.Sleep(100 * time.Millisecond)

--- a/internal/contour/listener.go
+++ b/internal/contour/listener.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package envoy
+package contour
 
 import (
 	v2 "github.com/envoyproxy/go-control-plane/api"

--- a/internal/contour/translator.go
+++ b/internal/contour/translator.go
@@ -11,7 +11,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package envoy
+// Package contour contains the translation business logic that listens
+// to Kubernetes ResourceEventHandler events and translates those into
+// additions/deletions in caches connected to the Envoy xDS gRPC API server.
+package contour
 
 import (
 	"crypto/sha256"

--- a/internal/contour/translator_test.go
+++ b/internal/contour/translator_test.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package envoy
+package contour
 
 import (
 	"io/ioutil"

--- a/internal/contour/virtualhost.go
+++ b/internal/contour/virtualhost.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package envoy
+package contour
 
 import (
 	"sort"

--- a/internal/grpc/grpc.go
+++ b/internal/grpc/grpc.go
@@ -26,7 +26,7 @@ import (
 	v2 "github.com/envoyproxy/go-control-plane/api"
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes/any"
-	"github.com/heptio/contour/internal/envoy"
+	"github.com/heptio/contour/internal/contour"
 	"github.com/heptio/contour/internal/log"
 )
 
@@ -80,7 +80,7 @@ type VirtualHostCache interface {
 }
 
 // NewAPI returns a *grpc.Server which responds to the Envoy v2 xDS gRPC API.
-func NewAPI(l log.Logger, t *envoy.Translator) *grpc.Server {
+func NewAPI(l log.Logger, t *contour.Translator) *grpc.Server {
 	g := grpc.NewServer()
 	s := newgrpcServer(l, t)
 	v2.RegisterClusterDiscoveryServiceServer(g, s)
@@ -97,7 +97,7 @@ type grpcServer struct {
 	RDS
 }
 
-func newgrpcServer(l log.Logger, t *envoy.Translator) *grpcServer {
+func newgrpcServer(l log.Logger, t *contour.Translator) *grpcServer {
 	return &grpcServer{
 		CDS: CDS{
 			ClusterCache: &t.ClusterCache,

--- a/internal/grpc/grpc_test.go
+++ b/internal/grpc/grpc_test.go
@@ -22,7 +22,7 @@ import (
 	"time"
 
 	v2 "github.com/envoyproxy/go-control-plane/api"
-	"github.com/heptio/contour/internal/envoy"
+	"github.com/heptio/contour/internal/contour"
 	"github.com/heptio/contour/internal/log/stdlog"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -40,7 +40,7 @@ func TestGRPCStreaming(t *testing.T) {
 	var l net.Listener
 
 	// tr is recreated before the start of each test.
-	var tr *envoy.Translator
+	var tr *contour.Translator
 
 	newClient := func(t *testing.T) *grpc.ClientConn {
 		cc, err := grpc.Dial(l.Addr().String(), grpc.WithInsecure())
@@ -155,7 +155,7 @@ func TestGRPCStreaming(t *testing.T) {
 
 	for name, fn := range tests {
 		t.Run(name, func(t *testing.T) {
-			tr = envoy.NewTranslator(log)
+			tr = contour.NewTranslator(log)
 			srv := NewAPI(log, tr)
 			var err error
 			l, err = net.Listen("tcp", "127.0.0.1:0")
@@ -233,7 +233,7 @@ func TestGRPCFetching(t *testing.T) {
 
 	for name, fn := range tests {
 		t.Run(name, func(t *testing.T) {
-			tr := envoy.NewTranslator(log)
+			tr := contour.NewTranslator(log)
 			srv := NewAPI(log, tr)
 			var err error
 			l, err = net.Listen("tcp", "127.0.0.1:0")


### PR DESCRIPTION
Move the k8s <> envoy translator components from internal/envour to
internal/contour. This leaves internal/envoy for JSON types and
configuration support.

Signed-off-by: Dave Cheney <dave@cheney.net>