### PR TITLE
internal/k8s: make buffer.loop respect stop channel

### DIFF
--- a/internal/k8s/buffer.go
+++ b/internal/k8s/buffer.go
@@ -54,16 +54,21 @@ func (b *buffer) loop(stop <-chan struct{}) {
 	log.Infof("started")
 	defer log.Infof("stopped")
 
-	for ev := range b.ev {
-		switch ev := ev.(type) {
-		case *addEvent:
-			b.rh.OnAdd(ev.obj)
-		case *updateEvent:
-			b.rh.OnUpdate(ev.oldObj, ev.newObj)
-		case *deleteEvent:
-			b.rh.OnDelete(ev.obj)
-		default:
-			log.Errorf("unhandled event type: %T: %v", ev, ev)
+	for {
+		select {
+		case ev := <-b.ev:
+			switch ev := ev.(type) {
+			case *addEvent:
+				b.rh.OnAdd(ev.obj)
+			case *updateEvent:
+				b.rh.OnUpdate(ev.oldObj, ev.newObj)
+			case *deleteEvent:
+				b.rh.OnDelete(ev.obj)
+			default:
+				log.Errorf("unhandled event type: %T: %v", ev, ev)
+			}
+		case <-stop:
+			return
 		}
 	}
 }


### PR DESCRIPTION
Spotted during manual testing. buffer.loop was not respecting the stop
channel so would not exit when the group was torn down.

Signed-off-by: Dave Cheney <dave@cheney.net>