### PR TITLE
gopkg.toml: upgrade to latest go-control-plane

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -296,6 +296,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "eb7b3ca39767b0d571cff7717d79a888cb3de8cccacdb80abdc59a2d743abb3a"
+  inputs-digest = "0b20b87b64d62f334b8a5ebc2236bbafe27558fc68252855a8e24e5cbc9ca477"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -47,7 +47,7 @@
   branch = "master"
   name = "github.com/envoyproxy/go-control-plane"
   packages = ["api"]
-  revision = "9c40bd0acb38c726f25af259e42f2ebe8b35a8d0"
+  revision = "858cbd409fb547344f222654241050fefce79535"
 
 [[projects]]
   name = "github.com/ghodss/yaml"
@@ -71,7 +71,7 @@
   branch = "master"
   name = "github.com/go-openapi/spec"
   packages = ["."]
-  revision = "65a3c60d6972c141df601865fdb53ce5fbfc78af"
+  revision = "01738944bdee0f26bf66420c5b17d54cfdf55341"
 
 [[projects]]
   branch = "master"
@@ -81,8 +81,9 @@
 
 [[projects]]
   name = "github.com/gogo/protobuf"
-  packages = ["proto","sortkeys"]
-  revision = "c0656edd0d9eab7c66d1eb0c568f9039345796f7"
+  packages = ["gogoproto","proto","protoc-gen-gogo/descriptor","sortkeys","types"]
+  revision = "342cbe0a04158f6dcb03ca0079991a51a4248c02"
+  version = "v0.5"
 
 [[projects]]
   branch = "master"
@@ -91,9 +92,10 @@
   revision = "23def4e6c14b4da8ac2ed8007337bc5eb5007998"
 
 [[projects]]
+  branch = "master"
   name = "github.com/golang/protobuf"
-  packages = ["proto","protoc-gen-go/descriptor","ptypes","ptypes/any","ptypes/duration","ptypes/struct","ptypes/timestamp","ptypes/wrappers"]
-  revision = "130e6b02ab059e7b717a096f397c5b60111cae74"
+  packages = ["proto","protoc-gen-go/descriptor","ptypes","ptypes/any","ptypes/duration","ptypes/timestamp"]
+  revision = "1e59b77b52bf8e4b449a57e6f79f21226d571845"
 
 [[projects]]
   branch = "master"
@@ -170,8 +172,8 @@
 [[projects]]
   name = "github.com/lyft/protoc-gen-validate"
   packages = ["validate"]
-  revision = "500ccdbb2e7d98ba50d19e07c001350c893a7c53"
-  version = "v0.0.4"
+  revision = "8e6aaf55f4954f1ef9d3ee2e8f5a50e79cc04f8f"
+  version = "v0.0.5"
 
 [[projects]]
   branch = "master"
@@ -213,25 +215,25 @@
   branch = "master"
   name = "golang.org/x/net"
   packages = ["context","context/ctxhttp","http2","http2/hpack","idna","internal/timeseries","lex/httplex","trace"]
-  revision = "a8b9294777976932365dabb6640cf1468d95c70f"
+  revision = "d866cfc389cec985d6fda2859936a575a55a3ab6"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/oauth2"
   packages = [".","internal"]
-  revision = "f95fa95eaa936d9d87489b15d1d18b97c1ba9c28"
+  revision = "462316686f20eb6df426961c1c131bdaa5dfa68e"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/sys"
   packages = ["unix","windows"]
-  revision = "8b4580aae2a0dd0c231a45d3ccb8434ff533b840"
+  revision = "571f7bbbe08da2a8955aed9d4db316e78630e9a3"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/text"
   packages = ["collate","collate/build","internal/colltab","internal/gen","internal/tag","internal/triegen","internal/ucd","language","secure/bidirule","transform","unicode/bidi","unicode/cldr","unicode/norm","unicode/rangetable","width"]
-  revision = "57961680700a5336d15015c8c50686ca5ba362a4"
+  revision = "d5a9226ed7dd70cade6ccae9d37517fe14dd9fee"
 
 [[projects]]
   name = "google.golang.org/appengine"
@@ -243,19 +245,19 @@
   branch = "master"
   name = "google.golang.org/genproto"
   packages = ["googleapis/api/annotations","googleapis/rpc/status"]
-  revision = "7f0da29060c682909f650ad8ed4e515bd74fa12a"
+  revision = "a8101f21cf983e773d0c1133ebc5424792003214"
 
 [[projects]]
   name = "google.golang.org/grpc"
