### PR TITLE
internal/contour: cache service and endpoints

### DIFF
--- a/internal/contour/translator.go
+++ b/internal/contour/translator.go
@@ -223,6 +223,8 @@ func (t *Translator) writeCerts(s *v1.Secret) {
 
 type translatorCache struct {
 	ingresses map[metadata]*v1beta1.Ingress
+	endpoints map[metadata]*v1.Endpoints
+	services  map[metadata]*v1.Service
 
 	// secrets stores tls secrets
 	secrets map[metadata]*v1.Secret
@@ -235,9 +237,15 @@ type translatorCache struct {
 func (t *translatorCache) OnAdd(obj interface{}) {
 	switch obj := obj.(type) {
 	case *v1.Service:
-		// nada
+		if t.services == nil {
+			t.services = make(map[metadata]*v1.Service)
+		}
+		t.services[metadata{name: obj.Name, namespace: obj.Namespace}] = obj
 	case *v1.Endpoints:
-		// nada
+		if t.endpoints == nil {
+			t.endpoints = make(map[metadata]*v1.Endpoints)
+		}
+		t.endpoints[metadata{name: obj.Name, namespace: obj.Namespace}] = obj
 	case *v1beta1.Ingress:
 		if t.ingresses == nil {
 			t.ingresses = make(map[metadata]*v1beta1.Ingress)
@@ -287,9 +295,9 @@ func (t *translatorCache) OnUpdate(oldObj, newObj interface{}) {
 func (t *translatorCache) OnDelete(obj interface{}) {
 	switch obj := obj.(type) {
 	case *v1.Service:
-		// nada
+		delete(t.services, metadata{name: obj.Name, namespace: obj.Namespace})
 	case *v1.Endpoints:
-		// nada
+		delete(t.endpoints, metadata{name: obj.Name, namespace: obj.Namespace})
 	case *v1beta1.Ingress:
 		md := metadata{name: obj.Name, namespace: obj.Namespace}
 		delete(t.ingresses, md)


### PR DESCRIPTION
Updates #175

Store service and endpoint documents. In the next PR we will need both
service and endpoint to recompute both SDS and EDS.

Signed-off-by: Dave Cheney <dave@cheney.net>