### PR TITLE
Launch envoy with --v2-config-only when using a yaml config file

### DIFF
--- a/deployment/deployment-grpc-v2/02-contour.yaml
+++ b/deployment/deployment-grpc-v2/02-contour.yaml
@@ -24,7 +24,7 @@ spec:
         - containerPort: 8443
           name: https
         command: ["envoy"]
-        args: ["-c", "/config/contour.yaml", "--service-cluster", "cluster0", "--service-node", "node0", "-l", "info"]
+        args: ["-c", "/config/contour.yaml", "--service-cluster", "cluster0", "--service-node", "node0", "-l", "info", "--v2-config-only"]
         volumeMounts:
         - name: contour-config
           mountPath: /config

--- a/deployment/ds-grpc-v2/02-contour.yaml
+++ b/deployment/ds-grpc-v2/02-contour.yaml
@@ -32,6 +32,9 @@ spec:
         name: contour
         command: ["contour"]
         args: ["serve", "--incluster"]
+        volumeMounts:
+        - name: contour-config
+          mountPath: /config
       initContainers:
       - image: gcr.io/heptio-images/contour:master
         imagePullPolicy: Always

--- a/deployment/ds-grpc-v2/02-contour.yaml
+++ b/deployment/ds-grpc-v2/02-contour.yaml
@@ -23,7 +23,7 @@ spec:
         - containerPort: 8080
           name: http
         command: ["envoy"]
-        args: ["-c", "/config/contour.yaml", "--service-cluster", "cluster0", "--service-node", "node0"]
+        args: ["-c", "/config/contour.yaml", "--service-cluster", "cluster0", "--service-node", "node0", "-l", "info", "--v2-config-only"]
         volumeMounts:
         - name: contour-config
           mountPath: /config

--- a/deployment/ds-grpc-v2/02-contour.yaml
+++ b/deployment/ds-grpc-v2/02-contour.yaml
@@ -9,12 +9,12 @@ spec:
   selector:
     matchLabels:
       app: contour
+  updateStrategy:
+    type: RollingUpdate
   template:
     metadata:
       labels:
         app: contour
-    updateStrategy:
-      type: RollingUpdate
     spec:
       containers:
       - image: docker.io/envoyproxy/envoy-alpine:latest

--- a/deployment/render/daemonset-norbac.yaml
+++ b/deployment/render/daemonset-norbac.yaml
@@ -37,7 +37,7 @@ spec:
         - containerPort: 8080
           name: http
         command: ["envoy"]
-        args: ["-c", "/config/contour.yaml", "--service-cluster", "cluster0", "--service-node", "node0"]
+        args: ["-c", "/config/contour.yaml", "--service-cluster", "cluster0", "--service-node", "node0", "-l", "info", "--v2-config-only"]
         volumeMounts:
         - name: contour-config
           mountPath: /config

--- a/deployment/render/daemonset-norbac.yaml
+++ b/deployment/render/daemonset-norbac.yaml
@@ -46,6 +46,9 @@ spec:
         name: contour
         command: ["contour"]
         args: ["serve", "--incluster"]
+        volumeMounts:
+        - name: contour-config
+          mountPath: /config
       initContainers:
       - image: gcr.io/heptio-images/contour:master
         imagePullPolicy: Always

--- a/deployment/render/daemonset-norbac.yaml
+++ b/deployment/render/daemonset-norbac.yaml
@@ -23,12 +23,12 @@ spec:
   selector:
     matchLabels:
       app: contour
+  updateStrategy:
+    type: RollingUpdate
   template:
     metadata:
       labels:
         app: contour
-    updateStrategy:
-      type: RollingUpdate
     spec:
       containers:
       - image: docker.io/envoyproxy/envoy-alpine:latest

--- a/deployment/render/daemonset-rbac.yaml
+++ b/deployment/render/daemonset-rbac.yaml
@@ -37,7 +37,7 @@ spec:
         - containerPort: 8080
           name: http
         command: ["envoy"]
-        args: ["-c", "/config/contour.yaml", "--service-cluster", "cluster0", "--service-node", "node0"]
+        args: ["-c", "/config/contour.yaml", "--service-cluster", "cluster0", "--service-node", "node0", "-l", "info", "--v2-config-only"]
         volumeMounts:
         - name: contour-config
           mountPath: /config

--- a/deployment/render/daemonset-rbac.yaml
+++ b/deployment/render/daemonset-rbac.yaml
@@ -46,6 +46,9 @@ spec:
         name: contour
         command: ["contour"]
         args: ["serve", "--incluster"]
+        volumeMounts:
+        - name: contour-config
+          mountPath: /config
       initContainers:
       - image: gcr.io/heptio-images/contour:master
         imagePullPolicy: Always

--- a/deployment/render/daemonset-rbac.yaml
+++ b/deployment/render/daemonset-rbac.yaml
@@ -23,12 +23,12 @@ spec:
   selector:
     matchLabels:
       app: contour
+  updateStrategy:
+    type: RollingUpdate
   template:
     metadata:
       labels:
         app: contour
-    updateStrategy:
-      type: RollingUpdate
     spec:
       containers:
       - image: docker.io/envoyproxy/envoy-alpine:latest

--- a/deployment/render/deployment-norbac.yaml
+++ b/deployment/render/deployment-norbac.yaml
@@ -38,7 +38,7 @@ spec:
         - containerPort: 8443
           name: https
         command: ["envoy"]
-        args: ["-c", "/config/contour.yaml", "--service-cluster", "cluster0", "--service-node", "node0", "-l", "info"]
+        args: ["-c", "/config/contour.yaml", "--service-cluster", "cluster0", "--service-node", "node0", "-l", "info", "--v2-config-only"]
         volumeMounts:
         - name: contour-config
           mountPath: /config

--- a/deployment/render/deployment-rbac.yaml
+++ b/deployment/render/deployment-rbac.yaml
@@ -38,7 +38,7 @@ spec:
         - containerPort: 8443
           name: https
         command: ["envoy"]
-        args: ["-c", "/config/contour.yaml", "--service-cluster", "cluster0", "--service-node", "node0", "-l", "info"]
+        args: ["-c", "/config/contour.yaml", "--service-cluster", "cluster0", "--service-node", "node0", "-l", "info", "--v2-config-only"]
         volumeMounts:
         - name: contour-config
           mountPath: /config


### PR DESCRIPTION
Fixes: https://github.com/heptio/contour/issues/138

There are two side things I noticed while doing this, both fixed as well
1. `-l info` wasn't always passed, it now is
2. The DaemonSet definitions were broken with k8s 1.8 at least, because the updateStrategy was inside of the template rather than inside `spec` (https://kubernetes.io/docs/tasks/manage-daemon/update-daemon-set/#daemonset-update-strategy)
3. The daemon set config was missing a volume mount on the main contour container (`contour serve --incluster`), added that in. Without it starting on a cluster using ssl certs doesn't work.