### PR TITLE
deployment: update grpc manifest for sni

### DIFF
--- a/deployment/deployment-grpc-v2/02-contour.yaml
+++ b/deployment/deployment-grpc-v2/02-contour.yaml
@@ -21,6 +21,8 @@ spec:
         ports:
         - containerPort: 8080
           name: http
+        - containerPort: 8443
+          name: https
         command: ["envoy"]
         args: ["-c", "/config/contour.yaml", "--service-cluster", "cluster0", "--service-node", "node0", "-l", "info"]
         volumeMounts:
@@ -31,6 +33,9 @@ spec:
         name: contour
         command: ["contour"]
         args: ["serve", "--incluster"]
+        volumeMounts:
+        - name: contour-config
+          mountPath: /config
       initContainers:
       - image: gcr.io/heptio-images/contour:master
         imagePullPolicy: Always

--- a/deployment/deployment-grpc-v2/02-service.yaml
+++ b/deployment/deployment-grpc-v2/02-service.yaml
@@ -1,1 +1,0 @@
-../common/service.yaml

--- a/deployment/deployment-grpc-v2/03-service-tcp.yaml
+++ b/deployment/deployment-grpc-v2/03-service-tcp.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Service
+metadata:
+ name: contour
+ namespace: heptio-contour
+ annotations:
+  # This annotation puts the AWS ELB into "TCP" mode so that it does not 
+  # to http negotiation at the ELB edge. This means the remote address of 
+  # all connectinos will appear to be the internal address of the ELB.
+  # See https://github.com/heptio/contour/issues/103
+  service.beta.kubernetes.io/aws-load-balancer-backend-protocol: tcp
+spec:
+ ports:
+ - port: 80
+   name: http
+   protocol: TCP
+   targetPort: 8080
+ - port: 443
+   name: https
+   protocol: TCP
+   targetPort: 8443
+ selector:
+   app: contour
+ type: LoadBalancer
+---


### PR DESCRIPTION
Various changes to the grpc version of the deployment manifest

- mount `/config` on the contour container so we can pass cert material via the file system. See envoyproxy/envoy#1357
- expose 443/8443 on the service load balancer
- switch to `tcp` mode for the service load balancer. See #103 for PROXY protocol support to recover `X-Forwarded-For`

Signed-off-by: Dave Cheney <dave@cheney.net>