### PR TITLE
internal/{json,contour}: support prefix routes on default vhost

### DIFF
--- a/internal/contour/translator.go
+++ b/internal/contour/translator.go
@@ -279,8 +279,13 @@ func (t *Translator) addIngress(i *v1beta1.Ingress) {
 	}
 
 	for _, rule := range i.Spec.Rules {
-		t.vhosts[rule.Host] = appendIfMissing(t.vhosts[rule.Host], i)
-		t.recomputevhost(rule.Host, t.vhosts[rule.Host])
+		host := rule.Host
+		if host == "" {
+			// If the host is unspecified, the Ingress routes all traffic based on the specified IngressRuleValue.
+			host = "*"
+		}
+		t.vhosts[host] = appendIfMissing(t.vhosts[host], i)
+		t.recomputevhost(host, t.vhosts[host])
 	}
 }
 

--- a/internal/contour/translator_test.go
+++ b/internal/contour/translator_test.go
@@ -713,6 +713,37 @@ func TestTranslatorAddIngress(t *testing.T) {
 				Action: clusteraction("default/httpbin/80"),
 			}},
 		}},
+	}, {
+		name: "IngressRuleValue without host should become the default vhost", // heptio/contour#101
+		ing: &v1beta1.Ingress{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "hello",
+				Namespace: "default",
+			},
+			Spec: v1beta1.IngressSpec{
+				Rules: []v1beta1.IngressRule{{
+					IngressRuleValue: v1beta1.IngressRuleValue{
+						HTTP: &v1beta1.HTTPIngressRuleValue{
+							Paths: []v1beta1.HTTPIngressPath{{
+								Path: "/hello",
+								Backend: v1beta1.IngressBackend{
+									ServiceName: "hello",
+									ServicePort: intstr.FromInt(80),
+								},
+							}},
+						},
+					},
+				}},
+			},
+		},
+		want: []*v2.VirtualHost{{
+			Name:    "*",
+			Domains: []string{"*"},
+			Routes: []*v2.Route{{
+				Match:  prefixmatch("/hello"),
+				Action: clusteraction("default/hello/80"),
+			}},
+		}},
 	}}
 
 	for _, tc := range tests {
@@ -725,7 +756,7 @@ func TestTranslatorAddIngress(t *testing.T) {
 			tr.addIngress(tc.ing)
 			got := tr.VirtualHostCache.Values()
 			if !reflect.DeepEqual(tc.want, got) {
-				t.Fatalf("eddIngress(%v):\n got: %v\nwant: %v", tc.ing, got, tc.want)
+				t.Fatalf("addIngress(%v):\n got: %v\nwant: %v", tc.ing, got, tc.want)
 			}
 		})
 	}

--- a/internal/contour/virtualhost.go
+++ b/internal/contour/virtualhost.go
@@ -46,7 +46,7 @@ func (v *VirtualHostCache) recomputevhost(vhost string, ingresses []*v1beta1.Ing
 		}
 		for _, ing := range ingresses {
 			for _, rule := range ing.Spec.Rules {
-				if rule.Host != vhost {
+				if rule.Host != "" && rule.Host != vhost {
 					continue
 				}
 				if rule.IngressRuleValue.HTTP == nil {

--- a/internal/json/json_test.go
+++ b/internal/json/json_test.go
@@ -356,6 +356,31 @@ func TestAPIServer(t *testing.T) {
 		path: "/v1/routes/ingress_http/cluster0/node0",
 		want: `{"virtual_hosts":[{"name":"default/httpbin/httpbin.org","domains":["httpbin.org"],"routes":[{"prefix":"/","cluster":"default/peter/80"}]},{"name":"default/httpbin/admin.httpbin.org","domains":["admin.httpbin.org"],"routes":[{"prefix":"/","cluster":"default/paul/paul"}]}]}` + "\n",
 	}, {
+		name: "IngressRuleValue without host should become the default vhost", // heptio/contour#101
+		ingresses: []*v1beta1.Ingress{{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "hello",
+				Namespace: "default",
+			},
+			Spec: v1beta1.IngressSpec{
+				Rules: []v1beta1.IngressRule{{
+					IngressRuleValue: v1beta1.IngressRuleValue{
+						HTTP: &v1beta1.HTTPIngressRuleValue{
+							Paths: []v1beta1.HTTPIngressPath{{
+								Path: "/hello",
+								Backend: v1beta1.IngressBackend{
+									ServiceName: "hello",
+									ServicePort: intstr.FromInt(80),
+								},
+							}},
+						},
+					},
+				}},
+			},
+		}},
+		path: "/v1/routes/ingress_http/cluster0/node0",
+		want: `{"virtual_hosts":[{"name":"default/hello","domains":["*"],"routes":[{"prefix":"/hello","cluster":"default/hello/80"}]}]}` + "\n",
+	}, {
 		name: "lds/0.0.0.0:8080",
 		path: "/v1/listeners/cluster0/node0",
 		want: `{"listeners":[{"name":"ingress_http","address":"tcp://0.0.0.0:8080","filters":[{"type":"read","name":"http_connection_manager","config":{"codec_type":"http1","stat_prefix":"ingress_http","rds":{"cluster":"rds","route_config_name":"ingress_http","refresh_delay_ms":1000},"filters":[{"type":"decoder","name":"router","config":{}}],"access_log":[{"path":"/dev/stdout"}],"use_remote_address":true}}]}]}` + "\n",

--- a/internal/json/rds_test.go
+++ b/internal/json/rds_test.go
@@ -311,6 +311,37 @@ func TestIngressToVirtualHost(t *testing.T) {
 				Cluster: "default/my-service-name/80",
 			}),
 		}},
+	}, {
+		name: "IngressRuleValue without host should become the default vhost", // heptio/contour#101
+		i: &v1beta1.Ingress{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "hello",
+				Namespace: "default",
+			},
+			Spec: v1beta1.IngressSpec{
+				Rules: []v1beta1.IngressRule{{
+					IngressRuleValue: v1beta1.IngressRuleValue{
+						HTTP: &v1beta1.HTTPIngressRuleValue{
+							Paths: []v1beta1.HTTPIngressPath{{
+								Path: "/hello",
+								Backend: v1beta1.IngressBackend{
+									ServiceName: "hello",
+									ServicePort: intstr.FromInt(80),
+								},
+							}},
+						},
+					},
+				}},
+			},
+		},
+		want: []*envoy.VirtualHost{{
+			Name:    "default/hello",
+			Domains: domains("*"),
+			Routes: routes(envoy.Route{
+				Prefix:  "/hello",
+				Cluster: "default/hello/80",
+			}),
+		}},
 	}}
 
 	for _, tc := range tests {
@@ -320,7 +351,7 @@ func TestIngressToVirtualHost(t *testing.T) {
 				t.Fatal(err)
 			}
 			if !reflect.DeepEqual(got, tc.want) {
-				t.Fatalf("got: %v, want: %v", got, tc.want)
+				t.Fatalf("got: %#v, want: %#v", got, tc.want)
 			}
 		})
 	}


### PR DESCRIPTION
Fixes #101

The Ingress spec premits declaration of path routes without a `host`
key. This means those routes will be declared on the default vhost, in
envoy this is the `*` route.

Signed-off-by: Dave Cheney <dave@cheney.net>