### PR TITLE
fix navigation, TLS content

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ This command creates:
 - A Service of `type: LoadBalancer` that points to the Contour instances
 - Depending on your configuration, new cloud resources -- for example, ELBs in AWS
 
+See also [TLS support](docs/tls.md) for details on configuring TLS support. TLS is available in Contour version 0.3 and later.
+
 #### Example workload
 
 If you don't have an application ready to run with Contour, you can explore with [kuard][14].
@@ -99,11 +101,6 @@ See also the Kubernetes documentation for [Services][11] and [Ingress][12].
 The [detailed documentation][3] provides additional information, including an introduction to Envoy and an explanation of how Contour maps key Envoy concepts to Kubernetes.
 
 We've also got [an FAQ][18] for short-answer questions and conceptual stuff that doesn't quite belong in the docs.
-
-## Known limitations
-
-* Contour does not yet support customizations with annotations.
-* Contour does not yet support SSL/TLS.
 
 ## Troubleshooting
 

--- a/docs/tls.md
+++ b/docs/tls.md
@@ -8,15 +8,9 @@ Enabling TLS support requires Contour version 0.3 or later. You must use the [YA
 
 You must also add an [entry for port 443][1] to your `contour` service object.
 
-## Recovering the remote IP address with an ELB
+## Configuring TLS with Contour on an ELB
 
-If you deploy behind an AWS Elastic Load Balancer, make sure that your `contour` Service object is configured with `service.beta.kubernetes.io/aws-load-balancer-backend-protocol: tcp`.
-Otherwise, the ELB will do HTTP termination on your HTTPS port.
-The downside of this configuration is the remote IP of your incoming connections will be the inside address of the ELB.
-
-To recover the remote IP, switch the ELB into PROXY mode:
-1. Add `service.beta.kubernetes.io/aws-load-balancer-proxy-protocol: "*"` to your `contour` service object.
-2. Add the `--use-proxy-protocol` flag to the flags for your `contour` Deployment or Daemonset.
+If you deploy behind an AWS Elastic Load Balancer, see [EC2 ELB PROXY protocol support](proxy-proto.md) for special instructions.
 
 [0]: upgrade.md
 [1]: https://github.com/heptio/contour/blob/master/deployment/deployment-grpc-v2/03-service-tcp.yaml#L18


### PR DESCRIPTION
- removed "Known limitations" section of README
- added navigation
- cleaned up a bit of TLS content (moved details about ELB PROXY protocol out of tls.md, linked to proxy-proto.md. Fixes duplicate content and keeps complexity for single use case in one place. See discussion in #159)

Signed-off-by: JENNIFER RONDEAU <jrondeau@heptio.com>