### PR TITLE
internal/contour: add support for watching secrets

### DIFF
--- a/cmd/contour/contour.go
+++ b/cmd/contour/contour.go
@@ -82,6 +82,7 @@ func main() {
 		k8s.WatchServices(&g, client, logger, &ds, buf)
 		k8s.WatchEndpoints(&g, client, logger, &ds, buf)
 		k8s.WatchIngress(&g, client, logger, &ds, buf)
+		k8s.WatchSecrets(&g, client, logger, buf) // don't deliver to &ds, the rest api doesn't know how to process secrets
 
 		g.Add(func(stop <-chan struct{}) {
 			logger := logger.WithPrefix("JSONAPI")

--- a/internal/contour/translator.go
+++ b/internal/contour/translator.go
@@ -68,6 +68,8 @@ func (t *Translator) OnAdd(obj interface{}) {
 		t.addEndpoints(obj)
 	case *v1beta1.Ingress:
 		t.addIngress(obj)
+	case *v1.Secret:
+		t.addSecret(obj)
 	default:
 		t.Errorf("OnAdd unexpected type %T: %#v", obj, obj)
 	}
@@ -82,6 +84,8 @@ func (t *Translator) OnUpdate(oldObj, newObj interface{}) {
 		t.addEndpoints(newObj)
 	case *v1beta1.Ingress:
 		t.addIngress(newObj)
+	case *v1.Secret:
+		t.addSecret(newObj)
 	default:
 		t.Errorf("OnUpdate unexpected type %T: %#v", newObj, newObj)
 	}
@@ -95,6 +99,8 @@ func (t *Translator) OnDelete(obj interface{}) {
 		t.removeEndpoints(obj)
 	case *v1beta1.Ingress:
 		t.removeIngress(obj)
+	case *v1.Secret:
+		t.removeSecret(obj)
 	case cache.DeletedFinalStateUnknown:
 		t.OnDelete(obj.Obj) // recurse into ourselves with the tombstoned value
 	default:
@@ -289,6 +295,14 @@ func (t *Translator) removeIngress(i *v1beta1.Ingress) {
 		t.vhosts[rule.Host] = removeIfPresent(t.vhosts[rule.Host], i)
 		t.recomputevhost(rule.Host, t.vhosts[rule.Host])
 	}
+}
+
+func (t *Translator) addSecret(s *v1.Secret) {
+
+}
+
+func (t *Translator) removeSecret(s *v1.Secret) {
+
 }
 
 func appendIfMissing(haystack []*v1beta1.Ingress, needle *v1beta1.Ingress) []*v1beta1.Ingress {

--- a/internal/k8s/watcher.go
+++ b/internal/k8s/watcher.go
@@ -43,6 +43,11 @@ func WatchIngress(g *workgroup.Group, client *kubernetes.Clientset, l log.Logger
 	watch(g, client.ExtensionsV1beta1().RESTClient(), l, "ingresses", new(v1beta1.Ingress), rs...)
 }
 
+// WatchSecrets creates a SharedInformer for v1.Secrets and registers it with g.
+func WatchSecrets(g *workgroup.Group, client *kubernetes.Clientset, l log.Logger, rs ...cache.ResourceEventHandler) {
+	watch(g, client.CoreV1().RESTClient(), l, "secrets", new(v1.Secret), rs...)
+}
+
 func watch(g *workgroup.Group, c cache.Getter, l log.Logger, resource string, objType runtime.Object, rs ...cache.ResourceEventHandler) {
 	lw := cache.NewListWatchFromClient(c, resource, v1.NamespaceAll, fields.Everything())
 	sw := cache.NewSharedInformer(lw, objType, 30*time.Minute)


### PR DESCRIPTION
Add support for watching secrets in all namespaces. This gives us access
to the TLS certs for LDS.

Secrets events are only transmitted to the contour.Translator via the
k8s.Buffer. They are not transmitted to the v1 json datasource.

Signed-off-by: Dave Cheney <dave@cheney.net>