### PR TITLE
internal/contour: recompute non tls listener dynamically

### DIFF
--- a/internal/contour/translator.go
+++ b/internal/contour/translator.go
@@ -39,8 +39,6 @@ func NewTranslator(log log.Logger) *Translator {
 	t := &Translator{
 		Logger: log,
 	}
-	t.ListenerCache.Add(defaultListener()) // insert default listener
-	t.ListenerCache.Notify()               // bump version to notify streamers
 	t.vhosts = make(map[string][]*v1beta1.Ingress)
 	t.ingresses = make(map[metadata]*v1beta1.Ingress)
 	t.secrets = make(map[metadata]*v1.Secret)
@@ -255,6 +253,7 @@ func (t *Translator) addIngress(i *v1beta1.Ingress) {
 
 	t.ingresses[metadata{name: i.Name, namespace: i.Namespace}] = i
 
+	t.recomputeListener(t.ingresses)
 	if len(i.Spec.TLS) > 0 {
 		t.recomputeTLSListener(t.ingresses, t.secrets)
 	}
@@ -300,6 +299,7 @@ func (t *Translator) removeIngress(i *v1beta1.Ingress) {
 
 	delete(t.ingresses, metadata{name: i.Name, namespace: i.Namespace})
 
+	t.recomputeListener(t.ingresses)
 	if len(i.Spec.TLS) > 0 {
 		t.recomputeTLSListener(t.ingresses, t.secrets)
 	}


### PR DESCRIPTION
Rather than hard coding a default (non tls) listener during Translator
creation, compute the `ingress_http` listener dynamically when there are
non tls ingress objects to serve.

This removes another blocker on Translator having a usable zero value.

Signed-off-by: Dave Cheney <dave@cheney.net>