### PR TITLE
internal/contour: initial SNI support

### DIFF
--- a/internal/grpc/grpc.go
+++ b/internal/grpc/grpc.go
@@ -253,17 +253,16 @@ type RDS struct {
 // TODO(dfc) cache the results of Resources in the VirtualHostCache so
 // we can avoid the error handling.
 func (r *RDS) Resources() ([]*any.Any, error) {
-	rc := v2.RouteConfiguration{
+	ingress_http, err := proto.Marshal(&v2.RouteConfiguration{
 		Name:         "ingress_http", // TODO(dfc) matches LDS configuration?
 		VirtualHosts: r.Values(),
-	}
-	data, err := proto.Marshal(&rc)
+	})
 	if err != nil {
 		return nil, err
 	}
 	return []*any.Any{{
 		TypeUrl: RouteType,
-		Value:   data,
+		Value:   ingress_http,
 	}}, nil
 }
 


### PR DESCRIPTION
Updates #78 

This is a alpha cut of ssl support using Envoy's SNI support. It is by no means complete, but it is usable for testing.

## Testing notes

### Deployment

You must use the deployment/deployment-grpc-v2 manifests. These are different to the quickstart manifests mentioned in the project README. SNI support requires switching to the grpc api, which will become the default for the 0.3 release.

### TLS secrets

Like other ingress controllers, contour watches for secret objects that contain `tls.crt` and `tls.key` values. You will need to manually configure these secret objects on a per ingress basis or use something like kube-lego to generate them from Let's Encrypt. 

Contour will work with kube-lego, but requires you to edit the ingress class on the ingress object that kube-lego creates to handle the authentication challenge.
```
kubectl -n kube-lego edit ing
```
and change `kubernetes.io/ingress.class: nginx` to `kubernetes.io/ingress.class: contour` so that Contour will see the additional ingress. You will need to repeat this frequently as kube-lego rewrites the ingress object and will overwrite your change.

### Known issues

- Virtually no annotations are supported, see #63 for example
- In EC2 the ELB is put into tcp passthrough mode, which causes the remote address to be overwritten with the internal ip address of the ELB. See #103 for PROXY protocol support.

Signed-off-by: Dave Cheney <dave@cheney.net>