### PR TITLE
internal/contour: refactor recompute{TLS,}Listener

### DIFF
--- a/internal/contour/listener_test.go
+++ b/internal/contour/listener_test.go
@@ -14,13 +14,181 @@
 package contour
 
 import (
+	"reflect"
 	"testing"
 
 	"k8s.io/api/core/v1"
 	"k8s.io/api/extensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+
+	v2 "github.com/envoyproxy/go-control-plane/api"
 )
+
+func TestRecomputeListener(t *testing.T) {
+	ingress_http := listener(ENVOY_HTTP_LISTENER, "0.0.0.0", 8080)
+	ingress_http.FilterChains = []*v2.FilterChain{{
+		Filters: []*v2.Filter{
+			httpfilter(ENVOY_HTTP_LISTENER),
+		},
+	}}
+
+	tests := map[string]struct {
+		ingresses map[metadata]*v1beta1.Ingress
+		add       []*v2.Listener
+		remove    []string
+	}{
+		"empty ingress map": {
+			ingresses: nil,
+			add:       nil,
+			remove:    []string{ENVOY_HTTP_LISTENER},
+		},
+		"default vhost ingress": {
+			ingresses: map[metadata]*v1beta1.Ingress{
+				metadata{namespace: "default", name: "simple"}: {
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "simple",
+						Namespace: "default",
+					},
+					Spec: v1beta1.IngressSpec{
+						Backend: backend("backend", intstr.FromInt(80)),
+					},
+				},
+			},
+			add: []*v2.Listener{
+				ingress_http,
+			},
+			remove: nil,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			add, remove := recomputeListener(tc.ingresses)
+			if !reflect.DeepEqual(add, tc.add) {
+				t.Errorf("add:\n\texpected: %v\n\tgot: %v", tc.add, add)
+			}
+			if !reflect.DeepEqual(remove, tc.remove) {
+				t.Errorf("remove:\n\texpected: %v,\n\tgot: %v", tc.remove, remove)
+			}
+		})
+	}
+}
+
+func TestRecomputeTLSListener(t *testing.T) {
+	ingresss_http := listener(ENVOY_HTTPS_LISTENER, "0.0.0.0", 8443)
+	ingresss_http.FilterChains = []*v2.FilterChain{{
+		Filters: []*v2.Filter{
+			httpfilter(ENVOY_HTTPS_LISTENER),
+		},
+	}}
+
+	tests := map[string]struct {
+		ingresses map[metadata]*v1beta1.Ingress
+		secrets   map[metadata]*v1.Secret
+		add       []*v2.Listener
+		remove    []string
+	}{
+		"empty ingress map": {
+			ingresses: nil,
+			secrets:   nil,
+			add:       nil,
+			remove:    []string{ENVOY_HTTPS_LISTENER},
+		},
+		// tls is not possible for the default backend vhost because it has no name.
+		"default vhost ingress": {
+			ingresses: map[metadata]*v1beta1.Ingress{
+				metadata{namespace: "default", name: "simple"}: {
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "simple",
+						Namespace: "default",
+					},
+					Spec: v1beta1.IngressSpec{
+						Backend: backend("backend", intstr.FromInt(80)),
+					},
+				},
+			},
+			secrets: nil,
+			add:     nil,
+			remove:  []string{ENVOY_HTTPS_LISTENER},
+		},
+		"simple vhost, with no secret": {
+			ingresses: map[metadata]*v1beta1.Ingress{
+				metadata{namespace: "default", name: "simple"}: {
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "simple",
+						Namespace: "default",
+					},
+					Spec: v1beta1.IngressSpec{
+						TLS: []v1beta1.IngressTLS{{
+							Hosts:      []string{"whatever.example.com"},
+							SecretName: "missing",
+						}},
+						Backend: backend("backend", intstr.FromInt(80)),
+					},
+				},
+			},
+			secrets: nil,
+			add:     nil,
+			remove:  []string{ENVOY_HTTPS_LISTENER},
+		},
+		"simple vhost, with secret": {
+			ingresses: map[metadata]*v1beta1.Ingress{
+				metadata{namespace: "default", name: "simple"}: {
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "simple",
+						Namespace: "default",
+					},
+					Spec: v1beta1.IngressSpec{
+						TLS: []v1beta1.IngressTLS{{
+							Hosts:      []string{"whatever.example.com"},
+							SecretName: "secret",
+						}},
+						Backend: backend("backend", intstr.FromInt(80)),
+					},
+				},
+			},
+			secrets: map[metadata]*v1.Secret{
+				metadata{namespace: "default", name: "secret"}: {
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "secret",
+						Namespace: "default",
+					},
+					Data: map[string][]byte{
+						v1.TLSCertKey:       []byte("certificate"),
+						v1.TLSPrivateKeyKey: []byte("key"),
+					},
+				},
+			},
+			add: []*v2.Listener{{
+				Name:    ENVOY_HTTPS_LISTENER,
+				Address: socketaddress("0.0.0.0", 8443),
+				FilterChains: []*v2.FilterChain{{
+					FilterChainMatch: &v2.FilterChainMatch{
+						SniDomains: []string{"whatever.example.com"},
+					},
+					TlsContext: tlscontext("default", "secret"),
+					Filters: []*v2.Filter{
+						httpfilter(ENVOY_HTTPS_LISTENER),
+					},
+				}},
+			}},
+			remove: nil,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			add, remove := recomputeTLSListener(tc.ingresses, tc.secrets)
+			if !reflect.DeepEqual(add, tc.add) {
+				t.Errorf("add:\n\texpected: %v\n\tgot: %v", tc.add, add)
+			}
+			if !reflect.DeepEqual(remove, tc.remove) {
+				t.Errorf("remove:\n\texpected: %v,\n\tgot: %v", tc.remove, remove)
+			}
+		})
+	}
+}
 
 func TestListenerCacheRecomputeListener(t *testing.T) {
 	lc := new(ListenerCache)
@@ -37,7 +205,7 @@ func TestListenerCacheRecomputeListener(t *testing.T) {
 			},
 		},
 	}
