### PR TITLE
cmd/contour: add readinessProbe support to contour container

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -35,6 +35,12 @@
   revision = "2efee857e7cfd4f3d0138cc3cbb1b4966962b93a"
 
 [[projects]]
+  branch = "master"
+  name = "github.com/beorn7/perks"
+  packages = ["quantile"]
+  revision = "4c0e84591b9aa9e6dcfdf3e020114cd81f89d5f9"
+
+[[projects]]
   name = "github.com/davecgh/go-spew"
   packages = ["spew"]
   revision = "346938d642f2ec3594ed81d874461961cd0faa76"
@@ -158,6 +164,12 @@
 
 [[projects]]
   branch = "master"
+  name = "github.com/heptiolabs/healthcheck"
+  packages = ["."]
+  revision = "da5fdee475fb09de87c5d4a50da233b7d28767b1"
+
+[[projects]]
+  branch = "master"
   name = "github.com/howeyc/gopass"
   packages = ["."]
   revision = "bf9dde6d0d2c004a008c27aaee91170c786f6db8"
@@ -197,6 +209,12 @@
   revision = "32fa128f234d041f196a9f3e0fea5ac9772c08e1"
 
 [[projects]]
+  name = "github.com/matttproud/golang_protobuf_extensions"
+  packages = ["pbutil"]
+  revision = "3247c84500bff8d9fb6d579d800f20b3e091582c"
+  version = "v1.0.0"
+
+[[projects]]
   branch = "master"
   name = "github.com/petar/GoLLRB"
   packages = ["llrb"]
@@ -207,6 +225,39 @@
   packages = ["."]
   revision = "5f041e8faa004a95c88a202771f4cc3e991971e6"
   version = "v2.0.1"
+
+[[projects]]
+  name = "github.com/prometheus/client_golang"
+  packages = ["prometheus"]
+  revision = "c5b7fccd204277076155f10851dad72b76a49317"
+  version = "v0.8.0"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/prometheus/client_model"
+  packages = ["go"]
+  revision = "99fa1f4be8e564e8a6b613da7fa6f46c9edafc6c"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/prometheus/common"
+  packages = [
+    "expfmt",
+    "internal/bitbucket.org/ww/goautoneg",
+    "model"
+  ]
+  revision = "89604d197083d4781071d3c65855d24ecfb0a563"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/prometheus/procfs"
+  packages = [
+    ".",
+    "internal/util",
+    "nfs",
+    "xfs"
+  ]
+  revision = "cb4147076ac75738c9a7d279075a253c0cc5acbd"
 
 [[projects]]
   name = "github.com/spf13/pflag"
@@ -502,6 +553,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "178653a683ca7a782dfcc5d09cccb58e6b782e33fd3b53ad97cb3bc2f4669166"
+  inputs-digest = "0d51328b2df5e89776ac980590dbcb6c72ab5481b784b47f925a55ef9978f30c"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/deployment/deployment-grpc-v2/02-contour.yaml
+++ b/deployment/deployment-grpc-v2/02-contour.yaml
@@ -36,6 +36,11 @@ spec:
         volumeMounts:
         - name: contour-config
           mountPath: /config
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 8086
+          periodSeconds: 5
       initContainers:
       - image: gcr.io/heptio-images/contour:master
         imagePullPolicy: Always

--- a/deployment/ds-grpc-v2/02-contour.yaml
+++ b/deployment/ds-grpc-v2/02-contour.yaml
@@ -35,6 +35,11 @@ spec:
         volumeMounts:
         - name: contour-config
           mountPath: /config
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 8086
+         periodSeconds: 5
       initContainers:
       - image: gcr.io/heptio-images/contour:master
         imagePullPolicy: Always

--- a/deployment/ds-hostnet/02-contour.yaml
+++ b/deployment/ds-hostnet/02-contour.yaml
@@ -36,6 +36,11 @@ spec:
         name: contour
         command: ["contour"]
         args: ["serve", "--incluster"]
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 8086
+          periodSeconds: 5
       initContainers:
       - image: gcr.io/heptio-images/contour:master
         imagePullPolicy: Always

--- a/deployment/render/daemonset-norbac.yaml
+++ b/deployment/render/daemonset-norbac.yaml
@@ -49,6 +49,11 @@ spec:
         volumeMounts:
         - name: contour-config
           mountPath: /config
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 8086
+         periodSeconds: 5
       initContainers:
       - image: gcr.io/heptio-images/contour:master
         imagePullPolicy: Always

--- a/deployment/render/daemonset-rbac.yaml
+++ b/deployment/render/daemonset-rbac.yaml
@@ -49,6 +49,11 @@ spec:
         volumeMounts:
         - name: contour-config
           mountPath: /config
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 8086
+         periodSeconds: 5
       initContainers:
       - image: gcr.io/heptio-images/contour:master
         imagePullPolicy: Always

--- a/deployment/render/deployment-norbac.yaml
+++ b/deployment/render/deployment-norbac.yaml
@@ -50,6 +50,11 @@ spec:
         volumeMounts:
         - name: contour-config
           mountPath: /config
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 8086
+          periodSeconds: 5
       initContainers:
       - image: gcr.io/heptio-images/contour:master
         imagePullPolicy: Always

--- a/deployment/render/deployment-rbac.yaml
+++ b/deployment/render/deployment-rbac.yaml
@@ -50,6 +50,11 @@ spec:
         volumeMounts:
         - name: contour-config
           mountPath: /config
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 8086
+          periodSeconds: 5
       initContainers:
       - image: gcr.io/heptio-images/contour:master
         imagePullPolicy: Always


### PR DESCRIPTION
Fixes #86
Updates #10

This PR adds healthz support to contour using the heptiolabs/healthcheck library.
The envoy container's heathcheck is not done, yet.

Signed-off-by: Dave Cheney <dave@cheney.net>