### PR TITLE
internal/e2e: add listener e2e test skeleton

### DIFF
--- a/internal/contour/listener.go
+++ b/internal/contour/listener.go
@@ -272,13 +272,12 @@ func httpfilter(routename string) *v2.Filter {
 		Name: httpFilter,
 		Config: &types.Struct{
 			Fields: map[string]*types.Value{
-				"codec_type":  sv("auto"),
 				"stat_prefix": sv(routename),
 				"rds": st(map[string]*types.Value{
 					"route_config_name": sv(routename),
 					"config_source": st(map[string]*types.Value{
 						"api_config_source": st(map[string]*types.Value{
-							"api_type": sv("grpc"),
+							"api_type": sv("GRPC"),
 							"cluster_names": lv(
 								sv("xds_cluster"),
 							),
@@ -297,13 +296,15 @@ func httpfilter(routename string) *v2.Filter {
 						"name": sv(router),
 					}),
 				),
-				"access_log": st(map[string]*types.Value{
-					"name": sv(accessLog),
-					"config": st(map[string]*types.Value{
-						"path": sv("/dev/stdout"),
-					}),
-				}),
 				"use_remote_address": bv(true), // TODO(jbeda) should this ever be false?
+				"access_log": lv(
+					st(map[string]*types.Value{
+						"name": sv(accessLog),
+						"config": st(map[string]*types.Value{
+							"path": sv("/dev/stdout"),
+						}),
+					}),
+				),
 			},
 		},
 	}

--- a/internal/e2e/grpc_test.go
+++ b/internal/e2e/grpc_test.go
@@ -15,9 +15,7 @@
 package e2e
 
 import (
-	"bytes"
 	"context"
-	"fmt"
 	"testing"
 	"time"
 
@@ -302,26 +300,16 @@ func any(t *testing.T, pb proto.Message) *types.Any {
 
 func assertEqual(t *testing.T, want, got *v2.DiscoveryResponse) {
 	t.Helper()
-	if !proto.Equal(want, got) {
+	m := proto.TextMarshaler{Compact: true, ExpandAny: true}
+	a := m.Text(want)
+	b := m.Text(got)
+	if a != b {
 		m := proto.TextMarshaler{
 			Compact:   false,
 			ExpandAny: true,
 		}
-		t.Fatalf("expected:\n%v\ngot:\n%v\n", m.Text(want), m.Text(got))
+		t.Fatalf("\nexpected:\n%v\ngot:\n%v", m.Text(want), m.Text(got))
 	}
-}
-
-func dumpany(any []*types.Any) string {
-	var buf bytes.Buffer
-	for _, a := range any {
-		pb := new(v2.RouteConfiguration)
-		if err := types.UnmarshalAny(a, pb); err != nil {
-			fmt.Fprintln(&buf, err)
-		} else {
-			fmt.Fprintln(&buf, pb)
-		}
-	}
-	return buf.String()
 }
 
 func service(ns, name string, ports ...v1.ServicePort) *v1.Service {

--- a/internal/e2e/lds_test.go
+++ b/internal/e2e/lds_test.go
@@ -1,0 +1,179 @@
+// Copyright © 2018 Heptio
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package e2e
+
+import (
+	"bytes"
+	"context"
+	"testing"
+	"time"
+
+	v2 "github.com/envoyproxy/go-control-plane/api"
+	"github.com/envoyproxy/go-control-plane/api/filter/accesslog"
+	"github.com/envoyproxy/go-control-plane/api/filter/network"
+	"github.com/gogo/protobuf/jsonpb"
+	"github.com/gogo/protobuf/proto"
+	"github.com/gogo/protobuf/types"
+	cgrpc "github.com/heptio/contour/internal/grpc"
+	"google.golang.org/grpc"
+	"k8s.io/api/extensions/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+func TestNonTLSListener(t *testing.T) {
+	rh, cc, done := setup(t)
+	defer done()
+
+	// assert that without any ingress objects registered
+	// there are no active listeners
+	assertEqual(t, &v2.DiscoveryResponse{
+		VersionInfo: "0",
+		Resources:   []*types.Any{},
+		TypeUrl:     cgrpc.ListenerType,
+		Nonce:       "0",
+	}, fetchLDS(t, cc))
+
+	// i1 is a simple ingress, no hostname, no tls.
+	i1 := &v1beta1.Ingress{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "simple",
+			Namespace: "default",
+		},
+		Spec: v1beta1.IngressSpec{
+			Backend: backend("backend", intstr.FromInt(80)),
+		},
+	}
+
+	// add it and assert that we now have a ingress_http listener
+	rh.OnAdd(i1)
+	assertEqual(t, &v2.DiscoveryResponse{
+		VersionInfo: "0",
+		Resources: []*types.Any{
+			any(t, listener("ingress_http", "0.0.0.0", 8080,
+				filterchain(false, httpfilter("ingress_http")),
+			)),
+		},
+		TypeUrl: cgrpc.ListenerType,
+		Nonce:   "0",
+	}, fetchLDS(t, cc))
+}
+
+func fetchLDS(t *testing.T, cc *grpc.ClientConn) *v2.DiscoveryResponse {
+	t.Helper()
+	rds := v2.NewListenerDiscoveryServiceClient(cc)
+	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(ctx, 100*time.Millisecond)
+	defer cancel()
+	resp, err := rds.FetchListeners(ctx, new(v2.DiscoveryRequest))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return resp
+}
+
+func backend(name string, port intstr.IntOrString) *v1beta1.IngressBackend {
+	return &v1beta1.IngressBackend{
+		ServiceName: name,
+		ServicePort: port,
+	}
+}
+
+func listener(name, address string, port uint32, filterchains ...*v2.FilterChain) *v2.Listener {
+	return &v2.Listener{
+		Name:         name,
+		Address:      socketaddress(address, port),
+		FilterChains: filterchains,
+	}
+}
+
+func socketaddress(address string, port uint32) *v2.Address {
+	return &v2.Address{
+		Address: &v2.Address_SocketAddress{
+			SocketAddress: &v2.SocketAddress{
+				Protocol: v2.SocketAddress_TCP,
+				Address:  address,
+				PortSpecifier: &v2.SocketAddress_PortValue{
+					PortValue: port,
+				},
+			},
+		},
+	}
+}
+
+func filterchain(useproxy bool, filters ...*v2.Filter) *v2.FilterChain {
+	fc := v2.FilterChain{
+		Filters: filters,
+	}
+	if useproxy {
+		fc.UseProxyProto = &types.BoolValue{Value: true}
+	}
+	return &fc
+}
+
+func httpfilter(routename string) *v2.Filter {
+	return &v2.Filter{
+		Name: "envoy.http_connection_manager",
+		Config: messageToStruct(&network.HttpConnectionManager{
+			StatPrefix: routename,
+			RouteSpecifier: &network.HttpConnectionManager_Rds{
+				Rds: &network.Rds{
+					ConfigSource: v2.ConfigSource{
+						ConfigSourceSpecifier: &v2.ConfigSource_ApiConfigSource{
+							ApiConfigSource: &v2.ApiConfigSource{
+								ApiType:      v2.ApiConfigSource_GRPC,
+								ClusterNames: []string{"xds_cluster"},
+								GrpcServices: []*v2.GrpcService{{
+									TargetSpecifier: &v2.GrpcService_EnvoyGrpc_{
+										EnvoyGrpc: &v2.GrpcService_EnvoyGrpc{
+											ClusterName: "xds_cluster",
+										},
+									},
+								}},
+							},
+						},
+					},
+					RouteConfigName: routename,
+				},
+			},
+			AccessLog: []*accesslog.AccessLog{{
+				Name: "envoy.file_access_log",
+				Config: messageToStruct(&accesslog.FileAccessLog{
+					Path: "/dev/stdout",
+				}),
+			}},
+			UseRemoteAddress: &types.BoolValue{Value: true},
+			HttpFilters: []*network.HttpFilter{{
+				Name: "envoy.router",
+			}},
+		}),
+	}
+}
+
+// messageToStruct encodes a protobuf Message into a Struct.
+// Hilariously, it uses JSON as the intermediary.
+// author:glen@turbinelabs.io
+func messageToStruct(msg proto.Message) *types.Struct {
+	buf := &bytes.Buffer{}
+	if err := (&jsonpb.Marshaler{OrigName: true}).Marshal(buf, msg); err != nil {
+		panic(err)
+	}
+
+	pbs := &types.Struct{}
+	if err := jsonpb.Unmarshal(buf, pbs); err != nil {
+		panic(err)
+	}
+
+	return pbs
+}


### PR DESCRIPTION
This PR adds a scaffold for LDS tests. It uses the go-control-plane api
types to generate the configuration for the http connection manager. I
had initially decided not to use this method inside contour/listener.go
because of the barf worthy way of converting those types to a grpc
struct type.

For this e2e test I decided to use go-control-plane pkg's methods as a
way of double checking my hand rolled proto struct, I found a few small
errors which have been corrected in this PR, so it's good to double
check the data structures line up.