### PR TITLE
internal/contour: introduce contour.Config

### DIFF
--- a/cmd/contour/contour.go
+++ b/cmd/contour/contour.go
@@ -52,6 +52,7 @@ func main() {
 	path := bootstrap.Arg("path", "Configuration file.").Required().String()
 
 	serve := app.Command("serve", "Serve xDS API traffic")
+	var config contour.Config
 	inCluster := serve.Flag("incluster", "use in cluster configuration.").Bool()
 	kubeconfig := serve.Flag("kubeconfig", "path to kubeconfig (if not in running inside a cluster)").Default(filepath.Join(os.Getenv("HOME"), ".kube", "config")).String()
 	debug := serve.Flag("debug", "enable v1 REST API request logging.").Bool()
@@ -65,6 +66,7 @@ func main() {
 		writeBootstrapConfig(*path)
 	case serve.FullCommand():
 		logger := stdlog.New(os.Stdout, os.Stderr, 0)
+		config.Logger = logger.WithPrefix("translator")
 		client := newClient(*kubeconfig, *inCluster)
 
 		// REST v1 support
@@ -73,7 +75,7 @@ func main() {
 		}
 
 		// gRPC v2 support
-		t := contour.NewTranslator(logger.WithPrefix("translator"))
+		t := contour.NewTranslator(&config)
 
 		var g workgroup.Group
 

--- a/internal/contour/translator.go
+++ b/internal/contour/translator.go
@@ -19,6 +19,7 @@ package contour
 import (
 	"crypto/sha256"
 	"fmt"
+	"os"
 	"strconv"
 	"strings"
 
@@ -26,15 +27,30 @@ import (
 	"github.com/golang/protobuf/ptypes/duration"
 
 	"github.com/heptio/contour/internal/log"
+	"github.com/heptio/contour/internal/log/stdlog"
 	"k8s.io/api/core/v1"
 	"k8s.io/api/extensions/v1beta1"
 	"k8s.io/client-go/tools/cache"
 )
 
-// NewTranslator returns a new Translator.
-func NewTranslator(log log.Logger) *Translator {
+// Config holds Translator configuration information.
+type Config struct {
+	// Logger holds the log.Logger instance for this Translator.
+	// If not provided, an unspecified logger will be supplied.
+	log.Logger
+}
+
+func (c *Config) logger() log.Logger {
+	if c.Logger == nil {
+		return stdlog.New(os.Stdout, os.Stderr, 0)
+	}
+	return c.Logger
+}
+
+// NewTranslator returns a new Translator using the specified Config.
+func NewTranslator(config *Config) *Translator {
 	t := &Translator{
-		Logger: log,
+		Logger: config.logger(),
 	}
 	t.ClusterCache.init()
 	t.ClusterLoadAssignmentCache.init()

--- a/internal/contour/translator_test.go
+++ b/internal/contour/translator_test.go
@@ -114,10 +114,11 @@ func TestTranslatorAddService(t *testing.T) {
 		want: []*v2.Cluster{},
 	}}
 
+	const NOFLAGS = 1 << 16
+	config := Config{Logger: stdlog.New(ioutil.Discard, ioutil.Discard, NOFLAGS)}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			const NOFLAGS = 1 << 16
-			tr := NewTranslator(stdlog.New(ioutil.Discard, ioutil.Discard, NOFLAGS))
+			tr := NewTranslator(&config)
 			tr.addService(tc.svc)
 			got := tr.ClusterCache.Values()
 			if !reflect.DeepEqual(tc.want, got) {
@@ -193,10 +194,11 @@ func TestTranslatorRemoveService(t *testing.T) {
 		},
 	}
 
+	const NOFLAGS = 1 << 16
+	config := Config{Logger: stdlog.New(ioutil.Discard, ioutil.Discard, NOFLAGS)}
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			const NOFLAGS = 1 << 16
-			tr := NewTranslator(stdlog.New(ioutil.Discard, ioutil.Discard, NOFLAGS))
+			tr := NewTranslator(&config)
 			tc.setup(tr)
 			tr.removeService(tc.svc)
 			got := tr.ClusterCache.Values()
@@ -242,10 +244,11 @@ func TestTranslatorAddEndpoints(t *testing.T) {
 		},
 	}}
 
+	const NOFLAGS = 1 << 16
+	config := Config{Logger: stdlog.New(ioutil.Discard, ioutil.Discard, NOFLAGS)}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			const NOFLAGS = 1 << 16
-			tr := NewTranslator(stdlog.New(ioutil.Discard, ioutil.Discard, NOFLAGS))
+			tr := NewTranslator(&config)
 			tr.addEndpoints(tc.ep)
 			got := tr.ClusterLoadAssignmentCache.Values()
 			if !reflect.DeepEqual(tc.want, got) {
@@ -299,10 +302,11 @@ func TestTranslatorRemoveEndpoints(t *testing.T) {
 		},
 	}
 
+	const NOFLAGS = 1 << 16
+	config := Config{Logger: stdlog.New(ioutil.Discard, ioutil.Discard, NOFLAGS)}
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			const NOFLAGS = 1 << 16
-			tr := NewTranslator(stdlog.New(ioutil.Discard, ioutil.Discard, NOFLAGS))
+			tr := NewTranslator(&config)
 			tc.setup(tr)
 			tr.removeEndpoints(tc.ep)
 			got := tr.ClusterLoadAssignmentCache.Values()
@@ -746,10 +750,11 @@ func TestTranslatorAddIngress(t *testing.T) {
 		}},
 	}}
 
