### PR TITLE
make check: interrupt build if render.sh fails

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ check: test
 	@echo Checking code is gofmted
 	@bash -c 'if [ -n "$(gofmt -s -l .)" ]; then echo "Go code is not formatted:"; gofmt -s -d -e .; exit 1;fi'
 	@echo Checking rendered files are up to date
-	@(cd deployment && bash render.sh && git diff --exit-code . || echo "rendered files are out of date" || exit 1)
+	@(cd deployment && bash render.sh && git diff --exit-code . || (echo "rendered files are out of date" && exit 1))
 
 install:
 	go install -v -tags "oidc gcp" ./...


### PR DESCRIPTION
This commit ensures that the `deployment/render.sh` test fails and blocks the
build when there were differences in the working tree after rendering.

It seems that the `&&` and `||` operator have the same precedence in Bash. I've
used grouping to avoid the conflict.

This closes #199.

Signed-off-by: Jesús García Crespo <jesus@sevein.com>