### PR TITLE
Consuming the new APIs provided by go-control-plane

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -52,8 +52,19 @@
 [[projects]]
   branch = "master"
   name = "github.com/envoyproxy/go-control-plane"
-  packages = ["api"]
-  revision = "cd217031c55a80342a864f9aff3b7a7f22205891"
+  packages = [
+    "envoy/api/v2",
+    "envoy/api/v2/auth",
+    "envoy/api/v2/cluster",
+    "envoy/api/v2/core",
+    "envoy/api/v2/endpoint",
+    "envoy/api/v2/listener",
+    "envoy/api/v2/route",
+    "envoy/config/filter/accesslog/v2",
+    "envoy/config/filter/network/http_connection_manager/v2",
+    "envoy/service/load_stats/v2"
+  ]
+  revision = "2fe005477d70adc579351a5a9c26408c4a54ef51"
 
 [[projects]]
   name = "github.com/ghodss/yaml"
@@ -89,6 +100,7 @@
   name = "github.com/gogo/protobuf"
   packages = [
     "gogoproto",
+    "jsonpb",
     "proto",
     "protoc-gen-gogo/descriptor",
     "sortkeys",
@@ -502,6 +514,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "178653a683ca7a782dfcc5d09cccb58e6b782e33fd3b53ad97cb3bc2f4669166"
+  inputs-digest = "0af7ca6e6588d044f73c38ca56f177c2e69e3a0918faac8a309c9a7cc5fff3aa"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/cmd/contourcli/cli.go
+++ b/cmd/contourcli/cli.go
@@ -22,7 +22,7 @@ import (
 
 	"google.golang.org/grpc"
 
-	v2 "github.com/envoyproxy/go-control-plane/api"
+	"github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	"github.com/gogo/protobuf/proto"
 )
 

--- a/internal/contour/cache.go
+++ b/internal/contour/cache.go
@@ -17,7 +17,8 @@ import (
 	"sort"
 	"sync"
 
-	v2 "github.com/envoyproxy/go-control-plane/api"
+	"github.com/envoyproxy/go-control-plane/envoy/api/v2"
+	envoy_api_v2_route "github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
 )
 
 // clusterCache is a thread safe, atomic, copy on write cache of *v2.Cluster objects.
@@ -235,23 +236,23 @@ func (l listenersByName) Len() int           { return len(l) }
 func (l listenersByName) Swap(i, j int)      { l[i], l[j] = l[j], l[i] }
 func (l listenersByName) Less(i, j int) bool { return l[i].Name < l[j].Name }
 
-// VirtualHostCache is a thread safe, atomic, copy on write cache of v2.VirtualHost objects.
+// VirtualHostCache is a thread safe, atomic, copy on write cache of envoy_api_v2_route.VirtualHost objects.
 type virtualHostCache struct {
 	sync.Mutex
-	values []*v2.VirtualHost
+	values []envoy_api_v2_route.VirtualHost
 }
 
 // Values returns a copy of the contents of the cache.
-func (vc *virtualHostCache) Values() []*v2.VirtualHost {
+func (vc *virtualHostCache) Values() []envoy_api_v2_route.VirtualHost {
 	vc.Lock()
-	r := append([]*v2.VirtualHost{}, vc.values...)
+	r := append([]envoy_api_v2_route.VirtualHost{}, vc.values...)
 	vc.Unlock()
 	return r
 }
 
 // Add adds an entry to the cache. If a VirtualHost with the same
 // name exists, it is replaced.
-func (vc *virtualHostCache) Add(virtualhosts ...*v2.VirtualHost) {
+func (vc *virtualHostCache) Add(virtualhosts ...envoy_api_v2_route.VirtualHost) {
 	if len(virtualhosts) == 0 {
 		return
 	}
@@ -265,7 +266,7 @@ func (vc *virtualHostCache) Add(virtualhosts ...*v2.VirtualHost) {
 
 // add adds v to the cache. If v is already present, the cached value of v is overwritten.
 // invariant: vc.values should be sorted on entry.
-func (vc *virtualHostCache) add(v *v2.VirtualHost) {
+func (vc *virtualHostCache) add(v envoy_api_v2_route.VirtualHost) {
 	i := sort.Search(len(vc.values), func(i int) bool { return vc.values[i].Name >= v.Name })
 	if i < len(vc.values) && vc.values[i].Name == v.Name {
 		// c is already present, replace
@@ -301,7 +302,7 @@ func (vc *virtualHostCache) remove(name string) {
 	}
 }
 
-type virtualHostsByName []*v2.VirtualHost
+type virtualHostsByName []envoy_api_v2_route.VirtualHost
 
 func (v virtualHostsByName) Len() int           { return len(v) }
 func (v virtualHostsByName) Swap(i, j int)      { v[i], v[j] = v[j], v[i] }

--- a/internal/contour/cache_test.go
+++ b/internal/contour/cache_test.go
@@ -17,7 +17,8 @@ import (
 	"reflect"
 	"testing"
 
-	v2 "github.com/envoyproxy/go-control-plane/api"
+	"github.com/envoyproxy/go-control-plane/envoy/api/v2"
+	envoy_api_v2_route "github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
 )
 
 func TestClusterCacheValuesReturnsACopyOfItsInternalSlice(t *testing.T) {
@@ -350,7 +351,7 @@ func TestListenerCacheRemove(t *testing.T) {
 
 func TestVirtualHostCacheValuesReturnsACopyOfItsInternalSlice(t *testing.T) {
 	var cc virtualHostCache
-	c := &v2.VirtualHost{
+	c := envoy_api_v2_route.VirtualHost{
 		Name: "alpha",
 	}
 	cc.Add(c)
@@ -361,38 +362,22 @@ func TestVirtualHostCacheValuesReturnsACopyOfItsInternalSlice(t *testing.T) {
 	if &v1[0] == &v2[0] {
 		// the address of the 0th element of the values slice should not be the same
 		// if it is, then we don't have a copy.
-		t.Fatalf("VirtualHostCache, consecutive calls to Values return the same backing slice: got: %p, want: %p", &v1[0], &v2[0])
-	}
-}
-
-func TestVirtualHostCacheValuesReturnsTheSameContents(t *testing.T) {
-	var cc virtualHostCache
-	c := &v2.VirtualHost{
-		Name: "alpha",
-	}
-	cc.Add(c)
-
-	v1 := cc.Values()
-	v2 := cc.Values()
-
-	if v1[0] != v2[0] {
-		// the value of the 0th element, a pointer to a v2.VirtualHost should be the same
-		t.Fatalf("VirtualHostCache, consecutive calls to Values returned different slice contents: got: %p, want: %p", v1[0], v2[0])
+		t.Fatalf("VirtualHostCache, consecutive calls to Values return the same backing slice: got: %p, want: %p", v1[0], v2[0])
 	}
 }
 
 func TestVirtualHostCacheAddInsertsTwoElementsInSortOrder(t *testing.T) {
 	var cc virtualHostCache
-	c1 := &v2.VirtualHost{
+	c1 := envoy_api_v2_route.VirtualHost{
 		Name: "beta",
 	}
 	cc.Add(c1)
-	c2 := &v2.VirtualHost{
+	c2 := envoy_api_v2_route.VirtualHost{
 		Name: "alpha",
 	}
 	cc.Add(c2)
 	got := cc.Values()
-	want := []*v2.VirtualHost{{
+	want := []envoy_api_v2_route.VirtualHost{{
 		Name: "alpha",
 	}, {
 		Name: "beta",
@@ -404,14 +389,14 @@ func TestVirtualHostCacheAddInsertsTwoElementsInSortOrder(t *testing.T) {
 
 func TestVirtualHostCacheAddOverwritesElementsWithTheSameName(t *testing.T) {
 	var cc virtualHostCache
-	c1 := &v2.VirtualHost{
+	c1 := envoy_api_v2_route.VirtualHost{
 		Name: "alpha",
 		Domains: []string{
 			"example.com",
 		},
 	}
 	cc.Add(c1)
-	c2 := &v2.VirtualHost{
+	c2 := envoy_api_v2_route.VirtualHost{
 		Name: "alpha",
 		Domains: []string{
 			"heptio.com",
@@ -419,7 +404,7 @@ func TestVirtualHostCacheAddOverwritesElementsWithTheSameName(t *testing.T) {
 	}
 	cc.Add(c2)
 	got := cc.Values()
-	want := []*v2.VirtualHost{
+	want := []envoy_api_v2_route.VirtualHost{
 		c2,
 	}
 	if !reflect.DeepEqual(got, want) {
@@ -429,13 +414,13 @@ func TestVirtualHostCacheAddOverwritesElementsWithTheSameName(t *testing.T) {
 
 func TestVirtualHostCacheAddIsCopyOnWrite(t *testing.T) {
 	var cc virtualHostCache
-	c1 := &v2.VirtualHost{
+	c1 := envoy_api_v2_route.VirtualHost{
 		Name: "alpha",
 	}
 	cc.Add(c1)
 	v1 := cc.Values()
 
-	c2 := &v2.VirtualHost{
+	c2 := envoy_api_v2_route.VirtualHost{
 		Name: "beta",
 	}
 	cc.Add(c2)
@@ -448,13 +433,13 @@ func TestVirtualHostCacheAddIsCopyOnWrite(t *testing.T) {
 
 func TestVirtualHostCacheRemove(t *testing.T) {
 	var cc virtualHostCache
-	c1 := &v2.VirtualHost{
+	c1 := envoy_api_v2_route.VirtualHost{
 		Name: "alpha",
 	}
 	cc.Add(c1)
 	cc.Remove("alpha")
 	got := cc.Values()
-	want := []*v2.VirtualHost{}
+	want := []envoy_api_v2_route.VirtualHost{}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("VirtualHostCache.Remove: got: %v, want: %v", got, want)
 	}

--- a/internal/contour/cluster.go
+++ b/internal/contour/cluster.go
@@ -17,7 +17,7 @@ import (
 	"strconv"
 	"time"
 
-	v2 "github.com/envoyproxy/go-control-plane/api"
+	"github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	"k8s.io/api/core/v1"
 )
 

--- a/internal/contour/cluster_test.go
+++ b/internal/contour/cluster_test.go
@@ -21,7 +21,7 @@ import (
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
-	v2 "github.com/envoyproxy/go-control-plane/api"
+	"github.com/envoyproxy/go-control-plane/envoy/api/v2"
 )
 
 func TestClusterCacheRecomputeService(t *testing.T) {

--- a/internal/contour/clusterloadassignment_test.go
+++ b/internal/contour/clusterloadassignment_test.go
@@ -17,7 +17,7 @@ import (
 	"reflect"
 	"testing"
 
-	v2 "github.com/envoyproxy/go-control-plane/api"
+	"github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	"k8s.io/api/core/v1"
 )
 

--- a/internal/contour/listener_test.go
+++ b/internal/contour/listener_test.go
@@ -22,7 +22,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
-	v2 "github.com/envoyproxy/go-control-plane/api"
+	"github.com/envoyproxy/go-control-plane/envoy/api/v2"
+	envoy_api_v2_listener "github.com/envoyproxy/go-control-plane/envoy/api/v2/listener"
 	"github.com/gogo/protobuf/types"
 )
 
@@ -135,14 +136,14 @@ func TestRecomputeListener(t *testing.T) {
 
 func TestRecomputeTLSListener(t *testing.T) {
 	ingresss_http := listener(ENVOY_HTTPS_LISTENER, "0.0.0.0", 8443)
-	ingresss_http.FilterChains = []*v2.FilterChain{{
-		Filters: []*v2.Filter{
+	ingresss_http.FilterChains = []envoy_api_v2_listener.FilterChain{{
+		Filters: []envoy_api_v2_listener.Filter{
 			httpfilter(ENVOY_HTTPS_LISTENER),
 		},
 	}}
 	ingress_http2 := listener(ENVOY_HTTPS_LISTENER, "::", 9000) // issue 72
-	ingress_http2.FilterChains = []*v2.FilterChain{{
-		Filters: []*v2.Filter{
+	ingress_http2.FilterChains = []envoy_api_v2_listener.FilterChain{{
+		Filters: []envoy_api_v2_listener.Filter{
 			httpfilter(ENVOY_HTTPS_LISTENER),
 		},
 	}}
@@ -225,14 +226,14 @@ func TestRecomputeTLSListener(t *testing.T) {
 			add: []*v2.Listener{{
 				Name:    ENVOY_HTTPS_LISTENER,
 				Address: socketaddress("0.0.0.0", 8443),
-				FilterChains: []*v2.FilterChain{{
-					FilterChainMatch: &v2.FilterChainMatch{
+				FilterChains: []envoy_api_v2_listener.FilterChain{{
+					FilterChainMatch: &envoy_api_v2_listener.FilterChainMatch{
 						SniDomains: []string{"whatever.example.com"},
 					},
 					TlsContext: tlscontext(&v1.Secret{
 						Data: secretdata("certificate", "key"),
 					}, "h2", "http/1.1"),
-					Filters: []*v2.Filter{
+					Filters: []envoy_api_v2_listener.Filter{
 						httpfilter(ENVOY_HTTPS_LISTENER),
 					},
 				}},
@@ -302,14 +303,14 @@ func TestRecomputeTLSListener(t *testing.T) {
 			add: []*v2.Listener{{
 				Name:    ENVOY_HTTPS_LISTENER,
 				Address: socketaddress("::", 9000),
-				FilterChains: []*v2.FilterChain{{
-					FilterChainMatch: &v2.FilterChainMatch{
+				FilterChains: []envoy_api_v2_listener.FilterChain{{
+					FilterChainMatch: &envoy_api_v2_listener.FilterChainMatch{
 						SniDomains: []string{"whatever.example.com"},
 					},
 					TlsContext: tlscontext(&v1.Secret{
 						Data: secretdata("certificate", "key"),
 					}, "h2", "http/1.1"),
-					Filters: []*v2.Filter{
+					Filters: []envoy_api_v2_listener.Filter{
 						httpfilter(ENVOY_HTTPS_LISTENER),
 					},
 				}},
@@ -350,14 +351,14 @@ func TestRecomputeTLSListener(t *testing.T) {
 			add: []*v2.Listener{{
 				Name:    ENVOY_HTTPS_LISTENER,
 				Address: socketaddress("0.0.0.0", 8443),
-				FilterChains: []*v2.FilterChain{{
-					FilterChainMatch: &v2.FilterChainMatch{
+				FilterChains: []envoy_api_v2_listener.FilterChain{{
+					FilterChainMatch: &envoy_api_v2_listener.FilterChainMatch{
 						SniDomains: []string{"whatever.example.com"},
 					},
 					TlsContext: tlscontext(&v1.Secret{
 						Data: secretdata("certificate", "key"),
 					}, "h2", "http/1.1"),
-					Filters: []*v2.Filter{
+					Filters: []envoy_api_v2_listener.Filter{
 						httpfilter(ENVOY_HTTPS_LISTENER),
 					},
 					UseProxyProto: &types.BoolValue{Value: true},

--- a/internal/contour/translator.go
+++ b/internal/contour/translator.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 	"strings"
 
-	v2 "github.com/envoyproxy/go-control-plane/api"
+	envoy_api_v2_core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 
 	"github.com/heptio/contour/internal/log"
 	"k8s.io/api/core/v1"
@@ -359,11 +359,11 @@ func min(a, b int) int {
 	return a
 }
 
-func apiconfigsource(clusters ...string) *v2.ConfigSource {
-	return &v2.ConfigSource{
-		ConfigSourceSpecifier: &v2.ConfigSource_ApiConfigSource{
-			ApiConfigSource: &v2.ApiConfigSource{
-				ApiType:      v2.ApiConfigSource_GRPC,
+func apiconfigsource(clusters ...string) *envoy_api_v2_core.ConfigSource {
+	return &envoy_api_v2_core.ConfigSource{
+		ConfigSourceSpecifier: &envoy_api_v2_core.ConfigSource_ApiConfigSource{
+			ApiConfigSource: &envoy_api_v2_core.ApiConfigSource{
+				ApiType:      envoy_api_v2_core.ApiConfigSource_GRPC,
 				ClusterNames: clusters,
 			},
 		},

--- a/internal/contour/translator_test.go
+++ b/internal/contour/translator_test.go
@@ -19,7 +19,8 @@ import (
 	"testing"
 	"time"
 
-	v2 "github.com/envoyproxy/go-control-plane/api"
+	"github.com/envoyproxy/go-control-plane/envoy/api/v2"
+	envoy_api_v2_route "github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
 	"github.com/heptio/contour/internal/log/stdlog"
 	"k8s.io/api/core/v1"
 	"k8s.io/api/extensions/v1beta1"
@@ -459,8 +460,8 @@ func TestTranslatorAddIngress(t *testing.T) {
 		name          string
 		setup         func(*Translator)
 		ing           *v1beta1.Ingress
-		ingress_http  []*v2.VirtualHost
-		ingress_https []*v2.VirtualHost
+		ingress_http  []envoy_api_v2_route.VirtualHost
+		ingress_https []envoy_api_v2_route.VirtualHost
 	}{{
 		name: "default backend",
 		ing: &v1beta1.Ingress{
@@ -472,15 +473,15 @@ func TestTranslatorAddIngress(t *testing.T) {
 				Backend: backend("backend", intstr.FromInt(80)),
 			},
 		},
-		ingress_http: []*v2.VirtualHost{{
+		ingress_http: []envoy_api_v2_route.VirtualHost{{
 			Name:    "*",
 			Domains: []string{"*"},
-			Routes: []*v2.Route{{
+			Routes: []envoy_api_v2_route.Route{{
 				Match:  prefixmatch("/"),
 				Action: clusteraction("default/backend/80"),
 			}},
 		}},
-		ingress_https: []*v2.VirtualHost{},
+		ingress_https: []envoy_api_v2_route.VirtualHost{},
 	}, {
 		name: "incorrect ingress class",
 		ing: &v1beta1.Ingress{
@@ -495,8 +496,8 @@ func TestTranslatorAddIngress(t *testing.T) {
 				Backend: backend("backend", intstr.FromInt(80)),
 			},
 		},
-		ingress_http:  []*v2.VirtualHost{}, // expected to be empty, the ingress class is ingnored
-		ingress_https: []*v2.VirtualHost{}, // expected to be empty, the ingress class is ingnored
+		ingress_http:  []envoy_api_v2_route.VirtualHost{}, // expected to be empty, the ingress class is ingnored
+		ingress_https: []envoy_api_v2_route.VirtualHost{}, // expected to be empty, the ingress class is ingnored
 	}, {
 		name: "explicit ingress class",
 		ing: &v1beta1.Ingress{
@@ -511,15 +512,15 @@ func TestTranslatorAddIngress(t *testing.T) {
 				Backend: backend("backend", intstr.FromInt(80)),
 			},
 		},
-		ingress_http: []*v2.VirtualHost{{
+		ingress_http: []envoy_api_v2_route.VirtualHost{{
 			Name:    "*",
 			Domains: []string{"*"},
-			Routes: []*v2.Route{{
+			Routes: []envoy_api_v2_route.Route{{
 				Match:  prefixmatch("/"), // match all
 				Action: clusteraction("default/backend/80"),
 			}},
 		}},
-		ingress_https: []*v2.VirtualHost{},
+		ingress_https: []envoy_api_v2_route.VirtualHost{},
 	}, {
 		name: "name based vhost",
 		ing: &v1beta1.Ingress{
@@ -534,15 +535,15 @@ func TestTranslatorAddIngress(t *testing.T) {
 				}},
 			},
 		},
-		ingress_http: []*v2.VirtualHost{{
+		ingress_http: []envoy_api_v2_route.VirtualHost{{
 			Name:    "httpbin.org",
 			Domains: []string{"httpbin.org"},
-			Routes: []*v2.Route{{
+			Routes: []envoy_api_v2_route.Route{{
 				Match:  prefixmatch("/"), // match all
 				Action: clusteraction("default/httpbin-org/80"),
 			}},
 		}},
-		ingress_https: []*v2.VirtualHost{},
+		ingress_https: []envoy_api_v2_route.VirtualHost{},
 	}, {
 		name: "regex vhost without match characters",
 		ing: &v1beta1.Ingress{
@@ -564,15 +565,15 @@ func TestTranslatorAddIngress(t *testing.T) {
 				}},
 			},
 		},
-		ingress_http: []*v2.VirtualHost{{
+		ingress_http: []envoy_api_v2_route.VirtualHost{{
 			Name:    "httpbin.org",
 			Domains: []string{"httpbin.org"},
-			Routes: []*v2.Route{{
+			Routes: []envoy_api_v2_route.Route{{
 				Match:  prefixmatch("/ip"), // if the field does not contact any regex characters, we treat it as a prefix
 				Action: clusteraction("default/httpbin-org/80"),
 			}},
 		}},
-		ingress_https: []*v2.VirtualHost{},
+		ingress_https: []envoy_api_v2_route.VirtualHost{},
 	}, {
 		name: "regex vhost with match characters",
 		ing: &v1beta1.Ingress{
@@ -594,15 +595,15 @@ func TestTranslatorAddIngress(t *testing.T) {
 				}},
 			},
 		},
-		ingress_http: []*v2.VirtualHost{{
+		ingress_http: []envoy_api_v2_route.VirtualHost{{
 			Name:    "httpbin.org",
 			Domains: []string{"httpbin.org"},
-			Routes: []*v2.Route{{
+			Routes: []envoy_api_v2_route.Route{{
 				Match:  regexmatch("/get.*"),
 				Action: clusteraction("default/httpbin-org/80"),
 			}},
 		}},
-		ingress_https: []*v2.VirtualHost{},
+		ingress_https: []envoy_api_v2_route.VirtualHost{},
 	}, {
 		name: "named service port",
 		ing: &v1beta1.Ingress{
@@ -617,15 +618,15 @@ func TestTranslatorAddIngress(t *testing.T) {
 				}},
 			},
 		},
-		ingress_http: []*v2.VirtualHost{{
+		ingress_http: []envoy_api_v2_route.VirtualHost{{
 			Name:    "httpbin.org",
 			Domains: []string{"httpbin.org"},
-			Routes: []*v2.Route{{
+			Routes: []envoy_api_v2_route.Route{{
 				Match:  prefixmatch("/"),
 				Action: clusteraction("default/httpbin-org/http"),
 			}},
 		}},
-		ingress_https: []*v2.VirtualHost{},
+		ingress_https: []envoy_api_v2_route.VirtualHost{},
 	}, {
 		name: "multiple routes",
 		ing: &v1beta1.Ingress{
@@ -650,10 +651,10 @@ func TestTranslatorAddIngress(t *testing.T) {
 				}},
 			},
 		},
-		ingress_http: []*v2.VirtualHost{{
+		ingress_http: []envoy_api_v2_route.VirtualHost{{
 			Name:    "httpbin.org",
 			Domains: []string{"httpbin.org"},
-			Routes: []*v2.Route{{
+			Routes: []envoy_api_v2_route.Route{{
 				Match:  prefixmatch("/peter"),
 				Action: clusteraction("default/peter/80"),
 			}, {
@@ -661,7 +662,7 @@ func TestTranslatorAddIngress(t *testing.T) {
 				Action: clusteraction("default/paul/paul"),
 			}},
 		}},
-		ingress_https: []*v2.VirtualHost{},
+		ingress_https: []envoy_api_v2_route.VirtualHost{},
 	}, {
 		name: "multiple rules, tls admin",
 		ing: &v1beta1.Ingress{
@@ -683,25 +684,25 @@ func TestTranslatorAddIngress(t *testing.T) {
 				}},
 			},
 		},
-		ingress_http: []*v2.VirtualHost{{
+		ingress_http: []envoy_api_v2_route.VirtualHost{{
 			Name:    "admin.httpbin.org",
 			Domains: []string{"admin.httpbin.org"},
-			Routes: []*v2.Route{{
+			Routes: []envoy_api_v2_route.Route{{
 				Match:  prefixmatch("/"),
 				Action: clusteraction("default/paul/paul"),
 			}},
 		}, {
 			Name:    "httpbin.org",
 			Domains: []string{"httpbin.org"},
-			Routes: []*v2.Route{{
+			Routes: []envoy_api_v2_route.Route{{
 				Match:  prefixmatch("/"),
 				Action: clusteraction("default/peter/80"),
 			}},
 		}},
-		ingress_https: []*v2.VirtualHost{{
+		ingress_https: []envoy_api_v2_route.VirtualHost{{
 			Name:    "admin.httpbin.org",
 			Domains: []string{"admin.httpbin.org"},
-			Routes: []*v2.Route{{
+			Routes: []envoy_api_v2_route.Route{{
 				Match:  prefixmatch("/"),
 				Action: clusteraction("default/paul/paul"),
 			}},
@@ -730,11 +731,11 @@ func TestTranslatorAddIngress(t *testing.T) {
 				}},
 			},
 		},
-		ingress_http: []*v2.VirtualHost{}, //  allow-http: false disables the http route entirely.
-		ingress_https: []*v2.VirtualHost{{
+		ingress_http: []envoy_api_v2_route.VirtualHost{}, //  allow-http: false disables the http route entirely.
+		ingress_https: []envoy_api_v2_route.VirtualHost{{
 			Name:    "admin.httpbin.org",
 			Domains: []string{"admin.httpbin.org"},
-			Routes: []*v2.Route{{
+			Routes: []envoy_api_v2_route.Route{{
 				Match:  prefixmatch("/"),
 				Action: clusteraction("default/paul/paul"),
 			}},
@@ -753,15 +754,15 @@ func TestTranslatorAddIngress(t *testing.T) {
 				}},
 			},
 		},
-		ingress_http: []*v2.VirtualHost{{
+		ingress_http: []envoy_api_v2_route.VirtualHost{{
 			Name:    "d31bb322ca62bb395acad00b3cbf45a3aa1010ca28dca7cddb4f7db786fa",
 			Domains: []string{"my-very-very-long-service-host-name.subdomain.boring-dept.my.company"},
-			Routes: []*v2.Route{{
+			Routes: []envoy_api_v2_route.Route{{
 				Match:  prefixmatch("/"),
 				Action: clusteraction("default/my-service-name/80"),
 			}},
 		}},
-		ingress_https: []*v2.VirtualHost{},
+		ingress_https: []envoy_api_v2_route.VirtualHost{},
 	}, {
 		name: "second ingress object extends an existing vhost",
 		setup: func(tr *Translator) {
@@ -804,10 +805,10 @@ func TestTranslatorAddIngress(t *testing.T) {
 				}},
 			},
 		},
-		ingress_http: []*v2.VirtualHost{{
+		ingress_http: []envoy_api_v2_route.VirtualHost{{
 			Name:    "httpbin.org",
 			Domains: []string{"httpbin.org"},
-			Routes: []*v2.Route{{
+			Routes: []envoy_api_v2_route.Route{{
 				Match:  prefixmatch("/admin"),
 				Action: clusteraction("kube-system/admin/admin"),
 			}, {
@@ -815,7 +816,7 @@ func TestTranslatorAddIngress(t *testing.T) {
 				Action: clusteraction("default/default/80"),
 			}},
 		}},
-		ingress_https: []*v2.VirtualHost{},
+		ingress_https: []envoy_api_v2_route.VirtualHost{},
 	}, {
 		// kube-lego uses a single vhost in its own namespace to insert its
 		// callback route for let's encrypt support.
@@ -889,10 +890,10 @@ func TestTranslatorAddIngress(t *testing.T) {
 				}},
 			},
 		},
-		ingress_http: []*v2.VirtualHost{{
+		ingress_http: []envoy_api_v2_route.VirtualHost{{
 			Name:    "httpbin.davecheney.com",
 			Domains: []string{"httpbin.davecheney.com"},
-			Routes: []*v2.Route{{
+			Routes: []envoy_api_v2_route.Route{{
 				Match:  prefixmatch("/.well-known/acme-challenge"),
 				Action: clusteraction("kube-lego/kube-lego-nginx/8080"),
 			}, {
@@ -902,7 +903,7 @@ func TestTranslatorAddIngress(t *testing.T) {
 		}, {
 			Name:    "httpbin2.davecheney.com",
 			Domains: []string{"httpbin2.davecheney.com"},
-			Routes: []*v2.Route{{
+			Routes: []envoy_api_v2_route.Route{{
 				Match:  prefixmatch("/.well-known/acme-challenge"),
 				Action: clusteraction("kube-lego/kube-lego-nginx/8080"),
 			}, {
@@ -910,7 +911,7 @@ func TestTranslatorAddIngress(t *testing.T) {
 				Action: clusteraction("default/httpbin/80"),
 			}},
 		}},
-		ingress_https: []*v2.VirtualHost{},
+		ingress_https: []envoy_api_v2_route.VirtualHost{},
 	}, {
 		name: "IngressRuleValue without host should become the default vhost", // heptio/contour#101
 		ing: &v1beta1.Ingress{
@@ -934,15 +935,15 @@ func TestTranslatorAddIngress(t *testing.T) {
 				}},
 			},
 		},
-		ingress_http: []*v2.VirtualHost{{
+		ingress_http: []envoy_api_v2_route.VirtualHost{{
 			Name:    "*",
 			Domains: []string{"*"},
-			Routes: []*v2.Route{{
+			Routes: []envoy_api_v2_route.Route{{
 				Match:  prefixmatch("/hello"),
 				Action: clusteraction("default/hello/80"),
 			}},
 		}},
-		ingress_https: []*v2.VirtualHost{},
+		ingress_https: []envoy_api_v2_route.VirtualHost{},
 	}}
 
 	for _, tc := range tests {
@@ -972,8 +973,8 @@ func TestTranslatorRemoveIngress(t *testing.T) {
 	tests := map[string]struct {
 		setup         func(*Translator)
 		ing           *v1beta1.Ingress
-		ingress_http  []*v2.VirtualHost
-		ingress_https []*v2.VirtualHost
+		ingress_http  []envoy_api_v2_route.VirtualHost
+		ingress_https []envoy_api_v2_route.VirtualHost
 	}{
 		"remove existing": {
 			setup: func(tr *Translator) {
@@ -1002,8 +1003,8 @@ func TestTranslatorRemoveIngress(t *testing.T) {
 					}},
 				},
 			},
-			ingress_http:  []*v2.VirtualHost{},
-			ingress_https: []*v2.VirtualHost{},
+			ingress_http:  []envoy_api_v2_route.VirtualHost{},
+			ingress_https: []envoy_api_v2_route.VirtualHost{},
 		},
 		"remove different": {
 			setup: func(tr *Translator) {
@@ -1032,15 +1033,15 @@ func TestTranslatorRemoveIngress(t *testing.T) {
 					}},
 				},
 			},
-			ingress_http: []*v2.VirtualHost{{
+			ingress_http: []envoy_api_v2_route.VirtualHost{{
 				Name:    "httpbin.org",
 				Domains: []string{"httpbin.org"},
-				Routes: []*v2.Route{{
+				Routes: []envoy_api_v2_route.Route{{
 					Match:  prefixmatch("/"),
 					Action: clusteraction("default/peter/80"),
 				}},
 			}},
-			ingress_https: []*v2.VirtualHost{},
+			ingress_https: []envoy_api_v2_route.VirtualHost{},
 		},
 		"remove non existant": {
 			setup: func(*Translator) {},
@@ -1053,8 +1054,8 @@ func TestTranslatorRemoveIngress(t *testing.T) {
 					Backend: backend("backend", intstr.FromInt(80)),
 				},
 			},
-			ingress_http:  []*v2.VirtualHost{},
-			ingress_https: []*v2.VirtualHost{},
+			ingress_http:  []envoy_api_v2_route.VirtualHost{},
+			ingress_https: []envoy_api_v2_route.VirtualHost{},
 		},
 	}
 	for name, tc := range tests {

--- a/internal/contour/virtualhost_test.go
+++ b/internal/contour/virtualhost_test.go
@@ -18,7 +18,7 @@ import (
 	"reflect"
 	"testing"
 
-	v2 "github.com/envoyproxy/go-control-plane/api"
+	envoy_api_v2_route "github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
 	"github.com/heptio/contour/internal/log/stdlog"
 	"k8s.io/api/extensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -36,8 +36,8 @@ func TestVirtualHostCacheRecomputevhost(t *testing.T) {
 	tests := map[string]struct {
 		vhost         string
 		ingresses     map[metadata]*v1beta1.Ingress
-		ingress_http  []*v2.VirtualHost
-		ingress_https []*v2.VirtualHost
+		ingress_http  []envoy_api_v2_route.VirtualHost
+		ingress_https []envoy_api_v2_route.VirtualHost
 	}{
 		"default backend": {
 			vhost: "*",
@@ -50,15 +50,15 @@ func TestVirtualHostCacheRecomputevhost(t *testing.T) {
 					Backend: backend("backend", intstr.FromInt(80)),
 				},
 			}}),
-			ingress_http: []*v2.VirtualHost{{
+			ingress_http: []envoy_api_v2_route.VirtualHost{{
 				Name:    "*",
 				Domains: []string{"*"},
-				Routes: []*v2.Route{{
+				Routes: []envoy_api_v2_route.Route{{
 					Match:  prefixmatch("/"),
 					Action: clusteraction("default/backend/80"),
 				}},
 			}},
-			ingress_https: []*v2.VirtualHost{},
+			ingress_https: []envoy_api_v2_route.VirtualHost{},
 		},
 		"name based vhost": {
 			vhost: "httpbin.org",
@@ -74,15 +74,15 @@ func TestVirtualHostCacheRecomputevhost(t *testing.T) {
 					}},
 				},
 			}}),
-			ingress_http: []*v2.VirtualHost{{
+			ingress_http: []envoy_api_v2_route.VirtualHost{{
 				Name:    "httpbin.org",
 				Domains: []string{"httpbin.org"},
-				Routes: []*v2.Route{{
+				Routes: []envoy_api_v2_route.Route{{
 					Match:  prefixmatch("/"), // match all
 					Action: clusteraction("default/httpbin-org/80"),
 				}},
 			}},
-			ingress_https: []*v2.VirtualHost{},
+			ingress_https: []envoy_api_v2_route.VirtualHost{},
 		},
 		"tls": {
 			vhost: "httpbin.org",
@@ -102,18 +102,18 @@ func TestVirtualHostCacheRecomputevhost(t *testing.T) {
 					}},
 				},
 			}}),
-			ingress_http: []*v2.VirtualHost{{
+			ingress_http: []envoy_api_v2_route.VirtualHost{{
 				Name:    "httpbin.org",
 				Domains: []string{"httpbin.org"},
-				Routes: []*v2.Route{{
+				Routes: []envoy_api_v2_route.Route{{
 					Match:  prefixmatch("/"), // match all
 					Action: clusteraction("default/httpbin-org/80"),
 				}},
 			}},
-			ingress_https: []*v2.VirtualHost{{
+			ingress_https: []envoy_api_v2_route.VirtualHost{{
 				Name:    "httpbin.org",
 				Domains: []string{"httpbin.org"},
-				Routes: []*v2.Route{{
+				Routes: []envoy_api_v2_route.Route{{
 					Match:  prefixmatch("/"), // match all
 					Action: clusteraction("default/httpbin-org/80"),
 				}},
@@ -140,11 +140,11 @@ func TestVirtualHostCacheRecomputevhost(t *testing.T) {
 					}},
 				},
 			}}),
-			ingress_http: []*v2.VirtualHost{}, // kubernetes.io/ingress.allow-http: "false" prevents ingress_http
-			ingress_https: []*v2.VirtualHost{{
+			ingress_http: []envoy_api_v2_route.VirtualHost{}, // kubernetes.io/ingress.allow-http: "false" prevents ingress_http
+			ingress_https: []envoy_api_v2_route.VirtualHost{{
 				Name:    "httpbin.org",
 				Domains: []string{"httpbin.org"},
-				Routes: []*v2.Route{{
+				Routes: []envoy_api_v2_route.Route{{
 					Match:  prefixmatch("/"), // match all
 					Action: clusteraction("default/httpbin-org/80"),
 				}},
@@ -171,19 +171,19 @@ func TestVirtualHostCacheRecomputevhost(t *testing.T) {
 					}},
 				},
 			}}),
-			ingress_http: []*v2.VirtualHost{{
+			ingress_http: []envoy_api_v2_route.VirtualHost{{
 				Name:    "httpbin.org",
 				Domains: []string{"httpbin.org"},
-				Routes: []*v2.Route{{
+				Routes: []envoy_api_v2_route.Route{{
 					Match:  prefixmatch("/"), // match all
 					Action: clusteraction("default/httpbin-org/80"),
 				}},
-				RequireTls: v2.VirtualHost_ALL,
+				RequireTls: envoy_api_v2_route.VirtualHost_ALL,
 			}},
-			ingress_https: []*v2.VirtualHost{{
+			ingress_https: []envoy_api_v2_route.VirtualHost{{
 				Name:    "httpbin.org",
 				Domains: []string{"httpbin.org"},
-				Routes: []*v2.Route{{
+				Routes: []envoy_api_v2_route.Route{{
 					Match:  prefixmatch("/"), // match all
 					Action: clusteraction("default/httpbin-org/80"),
 				}},
@@ -210,15 +210,15 @@ func TestVirtualHostCacheRecomputevhost(t *testing.T) {
 					}},
 				},
 			}}),
-			ingress_http: []*v2.VirtualHost{{
+			ingress_http: []envoy_api_v2_route.VirtualHost{{
 				Name:    "httpbin.org",
 				Domains: []string{"httpbin.org"},
-				Routes: []*v2.Route{{
+				Routes: []envoy_api_v2_route.Route{{
 					Match:  prefixmatch("/ip"), // if the field does not contact any regex characters, we treat it as a prefix
 					Action: clusteraction("default/httpbin-org/80"),
 				}},
 			}},
-			ingress_https: []*v2.VirtualHost{},
+			ingress_https: []envoy_api_v2_route.VirtualHost{},
 		},
 		"regex vhost with match characters": {
 			vhost: "httpbin.org",
@@ -241,15 +241,15 @@ func TestVirtualHostCacheRecomputevhost(t *testing.T) {
 					}},
 				},
 			}}),
-			ingress_http: []*v2.VirtualHost{{
+			ingress_http: []envoy_api_v2_route.VirtualHost{{
 				Name:    "httpbin.org",
 				Domains: []string{"httpbin.org"},
-				Routes: []*v2.Route{{
+				Routes: []envoy_api_v2_route.Route{{
 					Match:  regexmatch("/get.*"),
 					Action: clusteraction("default/httpbin-org/80"),
 				}},
 			}},
-			ingress_https: []*v2.VirtualHost{},
+			ingress_https: []envoy_api_v2_route.VirtualHost{},
 		},
 		"named service port": {
 			vhost: "httpbin.org",
@@ -265,15 +265,15 @@ func TestVirtualHostCacheRecomputevhost(t *testing.T) {
 					}},
 				},
 			}}),
-			ingress_http: []*v2.VirtualHost{{
+			ingress_http: []envoy_api_v2_route.VirtualHost{{
 				Name:    "httpbin.org",
 				Domains: []string{"httpbin.org"},
-				Routes: []*v2.Route{{
+				Routes: []envoy_api_v2_route.Route{{
 					Match:  prefixmatch("/"),
 					Action: clusteraction("default/httpbin-org/http"),
 				}},
 			}},
-			ingress_https: []*v2.VirtualHost{},
+			ingress_https: []envoy_api_v2_route.VirtualHost{},
 		},
 		"multiple routes": {
 			vhost: "httpbin.org",
@@ -299,10 +299,10 @@ func TestVirtualHostCacheRecomputevhost(t *testing.T) {
 					}},
 				},
 			}}),
-			ingress_http: []*v2.VirtualHost{{
+			ingress_http: []envoy_api_v2_route.VirtualHost{{
 				Name:    "httpbin.org",
 				Domains: []string{"httpbin.org"},
-				Routes: []*v2.Route{{
+				Routes: []envoy_api_v2_route.Route{{
 					Match:  prefixmatch("/peter"),
 					Action: clusteraction("default/peter/80"),
 				}, {
@@ -310,7 +310,7 @@ func TestVirtualHostCacheRecomputevhost(t *testing.T) {
 					Action: clusteraction("default/paul/paul"),
 				}},
 			}},
-			ingress_https: []*v2.VirtualHost{},
+			ingress_https: []envoy_api_v2_route.VirtualHost{},
 		},
 		"multiple rules (httpbin.org)": {
 			vhost: "httpbin.org",
@@ -329,15 +329,15 @@ func TestVirtualHostCacheRecomputevhost(t *testing.T) {
 					}},
 				},
 			}}),
-			ingress_http: []*v2.VirtualHost{{
+			ingress_http: []envoy_api_v2_route.VirtualHost{{
 				Name:    "httpbin.org",
 				Domains: []string{"httpbin.org"},
-				Routes: []*v2.Route{{
+				Routes: []envoy_api_v2_route.Route{{
 					Match:  prefixmatch("/"),
 					Action: clusteraction("default/peter/80"),
 				}},
 			}},
-			ingress_https: []*v2.VirtualHost{},
+			ingress_https: []envoy_api_v2_route.VirtualHost{},
 		},
 		"multiple rules (admin.httpbin.org)": {
 			vhost: "admin.httpbin.org",
@@ -356,15 +356,15 @@ func TestVirtualHostCacheRecomputevhost(t *testing.T) {
 					}},
 				},
 			}}),
-			ingress_http: []*v2.VirtualHost{{
+			ingress_http: []envoy_api_v2_route.VirtualHost{{
 				Name:    "admin.httpbin.org",
 				Domains: []string{"admin.httpbin.org"},
-				Routes: []*v2.Route{{
+				Routes: []envoy_api_v2_route.Route{{
 					Match:  prefixmatch("/"),
 					Action: clusteraction("default/paul/paul"),
 				}},
 			}},
-			ingress_https: []*v2.VirtualHost{},
+			ingress_https: []envoy_api_v2_route.VirtualHost{},
 		},
 		"vhost name exceeds 60 chars": { // heptio/contour#25
 			vhost: "my-very-very-long-service-host-name.subdomain.boring-dept.my.company",
@@ -380,15 +380,15 @@ func TestVirtualHostCacheRecomputevhost(t *testing.T) {
 					}},
 				},
 			}}),
-			ingress_http: []*v2.VirtualHost{{
+			ingress_http: []envoy_api_v2_route.VirtualHost{{
 				Name:    "d31bb322ca62bb395acad00b3cbf45a3aa1010ca28dca7cddb4f7db786fa",
 				Domains: []string{"my-very-very-long-service-host-name.subdomain.boring-dept.my.company"},
-				Routes: []*v2.Route{{
+				Routes: []envoy_api_v2_route.Route{{
 					Match:  prefixmatch("/"),
 					Action: clusteraction("default/my-service-name/80"),
 				}},
 			}},
-			ingress_https: []*v2.VirtualHost{},
+			ingress_https: []envoy_api_v2_route.VirtualHost{},
 		},
 		"second ingress object extends an existing vhost": {
 			vhost: "httpbin.org",
@@ -429,10 +429,10 @@ func TestVirtualHostCacheRecomputevhost(t *testing.T) {
 					}},
 				},
 			}}),
-			ingress_http: []*v2.VirtualHost{{
+			ingress_http: []envoy_api_v2_route.VirtualHost{{
 				Name:    "httpbin.org",
 				Domains: []string{"httpbin.org"},
-				Routes: []*v2.Route{{
+				Routes: []envoy_api_v2_route.Route{{
 					Match:  prefixmatch("/admin"),
 					Action: clusteraction("kube-system/admin/admin"),
 				}, {
@@ -440,7 +440,7 @@ func TestVirtualHostCacheRecomputevhost(t *testing.T) {
 					Action: clusteraction("default/default/80"),
 				}},
 			}},
-			ingress_https: []*v2.VirtualHost{},
+			ingress_https: []envoy_api_v2_route.VirtualHost{},
 		},
 		// kube-lego uses a single vhost in its own namespace to insert its
 		// callback route for let's encrypt support.
@@ -493,10 +493,10 @@ func TestVirtualHostCacheRecomputevhost(t *testing.T) {
 					}},
 				},
 			}}),
-			ingress_http: []*v2.VirtualHost{{
+			ingress_http: []envoy_api_v2_route.VirtualHost{{
 				Name:    "httpbin.davecheney.com",
 				Domains: []string{"httpbin.davecheney.com"},
-				Routes: []*v2.Route{{
+				Routes: []envoy_api_v2_route.Route{{
 					Match:  prefixmatch("/.well-known/acme-challenge"),
 					Action: clusteraction("kube-lego/kube-lego-nginx/8080"),
 				}, {
@@ -504,7 +504,7 @@ func TestVirtualHostCacheRecomputevhost(t *testing.T) {
 					Action: clusteraction("default/httpbin/80"),
 				}},
 			}},
-			ingress_https: []*v2.VirtualHost{},
+			ingress_https: []envoy_api_v2_route.VirtualHost{},
 		},
 		"IngressRuleValue without host should become the default vhost": { // heptio/contour#101
 			vhost: "*",
@@ -529,15 +529,15 @@ func TestVirtualHostCacheRecomputevhost(t *testing.T) {
 					}},
 				},
 			}}),
-			ingress_http: []*v2.VirtualHost{{
+			ingress_http: []envoy_api_v2_route.VirtualHost{{
 				Name:    "*",
 				Domains: []string{"*"},
-				Routes: []*v2.Route{{
+				Routes: []envoy_api_v2_route.Route{{
 					Match:  prefixmatch("/hello"),
 					Action: clusteraction("default/hello/80"),
 				}},
 			}},
-			ingress_https: []*v2.VirtualHost{},
+			ingress_https: []envoy_api_v2_route.VirtualHost{},
 		},
 	}
 
@@ -561,9 +561,9 @@ func TestVirtualHostCacheRecomputevhost(t *testing.T) {
 	}
 }
 
-func strip(v []*v2.VirtualHost) (r []v2.VirtualHost) {
+func strip(v []envoy_api_v2_route.VirtualHost) (r []envoy_api_v2_route.VirtualHost) {
 	for _, v := range v {
-		r = append(r, *v)
+		r = append(r, v)
 	}
 	return
 }

--- a/internal/e2e/cds_test.go
+++ b/internal/e2e/cds_test.go
@@ -18,7 +18,8 @@ import (
 	"testing"
 	"time"
 
-	v2 "github.com/envoyproxy/go-control-plane/api"
+	"github.com/envoyproxy/go-control-plane/envoy/api/v2"
+	envoy_api_v2_core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 	"github.com/gogo/protobuf/types"
 	cgrpc "github.com/heptio/contour/internal/grpc"
 	"google.golang.org/grpc"
@@ -45,7 +46,7 @@ func TestClusterLongServiceName(t *testing.T) {
 	// check that it's been translated correctly.
 	assertEqual(t, &v2.DiscoveryResponse{
 		VersionInfo: "0",
-		Resources: []*types.Any{
+		Resources: []types.Any{
 			any(t, &v2.Cluster{
 				Name: "kuard/kbujbkuhdod66-edfcfc/8080",
 				Type: v2.Cluster_EDS,
@@ -78,7 +79,7 @@ func TestClusterAddUpdateDelete(t *testing.T) {
 
 	assertEqual(t, &v2.DiscoveryResponse{
 		VersionInfo: "0",
-		Resources: []*types.Any{
+		Resources: []types.Any{
 			any(t, &v2.Cluster{
 				Name: "default/kuard/80",
 				Type: v2.Cluster_EDS,
@@ -108,7 +109,7 @@ func TestClusterAddUpdateDelete(t *testing.T) {
 	// check that we get two CDS records because the port is now named.
 	assertEqual(t, &v2.DiscoveryResponse{
 		VersionInfo: "0",
-		Resources: []*types.Any{
+		Resources: []types.Any{
 			any(t, &v2.Cluster{
 				Name: "default/kuard/80",
 				Type: v2.Cluster_EDS,
@@ -158,7 +159,7 @@ func TestClusterAddUpdateDelete(t *testing.T) {
 	// because the CDS cache is sorted.
 	assertEqual(t, &v2.DiscoveryResponse{
 		VersionInfo: "0",
-		Resources: []*types.Any{
+		Resources: []types.Any{
 			any(t, &v2.Cluster{
 				Name: "default/kuard/443",
 				Type: v2.Cluster_EDS,
@@ -221,7 +222,7 @@ func TestClusterAddUpdateDelete(t *testing.T) {
 	// records have been removed even though the service object remains.
 	assertEqual(t, &v2.DiscoveryResponse{
 		VersionInfo: "0",
-		Resources: []*types.Any{
+		Resources: []types.Any{
 			any(t, &v2.Cluster{
 				Name: "default/kuard/443",
 				Type: v2.Cluster_EDS,
@@ -271,7 +272,7 @@ func TestClusterRenameUpdateDelete(t *testing.T) {
 	rh.OnAdd(s1)
 	assertEqual(t, &v2.DiscoveryResponse{
 		VersionInfo: "0",
-		Resources: []*types.Any{
+		Resources: []types.Any{
 			any(t, &v2.Cluster{
 				Name: "default/kuard/443",
 				Type: v2.Cluster_EDS,
@@ -329,7 +330,7 @@ func TestClusterRenameUpdateDelete(t *testing.T) {
 	rh.OnUpdate(s1, s2)
 	assertEqual(t, &v2.DiscoveryResponse{
 		VersionInfo: "0",
-		Resources: []*types.Any{
+		Resources: []types.Any{
 			any(t, &v2.Cluster{
 				Name: "default/kuard/443",
 				Type: v2.Cluster_EDS,
@@ -349,7 +350,7 @@ func TestClusterRenameUpdateDelete(t *testing.T) {
 	rh.OnUpdate(s2, s1)
 	assertEqual(t, &v2.DiscoveryResponse{
 		VersionInfo: "0",
-		Resources: []*types.Any{
+		Resources: []types.Any{
 			any(t, &v2.Cluster{
 				Name: "default/kuard/443",
 				Type: v2.Cluster_EDS,
@@ -399,7 +400,7 @@ func TestClusterRenameUpdateDelete(t *testing.T) {
 	rh.OnDelete(s1)
 	assertEqual(t, &v2.DiscoveryResponse{
 		VersionInfo: "0",
-		Resources:   []*types.Any{},
+		Resources:   []types.Any{},
 		TypeUrl:     cgrpc.ClusterType,
 		Nonce:       "0",
 	}, fetchCDS(t, cc))
@@ -418,11 +419,11 @@ func fetchCDS(t *testing.T, cc *grpc.ClientConn) *v2.DiscoveryResponse {
 	return resp
 }
 
-func apiconfigsource(clusters ...string) *v2.ConfigSource {
-	return &v2.ConfigSource{
-		ConfigSourceSpecifier: &v2.ConfigSource_ApiConfigSource{
-			ApiConfigSource: &v2.ApiConfigSource{
-				ApiType:      v2.ApiConfigSource_GRPC,
+func apiconfigsource(clusters ...string) *envoy_api_v2_core.ConfigSource {
+	return &envoy_api_v2_core.ConfigSource{
+		ConfigSourceSpecifier: &envoy_api_v2_core.ConfigSource_ApiConfigSource{
+			ApiConfigSource: &envoy_api_v2_core.ApiConfigSource{
+				ApiType:      envoy_api_v2_core.ApiConfigSource_GRPC,
 				ClusterNames: clusters,
 			},
 		},

--- a/internal/e2e/e2e_test.go
+++ b/internal/e2e/e2e_test.go
@@ -17,18 +17,18 @@ package e2e
 import (
 	"testing"
 
-	v2 "github.com/envoyproxy/go-control-plane/api"
+	"github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	"github.com/gogo/protobuf/proto"
 	"github.com/gogo/protobuf/types"
 )
 
-func any(t *testing.T, pb proto.Message) *types.Any {
+func any(t *testing.T, pb proto.Message) types.Any {
 	t.Helper()
 	any, err := types.MarshalAny(pb)
 	if err != nil {
 		t.Fatal(err)
 	}
-	return any
+	return *any
 }
 
 func assertEqual(t *testing.T, want, got *v2.DiscoveryResponse) {

--- a/internal/e2e/rds_test.go
+++ b/internal/e2e/rds_test.go
@@ -19,7 +19,8 @@ import (
 	"testing"
 	"time"
 
-	v2 "github.com/envoyproxy/go-control-plane/api"
+	"github.com/envoyproxy/go-control-plane/envoy/api/v2"
+	envoy_api_v2_route "github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
 	"github.com/gogo/protobuf/types"
 	cgrpc "github.com/heptio/contour/internal/grpc"
 	"google.golang.org/grpc"
@@ -77,13 +78,13 @@ func TestEditIngress(t *testing.T) {
 	// check that it's been translated correctly.
 	assertEqual(t, &v2.DiscoveryResponse{
 		VersionInfo: "0",
-		Resources: []*types.Any{
+		Resources: []types.Any{
 			any(t, &v2.RouteConfiguration{
 				Name: "ingress_http",
-				VirtualHosts: []*v2.VirtualHost{{
+				VirtualHosts: []envoy_api_v2_route.VirtualHost{{
 					Name:    "*",
 					Domains: []string{"*"},
-					Routes: []*v2.Route{
+					Routes: []envoy_api_v2_route.Route{
 						route(prefixmatch("/"), cluster("default/kuard/80")),
 					},
 				}},
@@ -119,13 +120,13 @@ func TestEditIngress(t *testing.T) {
 	// check that ingress_http has been updated.
 	assertEqual(t, &v2.DiscoveryResponse{
 		VersionInfo: "0",
-		Resources: []*types.Any{
+		Resources: []types.Any{
 			any(t, &v2.RouteConfiguration{
 				Name: "ingress_http",
-				VirtualHosts: []*v2.VirtualHost{{
+				VirtualHosts: []envoy_api_v2_route.VirtualHost{{
 					Name:    "*",
 					Domains: []string{"*"},
-					Routes: []*v2.Route{
+					Routes: []envoy_api_v2_route.Route{
 						route(prefixmatch("/testing"), cluster("default/kuard/80")),
 					},
 				}},
@@ -181,13 +182,13 @@ func TestIngressPathRouteWithoutHost(t *testing.T) {
 	// check that it's been translated correctly.
 	assertEqual(t, &v2.DiscoveryResponse{
 		VersionInfo: "0",
-		Resources: []*types.Any{
+		Resources: []types.Any{
 			any(t, &v2.RouteConfiguration{
 				Name: "ingress_http",
-				VirtualHosts: []*v2.VirtualHost{{
+				VirtualHosts: []envoy_api_v2_route.VirtualHost{{
 					Name:    "*",
 					Domains: []string{"*"},
-					Routes: []*v2.Route{
+					Routes: []envoy_api_v2_route.Route{
 						route(prefixmatch("/hello"), cluster("default/hello/80")),
 					},
 				}},
@@ -228,13 +229,13 @@ func TestEditIngressInPlace(t *testing.T) {
 	rh.OnAdd(i1)
 	assertEqual(t, &v2.DiscoveryResponse{
 		VersionInfo: "0",
-		Resources: []*types.Any{
+		Resources: []types.Any{
 			any(t, &v2.RouteConfiguration{
 				Name: "ingress_http",
-				VirtualHosts: []*v2.VirtualHost{{
+				VirtualHosts: []envoy_api_v2_route.VirtualHost{{
 					Name:    "hello.example.com",
 					Domains: []string{"hello.example.com"},
-					Routes: []*v2.Route{
+					Routes: []envoy_api_v2_route.Route{
 						route(prefixmatch("/"), cluster("default/wowie/80")),
 					},
 				}},
@@ -276,13 +277,13 @@ func TestEditIngressInPlace(t *testing.T) {
 	rh.OnUpdate(i1, i2)
 	assertEqual(t, &v2.DiscoveryResponse{
 		VersionInfo: "0",
-		Resources: []*types.Any{
+		Resources: []types.Any{
 			any(t, &v2.RouteConfiguration{
 				Name: "ingress_http",
-				VirtualHosts: []*v2.VirtualHost{{
+				VirtualHosts: []envoy_api_v2_route.VirtualHost{{
 					Name:    "hello.example.com",
 					Domains: []string{"hello.example.com"},
-					Routes: []*v2.Route{
+					Routes: []envoy_api_v2_route.Route{
 						route(prefixmatch("/whoop"), cluster("default/kerpow/9000")),
 						route(prefixmatch("/"), cluster("default/wowie/80")),
 					},
@@ -330,17 +331,17 @@ func TestEditIngressInPlace(t *testing.T) {
 	rh.OnUpdate(i2, i3)
 	assertEqual(t, &v2.DiscoveryResponse{
 		VersionInfo: "0",
-		Resources: []*types.Any{
+		Resources: []types.Any{
 			any(t, &v2.RouteConfiguration{
 				Name: "ingress_http",
-				VirtualHosts: []*v2.VirtualHost{{
+				VirtualHosts: []envoy_api_v2_route.VirtualHost{{
 					Name:    "hello.example.com",
 					Domains: []string{"hello.example.com"},
-					Routes: []*v2.Route{
+					Routes: []envoy_api_v2_route.Route{
 						route(prefixmatch("/whoop"), cluster("default/kerpow/9000")),
 						route(prefixmatch("/"), cluster("default/wowie/80")),
 					},
-					RequireTls: v2.VirtualHost_ALL,
+					RequireTls: envoy_api_v2_route.VirtualHost_ALL,
 				}}}),
 			any(t, &v2.RouteConfiguration{Name: "ingress_https"}),
 		},
@@ -387,24 +388,24 @@ func TestEditIngressInPlace(t *testing.T) {
 	rh.OnUpdate(i3, i4)
 	assertEqual(t, &v2.DiscoveryResponse{
 		VersionInfo: "0",
-		Resources: []*types.Any{
+		Resources: []types.Any{
 			any(t, &v2.RouteConfiguration{
 				Name: "ingress_http",
-				VirtualHosts: []*v2.VirtualHost{{
+				VirtualHosts: []envoy_api_v2_route.VirtualHost{{
 					Name:    "hello.example.com",
 					Domains: []string{"hello.example.com"},
-					Routes: []*v2.Route{
+					Routes: []envoy_api_v2_route.Route{
 						route(prefixmatch("/whoop"), cluster("default/kerpow/9000")),
 						route(prefixmatch("/"), cluster("default/wowie/80")),
 					},
-					RequireTls: v2.VirtualHost_ALL,
+					RequireTls: envoy_api_v2_route.VirtualHost_ALL,
 				}}}),
 			any(t, &v2.RouteConfiguration{
 				Name: "ingress_https",
-				VirtualHosts: []*v2.VirtualHost{{
+				VirtualHosts: []envoy_api_v2_route.VirtualHost{{
 					Name:    "hello.example.com",
 					Domains: []string{"hello.example.com"},
-					Routes: []*v2.Route{
+					Routes: []envoy_api_v2_route.Route{
 						route(prefixmatch("/whoop"), cluster("default/kerpow/9000")),
 						route(prefixmatch("/"), cluster("default/wowie/80")),
 					},
@@ -429,25 +430,25 @@ func fetchRDS(t *testing.T, cc *grpc.ClientConn) *v2.DiscoveryResponse {
 	return resp
 }
 
-func route(match *v2.RouteMatch, action *v2.Route_Route) *v2.Route {
-	return &v2.Route{
-		Match:  match,
+func route(match *envoy_api_v2_route.RouteMatch, action *envoy_api_v2_route.Route_Route) envoy_api_v2_route.Route {
+	return envoy_api_v2_route.Route{
+		Match:  *match,
 		Action: action,
 	}
 }
 
-func prefixmatch(prefix string) *v2.RouteMatch {
-	return &v2.RouteMatch{
-		PathSpecifier: &v2.RouteMatch_Prefix{
+func prefixmatch(prefix string) *envoy_api_v2_route.RouteMatch {
+	return &envoy_api_v2_route.RouteMatch{
+		PathSpecifier: &envoy_api_v2_route.RouteMatch_Prefix{
 			Prefix: prefix,
 		},
 	}
 }
 
-func cluster(cluster string) *v2.Route_Route {
-	return &v2.Route_Route{
-		Route: &v2.RouteAction{
-			ClusterSpecifier: &v2.RouteAction_Cluster{
+func cluster(cluster string) *envoy_api_v2_route.Route_Route {
+	return &envoy_api_v2_route.Route_Route{
+		Route: &envoy_api_v2_route.RouteAction{
+			ClusterSpecifier: &envoy_api_v2_route.RouteAction_Cluster{
 				Cluster: cluster,
 			},
 		},

--- a/internal/grpc/grpc_test.go
+++ b/internal/grpc/grpc_test.go
@@ -21,7 +21,7 @@ import (
 	"testing"
 	"time"
 
-	v2 "github.com/envoyproxy/go-control-plane/api"
+	"github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	"github.com/heptio/contour/internal/contour"
 	"github.com/heptio/contour/internal/log/stdlog"
 	"google.golang.org/grpc"


### PR DESCRIPTION
- Consumes the changes in envoyproxy/go-control-plane#39.
- Changed Gopkg.lock to pick the latest go-control-plane.
- Changed code as per the changes in the structures
  defined in go-control-plane.
- Updated the unit tests.

Fixes issue #225 

Signed-off-by: Amarnath V. A. <vaamarnath@gmail.com>

PS: Being a new to open source contribution, please bear with the mistakes in the PR.