### PR TITLE
internal/contour: stop generating dummy locality data

### DIFF
--- a/internal/contour/clusterloadassignment.go
+++ b/internal/contour/clusterloadassignment.go
@@ -115,16 +115,8 @@ func clusterloadassignment(name string, lbendpoints ...*v2.LbEndpoint) *v2.Clust
 	return &v2.ClusterLoadAssignment{
 		ClusterName: name,
 		Endpoints: []*v2.LocalityLbEndpoints{{
-			Locality: &v2.Locality{
-				Region:  "ap-southeast-2", // totally a guess
-				Zone:    "2b",
-				SubZone: "banana", // yeah, need to think of better values here
-			},
 			LbEndpoints: lbendpoints,
 		}},
-		Policy: &v2.ClusterLoadAssignment_Policy{
-			DropOverload: 0.0,
-		},
 	}
 }
 

--- a/internal/e2e/eds_test.go
+++ b/internal/e2e/eds_test.go
@@ -200,16 +200,8 @@ func clusterloadassignment(name string, lbendpoints ...*v2.LbEndpoint) *v2.Clust
 	return &v2.ClusterLoadAssignment{
 		ClusterName: name,
 		Endpoints: []*v2.LocalityLbEndpoints{{
-			Locality: &v2.Locality{
-				Region:  "ap-southeast-2", // totally a guess
-				Zone:    "2b",
-				SubZone: "banana", // yeah, need to think of better values here
-			},
 			LbEndpoints: lbendpoints,
 		}},
-		Policy: &v2.ClusterLoadAssignment_Policy{
-			DropOverload: 0.0,
-		},
 	}
 }
 func lbendpoint(addr string, port uint32) *v2.LbEndpoint {


### PR DESCRIPTION
Fixes #224

This PR removes the dummy locality data for each set of locality
lb endpoints.