### PR TITLE
 internal/contour: make listener address configurable

### DIFF
--- a/cmd/contour/contour.go
+++ b/cmd/contour/contour.go
@@ -70,8 +70,10 @@ func main() {
 	debug := serve.Flag("debug", "enable v1 REST API request logging.").Bool()
 
 	// translator configuration
-	serve.Flag("envoy-http-port", "Envoy HTTP listener port").IntVar(&t.HTTPListenerPort)
-	serve.Flag("envoy-https-port", "Envoy HTTPS listener port").IntVar(&t.HTTPSListenerPort)
+	serve.Flag("envoy-http-address", "Envoy HTTP listener address").StringVar(&t.HTTPAddress)
+	serve.Flag("envoy-https-address", "Envoy HTTPS listener address").StringVar(&t.HTTPSAddress)
+	serve.Flag("envoy-http-port", "Envoy HTTP listener port").IntVar(&t.HTTPPort)
+	serve.Flag("envoy-https-port", "Envoy HTTPS listener port").IntVar(&t.HTTPSPort)
 
 	args := os.Args[1:]
 	switch kingpin.MustParse(app.Parse(args)) {
@@ -81,6 +83,7 @@ func main() {
 	case bootstrap.FullCommand():
 		writeBootstrapConfig(*path)
 	case serve.FullCommand():
+		logger.Infof("args: %v", args)
 		var g workgroup.Group
 
 		// buffer notifications to t to ensure they are handled sequentially.

--- a/internal/contour/listener_test.go
+++ b/internal/contour/listener_test.go
@@ -32,7 +32,7 @@ func TestRecomputeListener(t *testing.T) {
 			httpfilter(ENVOY_HTTP_LISTENER),
 		},
 	}}
-	ingress_http2 := listener(ENVOY_HTTP_LISTENER, "0.0.0.0", 9000) // issue 72
+	ingress_http2 := listener(ENVOY_HTTP_LISTENER, "127.0.0.1", 9000) // issue 72
 	ingress_http2.FilterChains = []*v2.FilterChain{{
 		Filters: []*v2.Filter{
 			httpfilter(ENVOY_HTTP_LISTENER),
@@ -90,7 +90,8 @@ func TestRecomputeListener(t *testing.T) {
 		// http listener on non default port.
 		"issue#72": {
 			ListenerCache: ListenerCache{
-				HTTPListenerPort: 9000,
+				HTTPAddress: "127.0.0.1",
+				HTTPPort:    9000,
 			},
 			ingresses: map[metadata]*v1beta1.Ingress{
 				metadata{namespace: "default", name: "simple"}: {
@@ -130,7 +131,7 @@ func TestRecomputeTLSListener(t *testing.T) {
 			httpfilter(ENVOY_HTTPS_LISTENER),
 		},
 	}}
-	ingress_http2 := listener(ENVOY_HTTPS_LISTENER, "0.0.0.0", 9000) // issue 72
+	ingress_http2 := listener(ENVOY_HTTPS_LISTENER, "::", 9000) // issue 72
 	ingress_http2.FilterChains = []*v2.FilterChain{{
 		Filters: []*v2.Filter{
 			httpfilter(ENVOY_HTTPS_LISTENER),
@@ -232,7 +233,8 @@ func TestRecomputeTLSListener(t *testing.T) {
 		},
 		"simple vhost, with non default listener port": {
 			ListenerCache: ListenerCache{
-				HTTPSListenerPort: 9000,
+				HTTPSAddress: "::", // ipv6 voodoo
+				HTTPSPort:    9000,
 			},
 			ingresses: map[metadata]*v1beta1.Ingress{
 				metadata{namespace: "default", name: "simple"}: {
@@ -263,7 +265,7 @@ func TestRecomputeTLSListener(t *testing.T) {
 			},
 			add: []*v2.Listener{{
 				Name:    ENVOY_HTTPS_LISTENER,
-				Address: socketaddress("0.0.0.0", 9000),
+				Address: socketaddress("::", 9000),
 				FilterChains: []*v2.FilterChain{{
 					FilterChainMatch: &v2.FilterChainMatch{
 						SniDomains: []string{"whatever.example.com"},


### PR DESCRIPTION
Updates #48

Introduce Translator.HTTP{,S}Address and plumb it to
--envoy-http{,s}-address respectively.

You can use this --envoy-https-address=:: to bind to IPv6 _only_. Dual
stack should probably be done with --envoy-https-address=0.0.0.0 and
falling back to the host's preference.

Signed-off-by: Dave Cheney <dave@cheney.net>