-  packages = [".","balancer","codes","connectivity","credentials","grpclb/grpc_lb_v1/messages","grpclog","internal","keepalive","metadata","naming","peer","resolver","stats","status","tap","transport"]
-  revision = "9a2334748bab9638f1480ad4f0ac6ac0c6c3a486"
-  version = "v1.7.4"
+  packages = [".","balancer","balancer/roundrobin","codes","connectivity","credentials","encoding","grpclb/grpc_lb_v1/messages","grpclog","internal","keepalive","metadata","naming","peer","resolver","resolver/dns","resolver/passthrough","stats","status","tap","transport"]
+  revision = "e687fa4e6424368ece6e4fe727cea2c806a0fcb4"
+  version = "v1.8.2"
 
 [[projects]]
   name = "gopkg.in/alecthomas/kingpin.v2"
   packages = ["."]
-  revision = "1087e65c9441605df944fb12c33f0fe7072d18ca"
-  version = "v2.2.5"
+  revision = "947dcec5ba9c011838740e680966fd7087a71d0d"
+  version = "v2.2.6"
 
 [[projects]]
   name = "gopkg.in/inf.v0"
@@ -273,13 +275,13 @@
   branch = "release-1.8"
   name = "k8s.io/api"
   packages = ["admissionregistration/v1alpha1","apps/v1beta1","apps/v1beta2","authentication/v1","authentication/v1beta1","authorization/v1","authorization/v1beta1","autoscaling/v1","autoscaling/v2beta1","batch/v1","batch/v1beta1","batch/v2alpha1","certificates/v1beta1","core/v1","extensions/v1beta1","networking/v1","policy/v1beta1","rbac/v1","rbac/v1alpha1","rbac/v1beta1","scheduling/v1alpha1","settings/v1alpha1","storage/v1","storage/v1beta1"]
-  revision = "4df58c811fe2e65feb879227b2b245e4dc26e7ad"
+  revision = "9b9dca205a15b6ce9ef10091f05d60a13fdcf418"
 
 [[projects]]
   branch = "release-1.8"
   name = "k8s.io/apimachinery"
   packages = ["pkg/api/equality","pkg/api/errors","pkg/api/meta","pkg/api/resource","pkg/apis/meta/internalversion","pkg/apis/meta/v1","pkg/apis/meta/v1/unstructured","pkg/apis/meta/v1alpha1","pkg/conversion","pkg/conversion/queryparams","pkg/conversion/unstructured","pkg/fields","pkg/labels","pkg/runtime","pkg/runtime/schema","pkg/runtime/serializer","pkg/runtime/serializer/json","pkg/runtime/serializer/protobuf","pkg/runtime/serializer/recognizer","pkg/runtime/serializer/streaming","pkg/runtime/serializer/versioning","pkg/selection","pkg/types","pkg/util/cache","pkg/util/clock","pkg/util/diff","pkg/util/errors","pkg/util/framer","pkg/util/intstr","pkg/util/json","pkg/util/net","pkg/util/runtime","pkg/util/sets","pkg/util/validation","pkg/util/validation/field","pkg/util/wait","pkg/util/yaml","pkg/version","pkg/watch","third_party/forked/golang/reflect"]
-  revision = "019ae5ada31de202164b118aee88ee2d14075c31"
+  revision = "5134afd2c0c91158afac0d8a28bd2177185a3bcc"
 
 [[projects]]
   name = "k8s.io/client-go"
@@ -291,11 +293,11 @@
   branch = "master"
   name = "k8s.io/kube-openapi"
   packages = ["pkg/common"]
-  revision = "39a7bf85c140f972372c2a0d1ee40adbf0c8bfe1"
+  revision = "b16ebc07f5cad97831f961e4b5a9cc1caed33b7e"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "0b20b87b64d62f334b8a5ebc2236bbafe27558fc68252855a8e24e5cbc9ca477"
+  inputs-digest = "26d99752fbece371dcd4533c7859435b7a18df8a59ded5045b211e4d54e424c8"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -18,7 +18,7 @@
   name="google.golang.org/grpc"
   version="~1.7"
 
-[[override]]
+[[constraint]]
   name="k8s.io/apimachinery"
   branch="release-1.8"
 

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -16,16 +16,8 @@
 
 [[constraint]]
   name="google.golang.org/grpc"
-  version="~1.7"
+  version="~1.8"
 
 [[constraint]]
   name="k8s.io/apimachinery"
   branch="release-1.8"
