### PR TITLE
internal/contour: bind https listener to ingress_https routes

### DIFF
--- a/internal/contour/listener.go
+++ b/internal/contour/listener.go
@@ -49,7 +49,7 @@ func (lc *ListenerCache) recomputeListener(ingresses map[metadata]*v1beta1.Ingre
 	if len(ingresses) > 0 {
 		l.FilterChains = []*v2.FilterChain{{
 			Filters: []*v2.Filter{
-				httpfilter(ENVOY_HTTP_LISTENER, ENVOY_HTTP_LISTENER),
+				httpfilter(ENVOY_HTTP_LISTENER),
 			},
 		}}
 	}
@@ -90,7 +90,7 @@ func (lc *ListenerCache) recomputeTLSListener(ingresses map[metadata]*v1beta1.In
 				},
 				TlsContext: tlscontext(i.Namespace, tls.SecretName),
 				Filters: []*v2.Filter{
-					httpfilter(ENVOY_HTTPS_LISTENER, ENVOY_HTTP_LISTENER), // stat_prefix, route_name
+					httpfilter(ENVOY_HTTPS_LISTENER),
 				},
 			}
 			l.FilterChains = append(l.FilterChains, fc)
@@ -145,13 +145,13 @@ func tlscontext(namespace, name string) *v2.DownstreamTlsContext {
 	}
 }
 
-func httpfilter(statprefix, routename string) *v2.Filter {
+func httpfilter(routename string) *v2.Filter {
 	return &v2.Filter{
 		Name: httpFilter,
 		Config: &types.Struct{
 			Fields: map[string]*types.Value{
 				"codec_type":  sv("auto"),
-				"stat_prefix": sv(statprefix), // TODO(dfc) should this come from pod.Name?
+				"stat_prefix": sv(routename),
 				"rds": st(map[string]*types.Value{
 					"route_config_name": sv(routename),
 					"config_source": st(map[string]*types.Value{

--- a/internal/contour/translator.go
+++ b/internal/contour/translator.go
@@ -280,6 +280,7 @@ func (t *Translator) addIngress(i *v1beta1.Ingress) {
 			}},
 		}
 		t.VirtualHostCache.HTTP.Add(&v)
+		t.VirtualHostCache.HTTPS.Add(&v)
 		return
 	}
 
@@ -306,6 +307,7 @@ func (t *Translator) removeIngress(i *v1beta1.Ingress) {
 
 	if i.Spec.Backend != nil {
 		t.VirtualHostCache.HTTP.Remove("*")
+		t.VirtualHostCache.HTTPS.Remove("*")
 		return
 	}
 

--- a/internal/contour/translator.go
+++ b/internal/contour/translator.go
@@ -279,7 +279,7 @@ func (t *Translator) addIngress(i *v1beta1.Ingress) {
 				Action: clusteraction(ingressBackendToClusterName(i, i.Spec.Backend)),
 			}},
 		}
-		t.VirtualHostCache.Add(&v)
+		t.VirtualHostCache.HTTP.Add(&v)
 		return
 	}
 
@@ -305,7 +305,7 @@ func (t *Translator) removeIngress(i *v1beta1.Ingress) {
 	}
 
 	if i.Spec.Backend != nil {
-		t.VirtualHostCache.Remove("*")
+		t.VirtualHostCache.HTTP.Remove("*")
 		return
 	}
 

--- a/internal/contour/translator_test.go
+++ b/internal/contour/translator_test.go
@@ -756,7 +756,12 @@ func TestTranslatorAddIngress(t *testing.T) {
 			tr.addIngress(tc.ing)
 			got := tr.VirtualHostCache.HTTP.Values()
 			if !reflect.DeepEqual(tc.want, got) {
-				t.Fatalf("addIngress(%v):\n got: %v\nwant: %v", tc.ing, got, tc.want)
+				t.Fatalf("addIngress(%v):\n (ingress_http) got: %v\nwant: %v", tc.ing, got, tc.want)
+			}
+
+			got = tr.VirtualHostCache.HTTPS.Values()
+			if !reflect.DeepEqual(tc.want, got) {
+				t.Fatalf("addIngress(%v):\n (ingress_https) got: %v\nwant: %v", tc.ing, got, tc.want)
 			}
 		})
 	}
@@ -855,9 +860,14 @@ func TestTranslatorRemoveIngress(t *testing.T) {
 			tr := NewTranslator(stdlog.New(ioutil.Discard, ioutil.Discard, NOFLAGS))
 			tc.setup(tr)
 			tr.removeIngress(tc.ing)
-			got := tr.VirtualHostCache.HTTP.Values()
+			got := tr.VirtualHostCache.HTTPS.Values()
 			if !reflect.DeepEqual(tc.want, got) {
-				t.Fatalf("removeIngress(%v): got: %v, want: %v", tc.ing, got, tc.want)
+				t.Fatalf("removeIngress(%v) (ingress_http): got: %v, want: %v", tc.ing, got, tc.want)
+			}
+
+			got = tr.VirtualHostCache.HTTPS.Values()
+			if !reflect.DeepEqual(tc.want, got) {
+				t.Fatalf("removeIngress(%v) (ingress_https): got: %v, want: %v", tc.ing, got, tc.want)
 			}
 		})
 	}

