### PR TITLE
Add AlpnProtocols to TLS Context so http2 with browsers works

### DIFF
--- a/internal/contour/listener.go
+++ b/internal/contour/listener.go
@@ -258,6 +258,7 @@ func tlscontext(namespace, name string) *v2.DownstreamTlsContext {
 					},
 				},
 			}},
+			AlpnProtocols: []string{"h2", "http/1.1"},
 		},
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/heptio/contour/issues/168

Signed-off-by: Cody Maloney <cody@emeraldcloudlab.com>