### PR TITLE
internal/contour: Do not hash ClusterLoadAssignment's ClusterName

### DIFF
--- a/internal/contour/translator.go
+++ b/internal/contour/translator.go
@@ -178,7 +178,7 @@ func (t *Translator) addEndpoints(e *v1.Endpoints) {
 
 		for _, p := range s.Ports {
 			cla := v2.ClusterLoadAssignment{
-				ClusterName: hashname(60, e.ObjectMeta.Namespace, e.ObjectMeta.Name, strconv.Itoa(int(p.Port))),
+				ClusterName: e.ObjectMeta.Namespace + "/" + e.ObjectMeta.Name + "/" + strconv.Itoa(int(p.Port)),
 				Endpoints: []*v2.LocalityLbEndpoints{{
 					Locality: &v2.Locality{
 						Region:  "ap-southeast-2",


### PR DESCRIPTION
Fixes #186 
```
The ClusterLoadAssignment's ClusterName must match the corresponding
Cluster's ServiceName in the EDS config. Given that the ServiceName does
not have a character limit and is not being hashed, we should not hash
the ClusterName field in the ClusterLoadAssignment.

Signed-off-by: Alexander Brand <alexbrand09@gmail.com>
```