-
-[[override]]
-  name="github.com/gogo/protobuf"
-  revision="c0656edd0d9eab7c66d1eb0c568f9039345796f7"
-
-[[override]]
-  name="github.com/golang/protobuf"
-  revision="130e6b02ab059e7b717a096f397c5b60111cae74"

--- a/internal/contour/listener.go
+++ b/internal/contour/listener.go
@@ -18,7 +18,7 @@ import (
 	"path/filepath"
 
 	v2 "github.com/envoyproxy/go-control-plane/api"
-	"github.com/golang/protobuf/ptypes/struct"
+	"github.com/gogo/protobuf/types"
 	"k8s.io/api/core/v1"
 	"k8s.io/api/extensions/v1beta1"
 )
@@ -86,14 +86,14 @@ func (lc *ListenerCache) recomputeTLSListener(ingresses map[metadata]*v1beta1.In
 				},
 				Filters: []*v2.Filter{{
 					Name: httpFilter,
-					Config: &structpb.Struct{
-						Fields: map[string]*structpb.Value{
+					Config: &types.Struct{
+						Fields: map[string]*types.Value{
 							"codec_type":  sv("auto"),
 							"stat_prefix": sv("ingress_https"),
-							"rds": st(map[string]*structpb.Value{
+							"rds": st(map[string]*types.Value{
 								"route_config_name": sv("ingress_http"), // TODO(dfc) issue 103
-								"config_source": st(map[string]*structpb.Value{
-									"api_config_source": st(map[string]*structpb.Value{
+								"config_source": st(map[string]*types.Value{
+									"api_config_source": st(map[string]*types.Value{
 										"api_type": sv("grpc"),
 										"cluster_name": lv(
 											sv("xds_cluster"),
@@ -102,13 +102,13 @@ func (lc *ListenerCache) recomputeTLSListener(ingresses map[metadata]*v1beta1.In
 								}),
 							}),
 							"http_filters": lv(
-								st(map[string]*structpb.Value{
+								st(map[string]*types.Value{
 									"name": sv(router),
 								}),
 							),
-							"access_log": st(map[string]*structpb.Value{
+							"access_log": st(map[string]*types.Value{
 								"name": sv(accessLog),
-								"config": st(map[string]*structpb.Value{
+								"config": st(map[string]*types.Value{
 									"path": sv("/dev/stdout"),
 								}),
 							}),
@@ -157,14 +157,14 @@ func defaultListener() *v2.Listener {
 		FilterChains: []*v2.FilterChain{{
 			Filters: []*v2.Filter{{
 				Name: httpFilter,
-				Config: &structpb.Struct{
-					Fields: map[string]*structpb.Value{
-						"codec_type":  sv("auto"),
-						"stat_prefix": sv("ingress_http"),
-						"rds": st(map[string]*structpb.Value{
-							"route_config_name": sv("ingress_http"), // TODO(dfc) issue 103
-							"config_source": st(map[string]*structpb.Value{
-								"api_config_source": st(map[string]*structpb.Value{
+				Config: &types.Struct{
+					Fields: map[string]*types.Value{
+						"codec_type":  sv("http1"),        // let's not go crazy now
+						"stat_prefix": sv("ingress_http"), // TODO(dfc) should this come from pod.Name?
+						"rds": st(map[string]*types.Value{
+							"route_config_name": sv("ingress_http"), // TODO(dfc) needed for grpc?
+							"config_source": st(map[string]*types.Value{
+								"api_config_source": st(map[string]*types.Value{
 									"api_type": sv("grpc"),
 									"cluster_name": lv(
 										sv("xds_cluster"),
@@ -173,13 +173,13 @@ func defaultListener() *v2.Listener {
 							}),
 						}),
 						"http_filters": lv(
-							st(map[string]*structpb.Value{
+							st(map[string]*types.Value{
 								"name": sv(router),
 							}),
 						),
-						"access_log": st(map[string]*structpb.Value{
+						"access_log": st(map[string]*types.Value{
 							"name": sv(accessLog),
-							"config": st(map[string]*structpb.Value{
+							"config": st(map[string]*types.Value{
 								"path": sv("/dev/stdout"),
 							}),
 						}),
@@ -191,17 +191,17 @@ func defaultListener() *v2.Listener {
 	}
 }
 
-func sv(s string) *structpb.Value {
-	return &structpb.Value{Kind: &structpb.Value_StringValue{StringValue: s}}
+func sv(s string) *types.Value {
+	return &types.Value{Kind: &types.Value_StringValue{StringValue: s}}
 }
 
-func bv(b bool) *structpb.Value {
-	return &structpb.Value{Kind: &structpb.Value_BoolValue{BoolValue: b}}
+func bv(b bool) *types.Value {
+	return &types.Value{Kind: &types.Value_BoolValue{BoolValue: b}}
 }
 
-func st(m map[string]*structpb.Value) *structpb.Value {
-	return &structpb.Value{Kind: &structpb.Value_StructValue{StructValue: &structpb.Struct{Fields: m}}}
+func st(m map[string]*types.Value) *types.Value {
+	return &types.Value{Kind: &types.Value_StructValue{StructValue: &types.Struct{Fields: m}}}
 }
-func lv(v ...*structpb.Value) *structpb.Value {
-	return &structpb.Value{Kind: &structpb.Value_ListValue{ListValue: &structpb.ListValue{Values: v}}}
+func lv(v ...*types.Value) *types.Value {
+	return &types.Value{Kind: &types.Value_ListValue{ListValue: &types.ListValue{Values: v}}}
 }

--- a/internal/contour/translator.go
+++ b/internal/contour/translator.go
@@ -24,9 +24,9 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"time"
 
 	v2 "github.com/envoyproxy/go-control-plane/api"
-	"github.com/golang/protobuf/ptypes/duration"
 
 	"github.com/heptio/contour/internal/log"
 	"k8s.io/api/core/v1"
@@ -122,12 +122,6 @@ func (t *Translator) OnDelete(obj interface{}) {
 	}
 }
 
-const (
-	nanosecond  = 1
-	microsecond = 1000 * nanosecond
-	millisecond = 1000 * microsecond
-)
-
 func (t *Translator) addService(svc *v1.Service) {
 	defer t.ClusterCache.Notify()
 	for _, p := range svc.Spec.Ports {
@@ -151,10 +145,8 @@ func (t *Translator) addService(svc *v1.Service) {
 					Name:             hashname(60, svc.ObjectMeta.Namespace, svc.ObjectMeta.Name, p.Name),
 					Type:             v2.Cluster_EDS,
 					EdsClusterConfig: config,
-					ConnectTimeout: &duration.Duration{
-						Nanos: 250 * millisecond,
-					},
-					LbPolicy: v2.Cluster_ROUND_ROBIN,
+					ConnectTimeout:   250 * time.Millisecond,
+					LbPolicy:         v2.Cluster_ROUND_ROBIN,
 				}
 				t.ClusterCache.Add(&c)
 			}
@@ -162,10 +154,8 @@ func (t *Translator) addService(svc *v1.Service) {
 				Name:             hashname(60, svc.ObjectMeta.Namespace, svc.ObjectMeta.Name, strconv.Itoa(int(p.Port))),
 				Type:             v2.Cluster_EDS,
 				EdsClusterConfig: config,
-				ConnectTimeout: &duration.Duration{
-					Nanos: 250 * millisecond,
-				},
-				LbPolicy: v2.Cluster_ROUND_ROBIN,
+				ConnectTimeout:   250 * time.Millisecond,
+				LbPolicy:         v2.Cluster_ROUND_ROBIN,
 			}
 			t.ClusterCache.Add(&c)
 		default:

--- a/internal/contour/translator_test.go
+++ b/internal/contour/translator_test.go
@@ -17,9 +17,9 @@ import (
 	"io/ioutil"
 	"reflect"
 	"testing"
+	"time"
 
 	v2 "github.com/envoyproxy/go-control-plane/api"
-	"github.com/golang/protobuf/ptypes/duration"
 	"github.com/heptio/contour/internal/log/stdlog"
 	"k8s.io/api/core/v1"
 	"k8s.io/api/extensions/v1beta1"
@@ -944,10 +944,8 @@ func cluster(name, servicename string) *v2.Cluster {
 			},
 			ServiceName: servicename,
 		},
-		ConnectTimeout: &duration.Duration{
-			Nanos: 250 * millisecond,
-		},
-		LbPolicy: v2.Cluster_ROUND_ROBIN,
+		ConnectTimeout: 250 * time.Millisecond,
+		LbPolicy:       v2.Cluster_ROUND_ROBIN,
 	}
 }
 

--- a/internal/grpc/grpc.go
+++ b/internal/grpc/grpc.go
@@ -24,8 +24,8 @@ import (
 	"google.golang.org/grpc/codes"
 
 	v2 "github.com/envoyproxy/go-control-plane/api"
-	"github.com/golang/protobuf/proto"
-	"github.com/golang/protobuf/ptypes/any"
+	"github.com/gogo/protobuf/proto"
+	"github.com/gogo/protobuf/types"
 	"github.com/heptio/contour/internal/contour"
 	"github.com/heptio/contour/internal/log"
 )
@@ -118,9 +118,9 @@ func newgrpcServer(l log.Logger, t *contour.Translator) *grpcServer {
 	}
 }
 
-// A resourcer provides resources formatted as []*any.Any.
+// A resourcer provides resources formatted as []*types.Any.
 type resourcer interface {
-	Resources() ([]*any.Any, error)
+	Resources() ([]*types.Any, error)
 	TypeURL() string
 }
 
@@ -131,18 +131,18 @@ type CDS struct {
 	count uint64
 }
 
-// Resources returns the contents of CDS"s cache as a []*any.Any.
+// Resources returns the contents of CDS"s cache as a []*types.Any.
 // TODO(dfc) cache the results of Resources in the ClusterCache so
 // we can avoid the error handling.
-func (c *CDS) Resources() ([]*any.Any, error) {
+func (c *CDS) Resources() ([]*types.Any, error) {
 	v := c.Values()
-	resources := make([]*any.Any, len(v))
+	resources := make([]*types.Any, len(v))
 	for i := range v {
 		data, err := proto.Marshal(v[i])
 		if err != nil {
 			return nil, err
 		}
-		resources[i] = &any.Any{
+		resources[i] = &types.Any{
 			TypeUrl: ClusterType,
 			Value:   data,
 		}
@@ -169,18 +169,18 @@ type EDS struct {
 	count uint64
 }
 
-// Resources returns the contents of EDS"s cache as a []*any.Any.
+// Resources returns the contents of EDS"s cache as a []*types.Any.
 // TODO(dfc) cache the results of Resources in the ClusterLoadAssignmentCache so
 // we can avoid the error handling.
-func (e *EDS) Resources() ([]*any.Any, error) {
+func (e *EDS) Resources() ([]*types.Any, error) {
 	v := e.Values()
-	resources := make([]*any.Any, len(v))
+	resources := make([]*types.Any, len(v))
 	for i := range v {
 		data, err := proto.Marshal(v[i])
 		if err != nil {
 			return nil, err
 		}
-		resources[i] = &any.Any{
+		resources[i] = &types.Any{
 			TypeUrl: EndpointType,
 			Value:   data,
 		}
@@ -211,18 +211,18 @@ type LDS struct {
 	count uint64
 }
 
-// Resources returns the contents of LDS"s cache as a []*any.Any.
+// Resources returns the contents of LDS"s cache as a []*types.Any.
 // TODO(dfc) cache the results of Resources in the ListenerCache so
 // we can avoid the error handling.
-func (l *LDS) Resources() ([]*any.Any, error) {
+func (l *LDS) Resources() ([]*types.Any, error) {
 	v := l.Values()
-	resources := make([]*any.Any, len(v))
+	resources := make([]*types.Any, len(v))
 	for i := range v {
 		data, err := proto.Marshal(v[i])
 		if err != nil {
 			return nil, err
 		}
-		resources[i] = &any.Any{
+		resources[i] = &types.Any{
 			TypeUrl: ListenerType,
 			Value:   data,
 		}
@@ -249,10 +249,10 @@ type RDS struct {
 	count uint64
 }
 
-// Resources returns the contents of RDS"s cache as a []*any.Any.
+// Resources returns the contents of RDS"s cache as a []*types.Any.
 // TODO(dfc) cache the results of Resources in the VirtualHostCache so
 // we can avoid the error handling.
-func (r *RDS) Resources() ([]*any.Any, error) {
+func (r *RDS) Resources() ([]*types.Any, error) {
 	ingress_http, err := proto.Marshal(&v2.RouteConfiguration{
 		Name:         "ingress_http", // TODO(dfc) matches LDS configuration?
 		VirtualHosts: r.Values(),
@@ -260,7 +260,7 @@ func (r *RDS) Resources() ([]*any.Any, error) {
 	if err != nil {
 		return nil, err
 	}
-	return []*any.Any{{
+	return []*types.Any{{
 		TypeUrl: RouteType,
 		Value:   ingress_http,
 	}}, nil


### PR DESCRIPTION
Fixes #110

Update envoyproxy/go-control-plane which switches from goprotobuf to gogo
encoding.

Signed-off-by: Dave Cheney <dave@cheney.net>