-	lc.recomputeListener(i)
+	lc.recomputeListeners(i, nil)
 	assertCacheNotEmpty(t, lc)
 }
 
@@ -87,12 +255,14 @@ func TestListenerCacheRecomputeTLSListener(t *testing.T) {
 }
 
 func assertCacheEmpty(t *testing.T, lc *ListenerCache) {
+	t.Helper()
 	if len(lc.values) > 0 {
 		t.Fatalf("len(lc.values): expected 0, got %d", len(lc.values))
 	}
 }
 
 func assertCacheNotEmpty(t *testing.T, lc *ListenerCache) {
+	t.Helper()
 	if len(lc.values) == 0 {
 		t.Fatalf("len(lc.values): expected > 0, got %d", len(lc.values))
 	}

--- a/internal/contour/translator.go
+++ b/internal/contour/translator.go
@@ -253,10 +253,7 @@ func (t *Translator) addIngress(i *v1beta1.Ingress) {
 
 	t.ingresses[metadata{name: i.Name, namespace: i.Namespace}] = i
 
-	t.recomputeListener(t.ingresses)
-	if len(i.Spec.TLS) > 0 {
-		t.recomputeTLSListener(t.ingresses, t.secrets)
-	}
+	t.recomputeListeners()
 
 	// notify watchers that the vhost cache has probably changed.
 	defer t.VirtualHostCache.Notify()
@@ -300,10 +297,7 @@ func (t *Translator) removeIngress(i *v1beta1.Ingress) {
 
 	delete(t.ingresses, metadata{name: i.Name, namespace: i.Namespace})
 
-	t.recomputeListener(t.ingresses)
-	if len(i.Spec.TLS) > 0 {
-		t.recomputeTLSListener(t.ingresses, t.secrets)
-	}
+	t.recomputeListeners()
 
 	if i.Spec.Backend != nil {
 		t.VirtualHostCache.HTTP.Remove("*")
@@ -315,6 +309,10 @@ func (t *Translator) removeIngress(i *v1beta1.Ingress) {
 		t.vhosts[rule.Host] = removeIfPresent(t.vhosts[rule.Host], i)
 		t.recomputevhost(rule.Host, t.vhosts[rule.Host])
 	}
+}
+
+func (t *Translator) recomputeListeners() {
+	t.ListenerCache.recomputeListeners(t.ingresses, t.secrets)
 }
 
 func (t *Translator) addSecret(s *v1.Secret) {


### PR DESCRIPTION
Refactor recompute{TLS,}Listener to be decoupled from the cache and the
notifier. In this way we can isolate most of the listener recompute
logic from cache and notifier management.

Signed-off-by: Dave Cheney <dave@cheney.net>