### PR TITLE
Issue/136

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -41,7 +41,7 @@
   branch = "master"
   name = "github.com/envoyproxy/go-control-plane"
   packages = ["api"]
-  revision = "5a2ca70225c7bd327548dae8962637d3dc45f15e"
+  revision = "7d4123ea69ef3bbe9053a4d7af7970db836753ac"
 
 [[projects]]
   name = "github.com/ghodss/yaml"
@@ -203,13 +203,13 @@
   branch = "master"
   name = "golang.org/x/crypto"
   packages = ["ssh/terminal"]
-  revision = "0fcca4842a8d74bfddc2c96a073bd2a4d2a7a2e8"
+  revision = "b3c9a1d25cfbbbab0ff4780b71c4f54e6e92a0de"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/net"
   packages = ["context","context/ctxhttp","http2","http2/hpack","idna","internal/timeseries","lex/httplex","trace"]
-  revision = "42fe2e1c20de1054d3d30f82cc9fb5b41e2e3767"
+  revision = "ab555f366c4508dbe0802550b1b20c46c5c18aa0"
 
 [[projects]]
   branch = "master"
@@ -221,7 +221,7 @@
   branch = "master"
   name = "golang.org/x/sys"
   packages = ["unix","windows"]
-  revision = "1792d66dc88e503d3cb2400578221cdf1f7fe26f"
+  revision = "810d7000345868fc619eb81f46307107118f4ae1"
 
 [[projects]]
   branch = "master"
@@ -263,7 +263,7 @@
   branch = "v2"
   name = "gopkg.in/yaml.v2"
   packages = ["."]
-  revision = "c4a9fb418357aceb801272d73efd518f183700fa"
+  revision = "d670f9405373e636a5a2765eea47fac0c9bc91a4"
 
 [[projects]]
   branch = "release-1.9"
@@ -287,7 +287,7 @@
   branch = "master"
   name = "k8s.io/kube-openapi"
   packages = ["pkg/common"]
-  revision = "b16ebc07f5cad97831f961e4b5a9cc1caed33b7e"
+  revision = "a07b7bbb58e7fdc5144f8d7046331d29fc9ad3b3"
 
 [solve-meta]
   analyzer-name = "dep"

--- a/internal/contour/listener.go
+++ b/internal/contour/listener.go
@@ -267,8 +267,15 @@ func httpfilter(routename string) *v2.Filter {
 					"config_source": st(map[string]*types.Value{
 						"api_config_source": st(map[string]*types.Value{
 							"api_type": sv("grpc"),
-							"cluster_name": lv(
+							"cluster_names": lv(
 								sv("xds_cluster"),
+							),
+							"grpc_services": lv(
+								st(map[string]*types.Value{
+									"envoy_grpc": st(map[string]*types.Value{
+										"cluster_name": sv("xds_cluster"),
+									}),
+								}),
 							),
 						}),
 					}),

--- a/internal/envoy/config.go
+++ b/internal/envoy/config.go
@@ -122,11 +122,17 @@ const yamlConfig = `dynamic_resources:
   lds_config:
     api_config_source:
       api_type: GRPC
-      cluster_name: [xds_cluster]
+      cluster_names: [xds_cluster]
+      grpc_services:
+      - envoy_grpc:
+          cluster_name: xds_cluster
   cds_config:
     api_config_source:
       api_type: GRPC
-      cluster_name: [xds_cluster]
+      cluster_names: [xds_cluster]
+      grpc_services:
+      - envoy_grpc:
+          cluster_name: xds_cluster
 static_resources:
   clusters:
   - name: xds_cluster

--- a/internal/envoy/config_test.go
+++ b/internal/envoy/config_test.go
@@ -111,11 +111,17 @@ func TestConfigWriter_WriteYAML(t *testing.T) {
   lds_config:
     api_config_source:
       api_type: GRPC
-      cluster_name: [xds_cluster]
+      cluster_names: [xds_cluster]
+      grpc_services:
+      - envoy_grpc:
+          cluster_name: xds_cluster
   cds_config:
     api_config_source:
       api_type: GRPC
-      cluster_name: [xds_cluster]
+      cluster_names: [xds_cluster]
+      grpc_services:
+      - envoy_grpc:
+          cluster_name: xds_cluster
 static_resources:
   clusters:
   - name: xds_cluster


### PR DESCRIPTION
Fixes #136 

Envoy added the ability to choose which grpc library to use which added a new mandatory field to the `api_config_source` proto. envoyproxy/data-plane-api#398

This PR adds support for generating this additional stanza in the bootstrap config and the LDS response.