+	const NOFLAGS = 1 << 16
+	config := Config{Logger: stdlog.New(ioutil.Discard, ioutil.Discard, NOFLAGS)}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			const NOFLAGS = 1 << 16
-			tr := NewTranslator(stdlog.New(ioutil.Discard, ioutil.Discard, NOFLAGS))
+			tr := NewTranslator(&config)
 			if tc.setup != nil {
 				tc.setup(tr)
 			}
@@ -849,10 +854,11 @@ func TestTranslatorRemoveIngress(t *testing.T) {
 			want: []*v2.VirtualHost{},
 		},
 	}
+	const NOFLAGS = 1 << 16
+	config := Config{Logger: stdlog.New(ioutil.Discard, ioutil.Discard, NOFLAGS)}
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			const NOFLAGS = 1 << 16
-			tr := NewTranslator(stdlog.New(ioutil.Discard, ioutil.Discard, NOFLAGS))
+			tr := NewTranslator(&config)
 			tc.setup(tr)
 			tr.removeIngress(tc.ing)
 			got := tr.VirtualHostCache.Values()

--- a/internal/grpc/grpc_test.go
+++ b/internal/grpc/grpc_test.go
@@ -34,9 +34,6 @@ import (
 )
 
 func TestGRPCStreaming(t *testing.T) {
-	const NOFLAGS = 1 << 16
-	log := stdlog.New(ioutil.Discard, ioutil.Discard, NOFLAGS)
-
 	var l net.Listener
 
 	// tr is recreated before the start of each test.
@@ -153,10 +150,12 @@ func TestGRPCStreaming(t *testing.T) {
 		},
 	}
 
+	const NOFLAGS = 1 << 16
+	config := contour.Config{Logger: stdlog.New(ioutil.Discard, ioutil.Discard, NOFLAGS)}
 	for name, fn := range tests {
 		t.Run(name, func(t *testing.T) {
-			tr = contour.NewTranslator(log)
-			srv := NewAPI(log, tr)
+			tr = contour.NewTranslator(&config)
+			srv := NewAPI(config.Logger, tr)
 			var err error
 			l, err = net.Listen("tcp", "127.0.0.1:0")
 			check(t, err)
@@ -177,9 +176,6 @@ func TestGRPCStreaming(t *testing.T) {
 }
 
 func TestGRPCFetching(t *testing.T) {
-	const NOFLAGS = 1 << 16
-	log := stdlog.New(ioutil.Discard, ioutil.Discard, NOFLAGS)
-
 	var l net.Listener
 
 	newClient := func(t *testing.T) *grpc.ClientConn {
@@ -231,10 +227,12 @@ func TestGRPCFetching(t *testing.T) {
 		},
 	}
 
+	const NOFLAGS = 1 << 16
+	config := contour.Config{Logger: stdlog.New(ioutil.Discard, ioutil.Discard, NOFLAGS)}
 	for name, fn := range tests {
 		t.Run(name, func(t *testing.T) {
-			tr := contour.NewTranslator(log)
-			srv := NewAPI(log, tr)
+			tr := contour.NewTranslator(&config)
+			srv := NewAPI(config.Logger, tr)
 			var err error
 			l, err = net.Listen("tcp", "127.0.0.1:0")
 			check(t, err)


### PR DESCRIPTION
Introduce a general configuration struct to carry config information
into contour.NewTranslator().

This unblocks a lot of configuration related issues, such as #48 and #72

Signed-off-by: Dave Cheney <dave@cheney.net>