### PR TITLE
internal/contour: support named container ports

### DIFF
--- a/internal/contour/clusterloadassignment.go
+++ b/internal/contour/clusterloadassignment.go
@@ -101,3 +101,10 @@ func endpoint(addr string, port int32) *v2.Endpoint {
 		},
 	}
 }
+
+func portname(p v1.EndpointPort) string {
+	if p.Name != "" {
+		return p.Name
+	}
+	return strconv.Itoa(int(p.Port))
+}

--- a/internal/contour/clusterloadassignment_test.go
+++ b/internal/contour/clusterloadassignment_test.go
@@ -1,0 +1,170 @@
+// Copyright © 2018 Heptio
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package contour
+
+import (
+	"reflect"
+	"testing"
+
+	v2 "github.com/envoyproxy/go-control-plane/api"
+	"k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+func TestClusterLoadAssignmentCacheRecomputeClusterLoadAssignment(t *testing.T) {
+	tests := map[string]struct {
+		svc  *v1.Service
+		ep   *v1.Endpoints
+		want []*v2.ClusterLoadAssignment
+	}{
+		"simple": {
+			svc: service("default", "simple", v1.ServicePort{
+				Protocol:   "TCP",
+				Port:       80,
+				TargetPort: intstr.FromInt(8080),
+			}),
+			ep: endpoints("default", "simple", v1.EndpointSubset{
+				Addresses: addresses("192.168.183.24"),
+				Ports:     ports(8080),
+			}),
+			want: []*v2.ClusterLoadAssignment{
+				clusterloadassignment("default/simple/8080", lbendpoint("192.168.183.24", 8080)),
+			},
+		},
+		"multiple addresses": {
+			svc: service("default", "httpbin-org", v1.ServicePort{
+				Protocol:   "TCP",
+				Port:       80,
+				TargetPort: intstr.FromInt(80),
+			}),
+			ep: endpoints("default", "httpbin-org", v1.EndpointSubset{
+				Addresses: addresses(
+					"23.23.247.89",
+					"50.17.192.147",
+					"50.17.206.192",
+					"50.19.99.160",
+				),
+				Ports: ports(80),
+			}),
+			want: []*v2.ClusterLoadAssignment{
+				clusterloadassignment("default/httpbin-org/80",
+					lbendpoint("23.23.247.89", 80),
+					lbendpoint("50.17.192.147", 80),
+					lbendpoint("50.17.206.192", 80),
+					lbendpoint("50.19.99.160", 80),
+				),
+			},
+		},
+		"named container port": {
+			svc: service("default", "secure", v1.ServicePort{
+				Protocol:   "TCP",
+				Port:       443,
+				TargetPort: intstr.FromString("https"),
+			}),
+			ep: endpoints("default", "secure", v1.EndpointSubset{
+				Addresses: addresses("192.168.183.24"),
+				Ports: []v1.EndpointPort{{
+					Name: "https",
+					Port: 8443,
+				}},
+			}),
+			want: []*v2.ClusterLoadAssignment{
+				clusterloadassignment("default/secure/https", lbendpoint("192.168.183.24", 8443)),
+			},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			var cc ClusterLoadAssignmentCache
+			cc.recomputeClusterLoadAssignment(tc.svc, tc.ep)
+			got := cc.Values()
+			if !reflect.DeepEqual(tc.want, got) {
+				t.Fatalf("expected:\n%v\ngot:\n%v", tc.want, got)
+			}
+		})
+	}
+}
+
+/*
+	func TestTranslatorRemoveEndpoints(t *testing.T) {
+		        tests := map[string]struct {
+				                setup func(*Translator)
+						                ep    *v1.Endpoints
+								                want  []*v2.ClusterLoadAssignment
+										        }{
+												                "remove existing": {
+															                        setup: func(tr *Translator) {
+																			                                tr.OnAdd(service("default", "simple", v1.ServicePort{
+																								                                        Protocol:   "TCP",
+																													                                        Port:       80,
+																																		                                        TargetPort: intstr.FromInt(8080),
+																																							                                }))
+																																											                                tr.OnAdd(endpoints("default", "simple", v1.EndpointSubset{
+																																																                                        Addresses: addresses("192.168.183.24"),
+																																																					                                        Ports:     ports(8080),
+																																																										                                }))
+																																																														                        },
+																																																																	                        ep: endpoints("default", "simple", v1.EndpointSubset{
+																																																																					                                Addresses: addresses("192.168.183.24"),
+																																																																									                                Ports:     ports(8080),
+																																																																													                        }),
+																																																																																                        want: []*v2.ClusterLoadAssignment{},
+																																																																																			                },
+																																																																																					                "remove different": {
+																																																																																								                        setup: func(tr *Translator) {
+																																																																																												                                tr.OnAdd(service("default", "simple", v1.ServicePort{
+																																																																																																	                                        Protocol:   "TCP",
+																																																																																																						                                        Port:       80,
+																																																																																																											                                        TargetPort: intstr.FromInt(8080),
+																																																																																																																                                }))
+																																																																																																																				                                tr.OnAdd(endpoints("default", "simple", v1.EndpointSubset{
+																																																																																																																									                                        Addresses: addresses("192.168.183.24"),
+																																																																																																																														                                        Ports:     ports(8080),
+																																																																																																																																			                                }))
+																																																																																																																																							                        },
+																																																																																																																																										                        ep: endpoints("default", "different", v1.EndpointSubset{
+																																																																																																																																														                                Addresses: addresses("192.168.183.24"),
+																																																																																																																																																		                                Ports:     ports(8080),
+																																																																																																																																																						                        }),
+																																																																																																																																																									                        want: []*v2.ClusterLoadAssignment{
+																																																																																																																																																													                                clusterloadassignment("default/simple/8080", lbendpoints(endpoint("192.168.183.24", 8080))),
+																																																																																																																																																																	                        },
+																																																																																																																																																																				                },
+																																																																																																																																																																						                "remove non existant": {
+																																																																																																																																																																									                        setup: func(*Translator) {},
+																																																																																																																																																																												                        ep: endpoints("default", "simple", v1.EndpointSubset{
+																																																																																																																																																																																                                Addresses: addresses("192.168.183.24"),
+																																																																																																																																																																																				                                Ports:     ports(8080),
+																																																																																																																																																																																								                        }),
+																																																																																																																																																																																											                        want: []*v2.ClusterLoadAssignment{},
+																																																																																																																																																																																														                },
+																																																																																																																																																																																																        }
+
+																																																																																																																																																																																																	        for name, tc := range tests {
+																																																																																																																																																																																																			                t.Run(name, func(t *testing.T) {
+																																																																																																																																																																																																						                        const NOFLAGS = 1 << 16
+																																																																																																																																																																																																									                        tr := &Translator{
+																																																																																																																																																																																																													                                Logger: stdlog.New(ioutil.Discard, ioutil.Discard, NOFLAGS),
+																																																																																																																																																																																																																	                        }
+																																																																																																																																																																																																																				                        tc.setup(tr)
+																																																																																																																																																																																																																							                        tr.OnDelete(tc.ep)
+																																																																																																																																																																																																																										                        got := tr.ClusterLoadAssignmentCache.Values()
+																																																																																																																																																																																																																													                        if !reflect.DeepEqual(tc.want, got) {
+																																																																																																																																																																																																																																	                                t.Fatalf("got: %v, want: %v", got, tc.want)
+																																																																																																																																																																																																																																					                        }
+																																																																																																																																																																																																																																								                })
+																																																																																																																																																																																																																																										        }
+																																																																																																																																																																																																																																										}
+*/

