### PR TITLE
deployment: optionally expose the Envoy admin inteface on an ClusterIP

### DIFF
--- a/deployment/debug/debug-service.yaml
+++ b/deployment/debug/debug-service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+ name: contour-admin
+ namespace: heptio-contour
+spec:
+ ports:
+ - port: 9001
+   name: admin
+   protocol: TCP
+ selector:
+   app: contour
+ type: ClusterIP

--- a/deployment/deployment-grpc-v2/02-contour.yaml
+++ b/deployment/deployment-grpc-v2/02-contour.yaml
@@ -41,7 +41,7 @@ spec:
         imagePullPolicy: Always
         name: envoy-initconfig
         command: ["contour"]
-        args: ["bootstrap", "/config/contour.yaml"]
+        args: ["bootstrap", "/config/contour.yaml", "--admin-address=0.0.0.0"]
         volumeMounts:
         - name: contour-config
           mountPath: /config

--- a/deployment/ds-grpc-v2/02-contour.yaml
+++ b/deployment/ds-grpc-v2/02-contour.yaml
@@ -40,7 +40,7 @@ spec:
         imagePullPolicy: Always
         name: envoy-initconfig
         command: ["contour"]
-        args: ["bootstrap", "/config/contour.yaml"]
+        args: ["bootstrap", "/config/contour.yaml", "--admin-address=0.0.0.0"]
         volumeMounts:
         - name: contour-config
           mountPath: /config

--- a/deployment/render/daemonset-norbac.yaml
+++ b/deployment/render/daemonset-norbac.yaml
@@ -54,7 +54,7 @@ spec:
         imagePullPolicy: Always
         name: envoy-initconfig
         command: ["contour"]
-        args: ["bootstrap", "/config/contour.yaml"]
+        args: ["bootstrap", "/config/contour.yaml", "--admin-address=0.0.0.0"]
         volumeMounts:
         - name: contour-config
           mountPath: /config

--- a/deployment/render/daemonset-rbac.yaml
+++ b/deployment/render/daemonset-rbac.yaml
@@ -54,7 +54,7 @@ spec:
         imagePullPolicy: Always
         name: envoy-initconfig
         command: ["contour"]
-        args: ["bootstrap", "/config/contour.yaml"]
+        args: ["bootstrap", "/config/contour.yaml", "--admin-address=0.0.0.0"]
         volumeMounts:
         - name: contour-config
           mountPath: /config

--- a/deployment/render/deployment-norbac.yaml
+++ b/deployment/render/deployment-norbac.yaml
@@ -55,7 +55,7 @@ spec:
         imagePullPolicy: Always
         name: envoy-initconfig
         command: ["contour"]
-        args: ["bootstrap", "/config/contour.yaml"]
+        args: ["bootstrap", "/config/contour.yaml", "--admin-address=0.0.0.0"]
         volumeMounts:
         - name: contour-config
           mountPath: /config

--- a/deployment/render/deployment-rbac.yaml
+++ b/deployment/render/deployment-rbac.yaml
@@ -55,7 +55,7 @@ spec:
         imagePullPolicy: Always
         name: envoy-initconfig
         command: ["contour"]
-        args: ["bootstrap", "/config/contour.yaml"]
+        args: ["bootstrap", "/config/contour.yaml", "--admin-address=0.0.0.0"]
         volumeMounts:
         - name: contour-config
           mountPath: /config


### PR DESCRIPTION
This PR addresses the issue of debugging what configuration has been
pushed to Envoy. I (Dave) am at a point where I can look at an ingress
object and I will know how Envoy will react, but this level of spoon
bending is not available to casual users. Users of Contour would
benefit from getting access to the Envoy admin interface so they can see
the resulting route, listerner, and cluster configs.

The previous documentation in the TROUBLESHOOTING document was less than
ideal as it encouraged users to edit the service connected to the
service load balancer, which would result in port 9001 binding to their
public IP.

This revised approach uses two service objects, the latter bound to a
ClusterIP, which offers a little more protection.

Signed-off-by: Dave Cheney <dave@cheney.net>