--- a/internal/contour/translator_test.go
+++ b/internal/contour/translator_test.go
@@ -754,7 +754,7 @@ func TestTranslatorAddIngress(t *testing.T) {
 				tc.setup(tr)
 			}
 			tr.addIngress(tc.ing)
-			got := tr.VirtualHostCache.Values()
+			got := tr.VirtualHostCache.HTTP.Values()
 			if !reflect.DeepEqual(tc.want, got) {
 				t.Fatalf("addIngress(%v):\n got: %v\nwant: %v", tc.ing, got, tc.want)
 			}
@@ -855,7 +855,7 @@ func TestTranslatorRemoveIngress(t *testing.T) {
 			tr := NewTranslator(stdlog.New(ioutil.Discard, ioutil.Discard, NOFLAGS))
 			tc.setup(tr)
 			tr.removeIngress(tc.ing)
-			got := tr.VirtualHostCache.Values()
+			got := tr.VirtualHostCache.HTTP.Values()
 			if !reflect.DeepEqual(tc.want, got) {
 				t.Fatalf("removeIngress(%v): got: %v, want: %v", tc.ing, got, tc.want)
 			}

--- a/internal/contour/virtualhost.go
+++ b/internal/contour/virtualhost.go
@@ -23,7 +23,8 @@ import (
 
 // VirtualHostCache manage the contents of the gRPC RDS cache.
 type VirtualHostCache struct {
-	virtualHostCache
+	HTTP  virtualHostCache
+	HTTPS virtualHostCache
 	Cond
 }
 
@@ -35,7 +36,7 @@ func (v *VirtualHostCache) recomputevhost(vhost string, ingresses []*v1beta1.Ing
 	case 0:
 		// there are no ingresses registered with this vhost any more
 		// remove the VirtualHost from the grpc cache.
-		v.Remove(hashname(60, vhost))
+		v.HTTP.Remove(hashname(60, vhost))
 	default:
 		// otherwise there is at least one ingress object associated with
 		// this vhost, so regernate the cache record and add/overwrite the
@@ -61,7 +62,7 @@ func (v *VirtualHostCache) recomputevhost(vhost string, ingresses []*v1beta1.Ing
 			}
 		}
 		sort.Stable(sort.Reverse(longestRouteFirst(vv.Routes)))
-		v.Add(&vv)
+		v.HTTP.Add(&vv)
 	}
 }
 

--- a/internal/contour/virtualhost.go
+++ b/internal/contour/virtualhost.go
@@ -37,6 +37,7 @@ func (v *VirtualHostCache) recomputevhost(vhost string, ingresses []*v1beta1.Ing
 		// there are no ingresses registered with this vhost any more
 		// remove the VirtualHost from the grpc cache.
 		v.HTTP.Remove(hashname(60, vhost))
+		v.HTTPS.Remove(hashname(60, vhost))
 	default:
 		// otherwise there is at least one ingress object associated with
 		// this vhost, so regernate the cache record and add/overwrite the
@@ -63,6 +64,7 @@ func (v *VirtualHostCache) recomputevhost(vhost string, ingresses []*v1beta1.Ing
 		}
 		sort.Stable(sort.Reverse(longestRouteFirst(vv.Routes)))
 		v.HTTP.Add(&vv)
+		v.HTTPS.Add(&vv)
 	}
 }
 


### PR DESCRIPTION
Fixes #104

RDS now publishes routes to http and https caches. LDS now binds the
http listener to the RDS http cache, ingress_http, by name, and vice
versa for the https listener.

This permits RDS to compute different routes for http and https
listeners, enabling http to https redirects.

Signed-off-by: Dave Cheney <dave@cheney.net>