--- a/internal/e2e/eds_test.go
+++ b/internal/e2e/eds_test.go
@@ -134,13 +134,14 @@ func clusterloadassignment(name string, lbendpoints ...*v2.LbEndpoint) *v2.Clust
 		},
 	}
 }
-func lbendpoint(addr string, port int32) *v2.LbEndpoint {
+
+func lbendpoint(addr string, port uint32) *v2.LbEndpoint {
 	return &v2.LbEndpoint{
 		Endpoint: endpoint(addr, port),
 	}
 }
 
-func endpoint(addr string, port int32) *v2.Endpoint {
+func endpoint(addr string, port uint32) *v2.Endpoint {
 	return &v2.Endpoint{
 		Address: &v2.Address{
 			Address: &v2.Address_SocketAddress{
@@ -148,10 +149,20 @@ func endpoint(addr string, port int32) *v2.Endpoint {
 					Protocol: v2.SocketAddress_TCP,
 					Address:  addr,
 					PortSpecifier: &v2.SocketAddress_PortValue{
-						PortValue: uint32(port),
+						PortValue: port,
 					},
 				},
 			},
 		},
 	}
+}
+
+func lbendpoints(eps ...*v2.Endpoint) []*v2.LbEndpoint {
+	var lbep []*v2.LbEndpoint
+	for _, ep := range eps {
+		lbep = append(lbep, &v2.LbEndpoint{
+			Endpoint: ep,
+		})
+	}
+	return lbep
 }

--- a/internal/e2e/grpc_test.go
+++ b/internal/e2e/grpc_test.go
@@ -210,6 +210,7 @@ func TestClusterLongServiceName(t *testing.T) {
 	rh, cc, done := setup(t)
 	defer done()
 
+	// add service
 	rh.OnAdd(service(
 		"kuard",
 		"kbujbkuhdod66gjdmwmijz8xzgsx1nkfbrloezdjiulquzk4x3p0nnvpzi8r",


### PR DESCRIPTION
Fixes #175

WIP

Allow services to use a named target port, not just a port number.

In the case that a target port is named, the name will be used for the
name of the cluster. Otherwise, the port number will be used.

Signed-off-by: Dave Cheney <dave@cheney.net>