### PR TITLE
internal/contour: refactor internal caches

### DIFF
--- a/internal/contour/cache.go
+++ b/internal/contour/cache.go
@@ -15,44 +15,41 @@ package contour
 
 import (
 	"sort"
+	"sync"
 
 	v2 "github.com/envoyproxy/go-control-plane/api"
 )
 
 // clusterCache is a thread safe, atomic, copy on write cache of *v2.Cluster objects.
-type clusterCache chan []*v2.Cluster
-
-// init must be called before clusterCache is used for the first time.
-func (cc *clusterCache) init() {
-	*cc = make(clusterCache, 1)
-	*cc <- nil // prime cache
+type clusterCache struct {
+	sync.Mutex
+	values []*v2.Cluster
 }
 
 // Values returns a copy of the contents of the cache.
-func (cc clusterCache) Values() []*v2.Cluster {
-	v := <-cc
-	r := make([]*v2.Cluster, len(v))
-	copy(r, v)
-	cc <- v
+func (cc *clusterCache) Values() []*v2.Cluster {
+	cc.Lock()
+	r := append([]*v2.Cluster{}, cc.values...)
+	cc.Unlock()
 	return r
 }
 
 // with executes f with the value of the stored in the cache.
 // the value returned from f replaces the contents in the cache.
-func (cc clusterCache) with(f func([]*v2.Cluster) []*v2.Cluster) {
-	v := <-cc
-	v = f(v)
+func (cc *clusterCache) with(f func([]*v2.Cluster) []*v2.Cluster) {
+	cc.Lock()
+	cc.values = f(cc.values)
 	// TODO(dfc) Add and Remove do not (currently) affect the sort order
 	// so it might be possible to avoid always sorting.
-	sort.Sort(clusterByName(v))
-	cc <- v
+	sort.Sort(clusterByName(cc.values))
+	cc.Unlock()
 }
 
 // Add adds an entry to the cache. If a Cluster with the same
 // name exists, it is replaced.
 // TODO(dfc) make Add variadic to support atomic addition of several clusters
 // also niladic Add can be used as a no-op notify for watchers.
-func (cc clusterCache) Add(c *v2.Cluster) {
+func (cc *clusterCache) Add(c *v2.Cluster) {
 	cc.with(func(in []*v2.Cluster) []*v2.Cluster {
 		sort.Sort(clusterByName(in))
 		i := sort.Search(len(in), func(i int) bool { return in[i].Name >= c.Name })
@@ -70,7 +67,7 @@ func (cc clusterCache) Add(c *v2.Cluster) {
 
 // Remove removes the named entry from the cache. If the entry
 // is not present in the cache, the operation is a no-op.
-func (cc clusterCache) Remove(name string) {
+func (cc *clusterCache) Remove(name string) {
 	cc.with(func(in []*v2.Cluster) []*v2.Cluster {
 		sort.Sort(clusterByName(in))
 		i := sort.Search(len(in), func(i int) bool { return in[i].Name >= name })
@@ -89,39 +86,35 @@ func (c clusterByName) Swap(i, j int)      { c[i], c[j] = c[j], c[i] }
 func (c clusterByName) Less(i, j int) bool { return c[i].Name < c[j].Name }
 
 // clusterLoadAssignmentCache is a thread safe, atomic, copy on write cache of v2.ClusterLoadAssignment objects.
-type clusterLoadAssignmentCache chan []*v2.ClusterLoadAssignment
-
-// init must be called before clusterLoadAssignmentCache is used for the first time.
-func (c *clusterLoadAssignmentCache) init() {
-	*c = make(clusterLoadAssignmentCache, 1)
-	*c <- nil // prime cache
+type clusterLoadAssignmentCache struct {
+	sync.Mutex
+	values []*v2.ClusterLoadAssignment
 }
 
 // Values returns a copy of the contents of the cache.
-func (c clusterLoadAssignmentCache) Values() []*v2.ClusterLoadAssignment {
-	v := <-c
-	r := make([]*v2.ClusterLoadAssignment, len(v))
-	copy(r, v)
-	c <- v
+func (c *clusterLoadAssignmentCache) Values() []*v2.ClusterLoadAssignment {
+	c.Lock()
+	r := append([]*v2.ClusterLoadAssignment{}, c.values...)
+	c.Unlock()
 	return r
 }
 
 // with executes f with the value of the stored in the cache.
 // the value returned from f replaces the contents in the cache.
-func (c clusterLoadAssignmentCache) with(f func([]*v2.ClusterLoadAssignment) []*v2.ClusterLoadAssignment) {
-	v := <-c
-	v = f(v)
+func (c *clusterLoadAssignmentCache) with(f func([]*v2.ClusterLoadAssignment) []*v2.ClusterLoadAssignment) {
+	c.Lock()
+	c.values = f(c.values)
 	// TODO(dfc) Add and Remove do not (currently) affect the sort order
 	// so it might be possible to avoid always sorting.
-	sort.Sort(clusterLoadAssignmentsByName(v))
-	c <- v
+	sort.Sort(clusterLoadAssignmentsByName(c.values))
+	c.Unlock()
 }
 
 // Add adds an entry to the cache. If a ClusterLoadAssignment with the same
 // name exists, it is replaced.
 // TODO(dfc) make Add variadic to support atomic addition of several clusterLoadAssignments
 // also niladic Add can be used as a no-op notify for watchers.
-func (c clusterLoadAssignmentCache) Add(e *v2.ClusterLoadAssignment) {
+func (c *clusterLoadAssignmentCache) Add(e *v2.ClusterLoadAssignment) {
 	c.with(func(in []*v2.ClusterLoadAssignment) []*v2.ClusterLoadAssignment {
 		sort.Sort(clusterLoadAssignmentsByName(in))
 		i := sort.Search(len(in), func(i int) bool { return in[i].ClusterName >= e.ClusterName })
@@ -137,7 +130,7 @@ func (c clusterLoadAssignmentCache) Add(e *v2.ClusterLoadAssignment) {
 
 // Remove removes the named entry from the cache. If the entry
 // is not present in the cache, the operation is a no-op.
-func (c clusterLoadAssignmentCache) Remove(name string) {
+func (c *clusterLoadAssignmentCache) Remove(name string) {
 	c.with(func(in []*v2.ClusterLoadAssignment) []*v2.ClusterLoadAssignment {
 		sort.Sort(clusterLoadAssignmentsByName(in))
 		i := sort.Search(len(in), func(i int) bool { return in[i].ClusterName >= name })
@@ -156,39 +149,35 @@ func (c clusterLoadAssignmentsByName) Swap(i, j int)      { c[i], c[j] = c[j], c
 func (c clusterLoadAssignmentsByName) Less(i, j int) bool { return c[i].ClusterName < c[j].ClusterName }
 
 // ListenerCache is a thread safe, atomic, copy on write cache of v2.Listener objects.
-type listenerCache chan []*v2.Listener
-
-// init must be called before listenerCache is used for the first time.
-func (lc *listenerCache) init() {
-	*lc = make(listenerCache, 1)
-	*lc <- nil // prime cache
+type listenerCache struct {
+	sync.Mutex
+	values []*v2.Listener
 }
 
 // Values returns a copy of the contents of the cache.
-func (lc listenerCache) Values() []*v2.Listener {
-	v := <-lc
-	r := make([]*v2.Listener, len(v))
-	copy(r, v)
-	lc <- v
+func (lc *listenerCache) Values() []*v2.Listener {
+	lc.Lock()
+	r := append([]*v2.Listener{}, lc.values...)
+	lc.Unlock()
 	return r
 }
 
 // with executes f with the value of the stored in the cache.
 // the value returned from f replaces the contents in the cache.
-func (lc listenerCache) with(f func([]*v2.Listener) []*v2.Listener) {
-	l := <-lc
-	l = f(l)
+func (lc *listenerCache) with(f func([]*v2.Listener) []*v2.Listener) {
+	lc.Lock()
+	lc.values = f(lc.values)
 	// TODO(dfc) Add and Remove do not (currently) affect the sort order
 	// so it might be possible to avoid always sorting.
-	sort.Sort(listenersByName(l))
-	lc <- l
+	sort.Sort(listenersByName(lc.values))
+	lc.Unlock()
 }
 
 // Add adds an entry to the cache. If a Listener with the same
 // name exists, it is replaced.
 // TODO(dfc) make Add variadic to support atomic addition of several listeners
 // also niladic Add can be used as a no-op notify for watchers.
-func (lc listenerCache) Add(r *v2.Listener) {
+func (lc *listenerCache) Add(r *v2.Listener) {
 	lc.with(func(in []*v2.Listener) []*v2.Listener {
 		sort.Sort(listenersByName(in))
 		i := sort.Search(len(in), func(i int) bool { return in[i].Name >= r.Name })
@@ -206,7 +195,7 @@ func (lc listenerCache) Add(r *v2.Listener) {
 
 // Remove removes the named entry from the cache. If the entry
 // is not present in the cache, the operation is a no-op.
-func (lc listenerCache) Remove(name string) {
+func (lc *listenerCache) Remove(name string) {
 	lc.with(func(in []*v2.Listener) []*v2.Listener {
 		sort.Sort(listenersByName(in))
 		i := sort.Search(len(in), func(i int) bool { return in[i].Name >= name })
@@ -227,39 +216,35 @@ func (l listenersByName) Less(i, j int) bool { return l[i].Name < l[j].Name }
 // clusterLoadAssignmentCache is a thread safe, atomic, copy on write cache of v2.ClusterLoadAssignment objects.
 
 // VirtualHostCache is a thread safe, atomic, copy on write cache of v2.VirtualHost objects.
-type virtualHostCache chan []*v2.VirtualHost
-
-// init must be called before virtualHostCache is used for the first time.
-func (vc *virtualHostCache) init() {
-	*vc = make(virtualHostCache, 1)
-	*vc <- nil // prime cache
+type virtualHostCache struct {
+	sync.Mutex
+	values []*v2.VirtualHost
 }
 
 // Values returns a copy of the contents of the cache.
-func (vc virtualHostCache) Values() []*v2.VirtualHost {
-	v := <-vc
-	r := make([]*v2.VirtualHost, len(v))
-	copy(r, v)
-	vc <- v
+func (vc *virtualHostCache) Values() []*v2.VirtualHost {
+	vc.Lock()
+	r := append([]*v2.VirtualHost{}, vc.values...)
+	vc.Unlock()
 	return r
 }
 
 // with executes f with the value of the stored in the cache.
 // the value returned from f replaces the contents in the cache.
-func (vc virtualHostCache) with(f func([]*v2.VirtualHost) []*v2.VirtualHost) {
-	v := <-vc
-	v = f(v)
+func (vc *virtualHostCache) with(f func([]*v2.VirtualHost) []*v2.VirtualHost) {
+	vc.Lock()
+	vc.values = f(vc.values)
 	// TODO(dfc) Add and Remove do not (currently) affect the sort order
 	// so it might be possible to avoid always sorting.
-	sort.Sort(virtualHostsByName(v))
-	vc <- v
+	sort.Sort(virtualHostsByName(vc.values))
+	vc.Unlock()
 }
 
 // Add adds an entry to the cache. If a VirtualHost with the same
 // name exists, it is replaced.
 // TODO(dfc) make Add variadic to support atomic addition of several clusters
 // also niladic Add can be used as a no-op notify for watchers.
-func (vc virtualHostCache) Add(r *v2.VirtualHost) {
+func (vc *virtualHostCache) Add(r *v2.VirtualHost) {
 	vc.with(func(in []*v2.VirtualHost) []*v2.VirtualHost {
 		sort.Sort(virtualHostsByName(in))
 		i := sort.Search(len(in), func(i int) bool { return in[i].Name >= r.Name })
@@ -277,7 +262,7 @@ func (vc virtualHostCache) Add(r *v2.VirtualHost) {
 
 // Remove removes the named entry from the cache. If the entry
 // is not present in the cache, the operation is a no-op.
-func (vc virtualHostCache) Remove(name string) {
+func (vc *virtualHostCache) Remove(name string) {
 	vc.with(func(in []*v2.VirtualHost) []*v2.VirtualHost {
 		sort.Sort(virtualHostsByName(in))
 		i := sort.Search(len(in), func(i int) bool { return in[i].Name >= name })

--- a/internal/contour/cache_test.go
+++ b/internal/contour/cache_test.go
@@ -22,7 +22,6 @@ import (
 
 func TestClusterCacheValuesReturnsACopyOfItsInternalSlice(t *testing.T) {
 	var cc clusterCache
-	cc.init()
 	c := &v2.Cluster{
 		Name: "alpha",
 	}
@@ -40,7 +39,6 @@ func TestClusterCacheValuesReturnsACopyOfItsInternalSlice(t *testing.T) {
 
 func TestClusterCacheValuesReturnsTheSameContents(t *testing.T) {
 	var cc clusterCache
-	cc.init()
 	c := &v2.Cluster{
 		Name: "alpha",
 	}
@@ -57,7 +55,6 @@ func TestClusterCacheValuesReturnsTheSameContents(t *testing.T) {
 
 func TestClusterCacheAddInsertsTwoElementsInSortOrder(t *testing.T) {
 	var cc clusterCache
-	cc.init()
 	c1 := &v2.Cluster{
 		Name: "beta",
 	}
@@ -79,7 +76,6 @@ func TestClusterCacheAddInsertsTwoElementsInSortOrder(t *testing.T) {
 
 func TestClusterCacheAddOverwritesElementsWithTheSameName(t *testing.T) {
 	var cc clusterCache
-	cc.init()
 	c1 := &v2.Cluster{
 		Name: "alpha",
 		Type: 1,
@@ -101,7 +97,6 @@ func TestClusterCacheAddOverwritesElementsWithTheSameName(t *testing.T) {
 
 func TestClusterCacheAddIsCopyOnWrite(t *testing.T) {
 	var cc clusterCache
-	cc.init()
 	c1 := &v2.Cluster{
 		Name: "alpha",
 	}
@@ -121,7 +116,6 @@ func TestClusterCacheAddIsCopyOnWrite(t *testing.T) {
 
 func TestClusterCacheRemove(t *testing.T) {
 	var cc clusterCache
-	cc.init()
 	c1 := &v2.Cluster{
 		Name: "alpha",
 	}
@@ -136,7 +130,6 @@ func TestClusterCacheRemove(t *testing.T) {
 
 func TestClusterLoadAssignmentCacheValuesReturnsACopyOfItsInternalSlice(t *testing.T) {
 	var cc clusterLoadAssignmentCache
-	cc.init()
 	c := &v2.ClusterLoadAssignment{
 		ClusterName: "alpha",
 	}
@@ -154,7 +147,6 @@ func TestClusterLoadAssignmentCacheValuesReturnsACopyOfItsInternalSlice(t *testi
 
 func TestClusterLoadAssignmentCacheValuesReturnsTheSameContents(t *testing.T) {
 	var cc clusterLoadAssignmentCache
-	cc.init()
 	c := &v2.ClusterLoadAssignment{
 		ClusterName: "alpha",
 	}
@@ -171,7 +163,6 @@ func TestClusterLoadAssignmentCacheValuesReturnsTheSameContents(t *testing.T) {
 
 func TestClusterLoadAssignmentCacheAddInsertsTwoElementsInSortOrder(t *testing.T) {
 	var cc clusterLoadAssignmentCache
-	cc.init()
 	c1 := &v2.ClusterLoadAssignment{
 		ClusterName: "beta",
 	}
@@ -193,7 +184,6 @@ func TestClusterLoadAssignmentCacheAddInsertsTwoElementsInSortOrder(t *testing.T
 
 func TestClusterLoadAssignmentCacheAddOverwritesElementsWithTheSameName(t *testing.T) {
 	var cc clusterLoadAssignmentCache
-	cc.init()
 	c1 := &v2.ClusterLoadAssignment{
 		ClusterName: "alpha",
 		Policy: &v2.ClusterLoadAssignment_Policy{
@@ -219,7 +209,6 @@ func TestClusterLoadAssignmentCacheAddOverwritesElementsWithTheSameName(t *testi
 
 func TestClusterLoadAssignmentCacheAddIsCopyOnWrite(t *testing.T) {
 	var cc clusterLoadAssignmentCache
-	cc.init()
 	c1 := &v2.ClusterLoadAssignment{
 		ClusterName: "alpha",
 	}
@@ -239,7 +228,6 @@ func TestClusterLoadAssignmentCacheAddIsCopyOnWrite(t *testing.T) {
 
 func TestClusterLoadAssignmentCacheRemove(t *testing.T) {
 	var cc clusterLoadAssignmentCache
-	cc.init()
 	c1 := &v2.ClusterLoadAssignment{
 		ClusterName: "alpha",
 	}
@@ -254,7 +242,6 @@ func TestClusterLoadAssignmentCacheRemove(t *testing.T) {
 
 func TestListenerCacheValuesReturnsACopyOfItsInternalSlice(t *testing.T) {
 	var cc listenerCache
-	cc.init()
 	l := &v2.Listener{
 		Name: "alpha",
 	}
@@ -272,7 +259,6 @@ func TestListenerCacheValuesReturnsACopyOfItsInternalSlice(t *testing.T) {
 
 func TestListenerCacheValuesReturnsTheSameContents(t *testing.T) {
 	var cc listenerCache
-	cc.init()
 	l := &v2.Listener{
 		Name: "alpha",
 	}
@@ -289,7 +275,6 @@ func TestListenerCacheValuesReturnsTheSameContents(t *testing.T) {
 
 func TestListenerCacheAddInsertsTwoElementsInSortOrder(t *testing.T) {
 	var cc listenerCache
-	cc.init()
 	l1 := &v2.Listener{
 		Name: "beta",
 	}
@@ -311,7 +296,6 @@ func TestListenerCacheAddInsertsTwoElementsInSortOrder(t *testing.T) {
 
 func TestListenerCacheAddOverwritesElementsWithTheSameName(t *testing.T) {
 	var cc listenerCache
-	cc.init()
 	l1 := &v2.Listener{
 		Name:      "alpha",
 		DrainType: 7,
@@ -333,7 +317,6 @@ func TestListenerCacheAddOverwritesElementsWithTheSameName(t *testing.T) {
 
 func TestListenerCacheAddIsCopyOnWrite(t *testing.T) {
 	var cc listenerCache
-	cc.init()
 	l1 := &v2.Listener{
 		Name: "alpha",
 	}
@@ -353,7 +336,6 @@ func TestListenerCacheAddIsCopyOnWrite(t *testing.T) {
 
 func TestListenerCacheRemove(t *testing.T) {
 	var cc listenerCache
-	cc.init()
 	l1 := &v2.Listener{
 		Name: "alpha",
 	}
@@ -368,7 +350,6 @@ func TestListenerCacheRemove(t *testing.T) {
 
 func TestVirtualHostCacheValuesReturnsACopyOfItsInternalSlice(t *testing.T) {
 	var cc virtualHostCache
-	cc.init()
 	c := &v2.VirtualHost{
 		Name: "alpha",
 	}
@@ -386,7 +367,6 @@ func TestVirtualHostCacheValuesReturnsACopyOfItsInternalSlice(t *testing.T) {
 
 func TestVirtualHostCacheValuesReturnsTheSameContents(t *testing.T) {
 	var cc virtualHostCache
-	cc.init()
 	c := &v2.VirtualHost{
 		Name: "alpha",
 	}
@@ -403,7 +383,6 @@ func TestVirtualHostCacheValuesReturnsTheSameContents(t *testing.T) {
 
 func TestVirtualHostCacheAddInsertsTwoElementsInSortOrder(t *testing.T) {
 	var cc virtualHostCache
-	cc.init()
 	c1 := &v2.VirtualHost{
 		Name: "beta",
 	}
@@ -425,7 +404,6 @@ func TestVirtualHostCacheAddInsertsTwoElementsInSortOrder(t *testing.T) {
 
 func TestVirtualHostCacheAddOverwritesElementsWithTheSameName(t *testing.T) {
 	var cc virtualHostCache
-	cc.init()
 	c1 := &v2.VirtualHost{
 		Name: "alpha",
 		Domains: []string{
@@ -451,7 +429,6 @@ func TestVirtualHostCacheAddOverwritesElementsWithTheSameName(t *testing.T) {
 
 func TestVirtualHostCacheAddIsCopyOnWrite(t *testing.T) {
 	var cc virtualHostCache
-	cc.init()
 	c1 := &v2.VirtualHost{
 		Name: "alpha",
 	}
@@ -471,7 +448,6 @@ func TestVirtualHostCacheAddIsCopyOnWrite(t *testing.T) {
 
 func TestVirtualHostCacheRemove(t *testing.T) {
 	var cc virtualHostCache
-	cc.init()
 	c1 := &v2.VirtualHost{
 		Name: "alpha",
 	}

--- a/internal/contour/translator.go
+++ b/internal/contour/translator.go
@@ -39,12 +39,8 @@ func NewTranslator(log log.Logger) *Translator {
 	t := &Translator{
 		Logger: log,
 	}
-	t.ClusterCache.init()
-	t.ClusterLoadAssignmentCache.init()
-	t.ListenerCache.init()
 	t.ListenerCache.Add(defaultListener()) // insert default listener
 	t.ListenerCache.Notify()               // bump version to notify streamers
-	t.VirtualHostCache.init()
 	t.vhosts = make(map[string][]*v1beta1.Ingress)
 	t.ingresses = make(map[metadata]*v1beta1.Ingress)
 	t.secrets = make(map[metadata]*v1.Secret)


### PR DESCRIPTION
Requiring the cache.init() setup step is a grotty code smell and
prevented the translator having a valid zero value.

Replace the (frankyly) far to clever channel based cache with a good old
mutex. The caches will be simplified more in the future, probably
collapsing down onto a single cache of type.Any's, but for now this
is one step in unblocking the transformer being usable without an
initaliser.

Signed-off-by: Dave Cheney <dave@cheney.net>