### PR TITLE
internal/contour: support PROXY protocol on listeners

### DIFF
--- a/cmd/contour/contour.go
+++ b/cmd/contour/contour.go
@@ -78,6 +78,7 @@ func main() {
 	serve.Flag("envoy-https-address", "Envoy HTTPS listener address").StringVar(&t.HTTPSAddress)
 	serve.Flag("envoy-http-port", "Envoy HTTP listener port").IntVar(&t.HTTPPort)
 	serve.Flag("envoy-https-port", "Envoy HTTPS listener port").IntVar(&t.HTTPSPort)
+	serve.Flag("use-proxy-protocol", "Use PROXY protocol for all listeners").BoolVar(&t.UseProxyProto)
 
 	args := os.Args[1:]
 	switch kingpin.MustParse(app.Parse(args)) {


### PR DESCRIPTION
Fixes #103

Add support for the
`service.beta.kubernetes.io/aws-load-balancer-proxy-protocol: "*"`
annotation.

Support is enabled via the `--use-proxy-protocol` flag to `serve` which
configures all listeners served via LDS to be configured with
`UseProxyProto: true`.

Signed-off-by: Dave Cheney <dave@cheney.net>