### PR TITLE
internal/contour: Make https listener port configurable

### DIFF
--- a/cmd/contour/contour.go
+++ b/cmd/contour/contour.go
@@ -68,7 +68,10 @@ func main() {
 	inCluster := serve.Flag("incluster", "use in cluster configuration.").Bool()
 	kubeconfig := serve.Flag("kubeconfig", "path to kubeconfig (if not in running inside a cluster)").Default(filepath.Join(os.Getenv("HOME"), ".kube", "config")).String()
 	debug := serve.Flag("debug", "enable v1 REST API request logging.").Bool()
+
+	// translator configuration
 	serve.Flag("envoy-http-port", "Envoy HTTP listener port").IntVar(&t.HTTPListenerPort)
+	serve.Flag("envoy-https-port", "Envoy HTTPS listener port").IntVar(&t.HTTPSListenerPort)
 
 	args := os.Args[1:]
 	switch kingpin.MustParse(app.Parse(args)) {

--- a/internal/contour/listener_test.go
+++ b/internal/contour/listener_test.go
@@ -130,6 +130,12 @@ func TestRecomputeTLSListener(t *testing.T) {
 			httpfilter(ENVOY_HTTPS_LISTENER),
 		},
 	}}
+	ingress_http2 := listener(ENVOY_HTTPS_LISTENER, "0.0.0.0", 9000) // issue 72
+	ingress_http2.FilterChains = []*v2.FilterChain{{
+		Filters: []*v2.Filter{
+			httpfilter(ENVOY_HTTPS_LISTENER),
+		},
+	}}
 
 	tests := map[string]struct {
 		ingresses map[metadata]*v1beta1.Ingress
@@ -212,6 +218,52 @@ func TestRecomputeTLSListener(t *testing.T) {
 			add: []*v2.Listener{{
 				Name:    ENVOY_HTTPS_LISTENER,
 				Address: socketaddress("0.0.0.0", 8443),
+				FilterChains: []*v2.FilterChain{{
+					FilterChainMatch: &v2.FilterChainMatch{
+						SniDomains: []string{"whatever.example.com"},
+					},
+					TlsContext: tlscontext("default", "secret"),
+					Filters: []*v2.Filter{
+						httpfilter(ENVOY_HTTPS_LISTENER),
+					},
+				}},
+			}},
+			remove: nil,
+		},
+		"simple vhost, with non default listener port": {
+			ListenerCache: ListenerCache{
+				HTTPSListenerPort: 9000,
+			},
+			ingresses: map[metadata]*v1beta1.Ingress{
+				metadata{namespace: "default", name: "simple"}: {
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "simple",
+						Namespace: "default",
+					},
+					Spec: v1beta1.IngressSpec{
+						TLS: []v1beta1.IngressTLS{{
+							Hosts:      []string{"whatever.example.com"},
+							SecretName: "secret",
+						}},
+						Backend: backend("backend", intstr.FromInt(80)),
+					},
+				},
+			},
+			secrets: map[metadata]*v1.Secret{
+				metadata{namespace: "default", name: "secret"}: {
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "secret",
+						Namespace: "default",
+					},
+					Data: map[string][]byte{
+						v1.TLSCertKey:       []byte("certificate"),
+						v1.TLSPrivateKeyKey: []byte("key"),
+					},
+				},
+			},
+			add: []*v2.Listener{{
+				Name:    ENVOY_HTTPS_LISTENER,
+				Address: socketaddress("0.0.0.0", 9000),
 				FilterChains: []*v2.FilterChain{{
 					FilterChainMatch: &v2.FilterChainMatch{
 						SniDomains: []string{"whatever.example.com"},


### PR DESCRIPTION
Updates #72

Introduce Translator.HTTPSListenerPort and plumb it through to
--envoy-https-port.