### PR TITLE
internal/contour: always overwrite cached Ingress

### DIFF
--- a/internal/contour/virtualhost.go
+++ b/internal/contour/virtualhost.go
@@ -67,19 +67,14 @@ func (v *VirtualHostCache) recomputevhost(vhost string, ingresses []*v1beta1.Ing
 			// skip this vhosts ingress_http route.
 			continue
 		}
+		if i.Annotations["ingress.kubernetes.io/force-ssl-redirect"] == "true" {
+			// set blanket 301 redirect
+			vv.RequireTls = v2.VirtualHost_ALL
+		}
 		if i.Spec.Backend != nil && len(ingresses) == 1 {
 			vv.Routes = []*v2.Route{{
 				Match:  prefixmatch("/"), // match all
 				Action: clusteraction(ingressBackendToClusterName(i, i.Spec.Backend)),
-			}}
-			continue
-		}
-		if i.Annotations["ingress.kubernetes.io/force-ssl-redirect"] == "true" {
-			// set blanket 301 redirect
-			vv.RequireTls = v2.VirtualHost_ALL
-			vv.Routes = []*v2.Route{{
-				Match:  prefixmatch("/"), // match all
-				Action: clusteraction("dummy"),
 			}}
 			continue
 		}

--- a/internal/contour/virtualhost_test.go
+++ b/internal/contour/virtualhost_test.go
@@ -169,7 +169,7 @@ func TestVirtualHostCacheRecomputevhost(t *testing.T) {
 				Domains: []string{"httpbin.org"},
 				Routes: []*v2.Route{{
 					Match:  prefixmatch("/"), // match all
-					Action: clusteraction("dummy"),
+					Action: clusteraction("default/httpbin-org/80"),
 				}},
 				RequireTls: v2.VirtualHost_ALL,
 			}},


### PR DESCRIPTION
Fixes #150

appendIfMissing was not replacing the element if it was present in the
list. Perhaps we should be using a map, or at least add a test.

Signed-off-by: Dave Cheney <dave@cheney.net>