### PR TITLE
internal/contour: remove contour.NewTranslator

### DIFF
--- a/cmd/contour/contour.go
+++ b/cmd/contour/contour.go
@@ -81,7 +81,9 @@ func main() {
 		}
 
 		// gRPC v2 support
-		t := contour.NewTranslator(logger.WithPrefix("translator"))
+		t := &contour.Translator{
+			Logger: logger.WithPrefix("translator"),
+		}
 
 		var g workgroup.Group
 

--- a/internal/contour/translator_test.go
+++ b/internal/contour/translator_test.go
@@ -117,7 +117,9 @@ func TestTranslatorAddService(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			const NOFLAGS = 1 << 16
-			tr := NewTranslator(stdlog.New(ioutil.Discard, ioutil.Discard, NOFLAGS))
+			tr := &Translator{
+				Logger: stdlog.New(ioutil.Discard, ioutil.Discard, NOFLAGS),
+			}
 			tr.addService(tc.svc)
 			got := tr.ClusterCache.Values()
 			if !reflect.DeepEqual(tc.want, got) {
@@ -196,7 +198,9 @@ func TestTranslatorRemoveService(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			const NOFLAGS = 1 << 16
-			tr := NewTranslator(stdlog.New(ioutil.Discard, ioutil.Discard, NOFLAGS))
+			tr := &Translator{
+				Logger: stdlog.New(ioutil.Discard, ioutil.Discard, NOFLAGS),
+			}
 			tc.setup(tr)
 			tr.removeService(tc.svc)
 			got := tr.ClusterCache.Values()
@@ -245,7 +249,9 @@ func TestTranslatorAddEndpoints(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			const NOFLAGS = 1 << 16
-			tr := NewTranslator(stdlog.New(ioutil.Discard, ioutil.Discard, NOFLAGS))
+			tr := &Translator{
+				Logger: stdlog.New(ioutil.Discard, ioutil.Discard, NOFLAGS),
+			}
 			tr.addEndpoints(tc.ep)
 			got := tr.ClusterLoadAssignmentCache.Values()
 			if !reflect.DeepEqual(tc.want, got) {
@@ -302,7 +308,9 @@ func TestTranslatorRemoveEndpoints(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			const NOFLAGS = 1 << 16
-			tr := NewTranslator(stdlog.New(ioutil.Discard, ioutil.Discard, NOFLAGS))
+			tr := &Translator{
+				Logger: stdlog.New(ioutil.Discard, ioutil.Discard, NOFLAGS),
+			}
 			tc.setup(tr)
 			tr.removeEndpoints(tc.ep)
 			got := tr.ClusterLoadAssignmentCache.Values()
@@ -749,7 +757,9 @@ func TestTranslatorAddIngress(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			const NOFLAGS = 1 << 16
-			tr := NewTranslator(stdlog.New(ioutil.Discard, ioutil.Discard, NOFLAGS))
+			tr := &Translator{
+				Logger: stdlog.New(ioutil.Discard, ioutil.Discard, NOFLAGS),
+			}
 			if tc.setup != nil {
 				tc.setup(tr)
 			}
@@ -857,7 +867,9 @@ func TestTranslatorRemoveIngress(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			const NOFLAGS = 1 << 16
-			tr := NewTranslator(stdlog.New(ioutil.Discard, ioutil.Discard, NOFLAGS))
+			tr := &Translator{
+				Logger: stdlog.New(ioutil.Discard, ioutil.Discard, NOFLAGS),
+			}
 			tc.setup(tr)
 			tr.removeIngress(tc.ing)
 			got := tr.VirtualHostCache.HTTPS.Values()

--- a/internal/grpc/grpc_test.go
+++ b/internal/grpc/grpc_test.go
@@ -178,7 +178,9 @@ func TestGRPCStreaming(t *testing.T) {
 
 	for name, fn := range tests {
 		t.Run(name, func(t *testing.T) {
-			tr = contour.NewTranslator(log)
+			tr = &contour.Translator{
+				Logger: log,
+			}
 			srv := NewAPI(log, tr)
 			var err error
 			l, err = net.Listen("tcp", "127.0.0.1:0")
@@ -256,7 +258,9 @@ func TestGRPCFetching(t *testing.T) {
 
 	for name, fn := range tests {
 		t.Run(name, func(t *testing.T) {
-			tr := contour.NewTranslator(log)
+			tr := &contour.Translator{
+				Logger: log,
+			}
 			srv := NewAPI(log, tr)
 			var err error
 			l, err = net.Listen("tcp", "127.0.0.1:0")


### PR DESCRIPTION
Translator no longer needs a NewTranslator constructor. The Logger
field remains mandatory, but now the translator can be embedded
directly.

Signed-off-by: Dave Cheney <dave@cheney.net>