### PR TITLE
internal/contour: update cluster name

### DIFF
--- a/internal/contour/cluster.go
+++ b/internal/contour/cluster.go
@@ -73,7 +73,7 @@ func (cc *ClusterCache) recomputeService(oldsvc, newsvc *v1.Service) {
 				// for this service.
 				sname = strconv.Itoa(int(p.Port))
 			}
-			config := edsconfig("xds_cluster", servicename(newsvc.ObjectMeta, sname))
+			config := edsconfig("contour", servicename(newsvc.ObjectMeta, sname))
 
 			// sname is the entry that EDS will try to match on, it is independant
 			// of named and unnamed ports below.

--- a/internal/contour/cluster_test.go
+++ b/internal/contour/cluster_test.go
@@ -43,7 +43,7 @@ func TestClusterCacheRecomputeService(t *testing.T) {
 				Name: "default/kuard/443",
 				Type: v2.Cluster_EDS,
 				EdsClusterConfig: &v2.Cluster_EdsClusterConfig{
-					EdsConfig:   apiconfigsource("xds_cluster"), // hard coded by initconfig
+					EdsConfig:   apiconfigsource("contour"), // hard coded by initconfig
 					ServiceName: "default/kuard/443",
 				},
 				ConnectTimeout: 250 * time.Millisecond,
@@ -70,7 +70,7 @@ func TestClusterCacheRecomputeService(t *testing.T) {
 				Name: "default/kuard/443",
 				Type: v2.Cluster_EDS,
 				EdsClusterConfig: &v2.Cluster_EdsClusterConfig{
-					EdsConfig:   apiconfigsource("xds_cluster"), // hard coded by initconfig
+					EdsConfig:   apiconfigsource("contour"), // hard coded by initconfig
 					ServiceName: "default/kuard/https",
 				},
 				ConnectTimeout: 250 * time.Millisecond,
@@ -79,7 +79,7 @@ func TestClusterCacheRecomputeService(t *testing.T) {
 				Name: "default/kuard/https",
 				Type: v2.Cluster_EDS,
 				EdsClusterConfig: &v2.Cluster_EdsClusterConfig{
-					EdsConfig:   apiconfigsource("xds_cluster"), // hard coded by initconfig
+					EdsConfig:   apiconfigsource("contour"), // hard coded by initconfig
 					ServiceName: "default/kuard/https",
 				},
 				ConnectTimeout: 250 * time.Millisecond,
@@ -106,7 +106,7 @@ func TestClusterCacheRecomputeService(t *testing.T) {
 				Name: "default/kuard/443",
 				Type: v2.Cluster_EDS,
 				EdsClusterConfig: &v2.Cluster_EdsClusterConfig{
-					EdsConfig:   apiconfigsource("xds_cluster"), // hard coded by initconfig
+					EdsConfig:   apiconfigsource("contour"), // hard coded by initconfig
 					ServiceName: "default/kuard/443",
 				},
 				ConnectTimeout: 250 * time.Millisecond,
@@ -134,7 +134,7 @@ func TestClusterCacheRecomputeService(t *testing.T) {
 				Name: "default/kuard/8080",
 				Type: v2.Cluster_EDS,
 				EdsClusterConfig: &v2.Cluster_EdsClusterConfig{
-					EdsConfig:   apiconfigsource("xds_cluster"), // hard coded by initconfig
+					EdsConfig:   apiconfigsource("contour"), // hard coded by initconfig
 					ServiceName: "default/kuard/http",
 				},
 				ConnectTimeout: 250 * time.Millisecond,
@@ -143,7 +143,7 @@ func TestClusterCacheRecomputeService(t *testing.T) {
 				Name: "default/kuard/http",
 				Type: v2.Cluster_EDS,
 				EdsClusterConfig: &v2.Cluster_EdsClusterConfig{
-					EdsConfig:   apiconfigsource("xds_cluster"), // hard coded by initconfig
+					EdsConfig:   apiconfigsource("contour"), // hard coded by initconfig
 					ServiceName: "default/kuard/http",
 				},
 				ConnectTimeout: 250 * time.Millisecond,
@@ -177,7 +177,7 @@ func TestClusterCacheRecomputeService(t *testing.T) {
 				Name: "default/kuard/443",
 				Type: v2.Cluster_EDS,
 				EdsClusterConfig: &v2.Cluster_EdsClusterConfig{
-					EdsConfig:   apiconfigsource("xds_cluster"), // hard coded by initconfig
+					EdsConfig:   apiconfigsource("contour"), // hard coded by initconfig
 					ServiceName: "default/kuard/https",
 				},
 				ConnectTimeout: 250 * time.Millisecond,
@@ -186,7 +186,7 @@ func TestClusterCacheRecomputeService(t *testing.T) {
 				Name: "default/kuard/https",
 				Type: v2.Cluster_EDS,
 				EdsClusterConfig: &v2.Cluster_EdsClusterConfig{
-					EdsConfig:   apiconfigsource("xds_cluster"), // hard coded by initconfig
+					EdsConfig:   apiconfigsource("contour"), // hard coded by initconfig
 					ServiceName: "default/kuard/https",
 				},
 				ConnectTimeout: 250 * time.Millisecond,
@@ -219,7 +219,7 @@ func TestClusterCacheRecomputeService(t *testing.T) {
 				Name: "default/kuard/443",
 				Type: v2.Cluster_EDS,
 				EdsClusterConfig: &v2.Cluster_EdsClusterConfig{
-					EdsConfig:   apiconfigsource("xds_cluster"), // hard coded by initconfig
+					EdsConfig:   apiconfigsource("contour"), // hard coded by initconfig
 					ServiceName: "default/kuard/443",
 				},
 				ConnectTimeout: 250 * time.Millisecond,

--- a/internal/contour/listener.go
+++ b/internal/contour/listener.go
@@ -283,12 +283,12 @@ func httpfilter(routename string) *v2.Filter {
 						"api_config_source": st(map[string]*types.Value{
 							"api_type": sv("GRPC"),
 							"cluster_names": lv(
-								sv("xds_cluster"),
+								sv("contour"),
 							),
 							"grpc_services": lv(
 								st(map[string]*types.Value{
 									"envoy_grpc": st(map[string]*types.Value{
-										"cluster_name": sv("xds_cluster"),
+										"cluster_name": sv("contour"),
 									}),
 								}),
 							),

--- a/internal/contour/translator_test.go
+++ b/internal/contour/translator_test.go
@@ -162,7 +162,7 @@ func TestTranslatorUpdateService(t *testing.T) {
 				Name: "default/kuard/443",
 				Type: v2.Cluster_EDS,
 				EdsClusterConfig: &v2.Cluster_EdsClusterConfig{
-					EdsConfig:   apiconfigsource("xds_cluster"), // hard coded by initconfig
+					EdsConfig:   apiconfigsource("contour"), // hard coded by initconfig
 					ServiceName: "default/kuard/https",
 				},
 				ConnectTimeout: 250 * time.Millisecond,
@@ -171,7 +171,7 @@ func TestTranslatorUpdateService(t *testing.T) {
 				Name: "default/kuard/https",
 				Type: v2.Cluster_EDS,
 				EdsClusterConfig: &v2.Cluster_EdsClusterConfig{
-					EdsConfig:   apiconfigsource("xds_cluster"), // hard coded by initconfig
+					EdsConfig:   apiconfigsource("contour"), // hard coded by initconfig
 					ServiceName: "default/kuard/https",
 				},
 				ConnectTimeout: 250 * time.Millisecond,
@@ -1765,7 +1765,7 @@ func cluster(name, servicename string) *v2.Cluster {
 		Name: name,
 		Type: v2.Cluster_EDS,
 		EdsClusterConfig: &v2.Cluster_EdsClusterConfig{
-			EdsConfig:   apiconfigsource("xds_cluster"),
+			EdsConfig:   apiconfigsource("contour"),
 			ServiceName: servicename,
 		},
 		ConnectTimeout: 250 * time.Millisecond,

--- a/internal/e2e/cds_test.go
+++ b/internal/e2e/cds_test.go
@@ -50,7 +50,7 @@ func TestClusterLongServiceName(t *testing.T) {
 				Name: "kuard/kbujbkuhdod66-edfcfc/8080",
 				Type: v2.Cluster_EDS,
 				EdsClusterConfig: &v2.Cluster_EdsClusterConfig{
-					EdsConfig:   apiconfigsource("xds_cluster"), // hard coded by initconfig
+					EdsConfig:   apiconfigsource("contour"), // hard coded by initconfig
 					ServiceName: "kuard/kbujbkuhdod66gjdmwmijz8xzgsx1nkfbrloezdjiulquzk4x3p0nnvpzi8r/8080",
 				},
 				ConnectTimeout: 250 * time.Millisecond,
@@ -83,7 +83,7 @@ func TestClusterAddUpdateDelete(t *testing.T) {
 				Name: "default/kuard/80",
 				Type: v2.Cluster_EDS,
 				EdsClusterConfig: &v2.Cluster_EdsClusterConfig{
-					EdsConfig:   apiconfigsource("xds_cluster"), // hard coded by initconfig
+					EdsConfig:   apiconfigsource("contour"), // hard coded by initconfig
 					ServiceName: "default/kuard/80",
 				},
 				ConnectTimeout: 250 * time.Millisecond,
@@ -113,7 +113,7 @@ func TestClusterAddUpdateDelete(t *testing.T) {
 				Name: "default/kuard/80",
 				Type: v2.Cluster_EDS,
 				EdsClusterConfig: &v2.Cluster_EdsClusterConfig{
-					EdsConfig:   apiconfigsource("xds_cluster"), // hard coded by initconfig
+					EdsConfig:   apiconfigsource("contour"), // hard coded by initconfig
 					ServiceName: "default/kuard/http",
 				},
 				ConnectTimeout: 250 * time.Millisecond,
@@ -123,7 +123,7 @@ func TestClusterAddUpdateDelete(t *testing.T) {
 				Name: "default/kuard/http",
 				Type: v2.Cluster_EDS,
 				EdsClusterConfig: &v2.Cluster_EdsClusterConfig{
-					EdsConfig:   apiconfigsource("xds_cluster"), // hard coded by initconfig
+					EdsConfig:   apiconfigsource("contour"), // hard coded by initconfig
 					ServiceName: "default/kuard/http",
 				},
 				ConnectTimeout: 250 * time.Millisecond,
@@ -163,7 +163,7 @@ func TestClusterAddUpdateDelete(t *testing.T) {
 				Name: "default/kuard/443",
 				Type: v2.Cluster_EDS,
 				EdsClusterConfig: &v2.Cluster_EdsClusterConfig{
-					EdsConfig:   apiconfigsource("xds_cluster"), // hard coded by initconfig
+					EdsConfig:   apiconfigsource("contour"), // hard coded by initconfig
 					ServiceName: "default/kuard/https",
 				},
 				ConnectTimeout: 250 * time.Millisecond,
@@ -173,7 +173,7 @@ func TestClusterAddUpdateDelete(t *testing.T) {
 				Name: "default/kuard/80",
 				Type: v2.Cluster_EDS,
 				EdsClusterConfig: &v2.Cluster_EdsClusterConfig{
-					EdsConfig:   apiconfigsource("xds_cluster"), // hard coded by initconfig
+					EdsConfig:   apiconfigsource("contour"), // hard coded by initconfig
 					ServiceName: "default/kuard/http",
 				},
 				ConnectTimeout: 250 * time.Millisecond,
@@ -183,7 +183,7 @@ func TestClusterAddUpdateDelete(t *testing.T) {
 				Name: "default/kuard/http",
 				Type: v2.Cluster_EDS,
 				EdsClusterConfig: &v2.Cluster_EdsClusterConfig{
-					EdsConfig:   apiconfigsource("xds_cluster"), // hard coded by initconfig
+					EdsConfig:   apiconfigsource("contour"), // hard coded by initconfig
 					ServiceName: "default/kuard/http",
 				},
 				ConnectTimeout: 250 * time.Millisecond,
@@ -193,7 +193,7 @@ func TestClusterAddUpdateDelete(t *testing.T) {
 				Name: "default/kuard/https",
 				Type: v2.Cluster_EDS,
 				EdsClusterConfig: &v2.Cluster_EdsClusterConfig{
-					EdsConfig:   apiconfigsource("xds_cluster"), // hard coded by initconfig
+					EdsConfig:   apiconfigsource("contour"), // hard coded by initconfig
 					ServiceName: "default/kuard/https",
 				},
 				ConnectTimeout: 250 * time.Millisecond,
@@ -226,7 +226,7 @@ func TestClusterAddUpdateDelete(t *testing.T) {
 				Name: "default/kuard/443",
 				Type: v2.Cluster_EDS,
 				EdsClusterConfig: &v2.Cluster_EdsClusterConfig{
-					EdsConfig:   apiconfigsource("xds_cluster"), // hard coded by initconfig
+					EdsConfig:   apiconfigsource("contour"), // hard coded by initconfig
 					ServiceName: "default/kuard/https",
 				},
 				ConnectTimeout: 250 * time.Millisecond,
@@ -236,7 +236,7 @@ func TestClusterAddUpdateDelete(t *testing.T) {
 				Name: "default/kuard/https",
 				Type: v2.Cluster_EDS,
 				EdsClusterConfig: &v2.Cluster_EdsClusterConfig{
-					EdsConfig:   apiconfigsource("xds_cluster"), // hard coded by initconfig
+					EdsConfig:   apiconfigsource("contour"), // hard coded by initconfig
 					ServiceName: "default/kuard/https",
 				},
 				ConnectTimeout: 250 * time.Millisecond,
@@ -276,7 +276,7 @@ func TestClusterRenameUpdateDelete(t *testing.T) {
 				Name: "default/kuard/443",
 				Type: v2.Cluster_EDS,
 				EdsClusterConfig: &v2.Cluster_EdsClusterConfig{
-					EdsConfig:   apiconfigsource("xds_cluster"), // hard coded by initconfig
+					EdsConfig:   apiconfigsource("contour"), // hard coded by initconfig
 					ServiceName: "default/kuard/https",
 				},
 				ConnectTimeout: 250 * time.Millisecond,
@@ -286,7 +286,7 @@ func TestClusterRenameUpdateDelete(t *testing.T) {
 				Name: "default/kuard/80",
 				Type: v2.Cluster_EDS,
 				EdsClusterConfig: &v2.Cluster_EdsClusterConfig{
-					EdsConfig:   apiconfigsource("xds_cluster"), // hard coded by initconfig
+					EdsConfig:   apiconfigsource("contour"), // hard coded by initconfig
 					ServiceName: "default/kuard/http",
 				},
 				ConnectTimeout: 250 * time.Millisecond,
@@ -296,7 +296,7 @@ func TestClusterRenameUpdateDelete(t *testing.T) {
 				Name: "default/kuard/http",
 				Type: v2.Cluster_EDS,
 				EdsClusterConfig: &v2.Cluster_EdsClusterConfig{
-					EdsConfig:   apiconfigsource("xds_cluster"), // hard coded by initconfig
+					EdsConfig:   apiconfigsource("contour"), // hard coded by initconfig
 					ServiceName: "default/kuard/http",
 				},
 				ConnectTimeout: 250 * time.Millisecond,
@@ -306,7 +306,7 @@ func TestClusterRenameUpdateDelete(t *testing.T) {
 				Name: "default/kuard/https",
 				Type: v2.Cluster_EDS,
 				EdsClusterConfig: &v2.Cluster_EdsClusterConfig{
-					EdsConfig:   apiconfigsource("xds_cluster"), // hard coded by initconfig
+					EdsConfig:   apiconfigsource("contour"), // hard coded by initconfig
 					ServiceName: "default/kuard/https",
 				},
 				ConnectTimeout: 250 * time.Millisecond,
@@ -334,7 +334,7 @@ func TestClusterRenameUpdateDelete(t *testing.T) {
 				Name: "default/kuard/443",
 				Type: v2.Cluster_EDS,
 				EdsClusterConfig: &v2.Cluster_EdsClusterConfig{
-					EdsConfig:   apiconfigsource("xds_cluster"), // hard coded by initconfig
+					EdsConfig:   apiconfigsource("contour"), // hard coded by initconfig
 					ServiceName: "default/kuard/443",
 				},
 				ConnectTimeout: 250 * time.Millisecond,
@@ -354,7 +354,7 @@ func TestClusterRenameUpdateDelete(t *testing.T) {
 				Name: "default/kuard/443",
 				Type: v2.Cluster_EDS,
 				EdsClusterConfig: &v2.Cluster_EdsClusterConfig{
-					EdsConfig:   apiconfigsource("xds_cluster"), // hard coded by initconfig
+					EdsConfig:   apiconfigsource("contour"), // hard coded by initconfig
 					ServiceName: "default/kuard/https",
 				},
 				ConnectTimeout: 250 * time.Millisecond,
@@ -364,7 +364,7 @@ func TestClusterRenameUpdateDelete(t *testing.T) {
 				Name: "default/kuard/80",
 				Type: v2.Cluster_EDS,
 				EdsClusterConfig: &v2.Cluster_EdsClusterConfig{
-					EdsConfig:   apiconfigsource("xds_cluster"), // hard coded by initconfig
+					EdsConfig:   apiconfigsource("contour"), // hard coded by initconfig
 					ServiceName: "default/kuard/http",
 				},
 				ConnectTimeout: 250 * time.Millisecond,
@@ -374,7 +374,7 @@ func TestClusterRenameUpdateDelete(t *testing.T) {
 				Name: "default/kuard/http",
 				Type: v2.Cluster_EDS,
 				EdsClusterConfig: &v2.Cluster_EdsClusterConfig{
-					EdsConfig:   apiconfigsource("xds_cluster"), // hard coded by initconfig
+					EdsConfig:   apiconfigsource("contour"), // hard coded by initconfig
 					ServiceName: "default/kuard/http",
 				},
 				ConnectTimeout: 250 * time.Millisecond,
@@ -384,7 +384,7 @@ func TestClusterRenameUpdateDelete(t *testing.T) {
 				Name: "default/kuard/https",
 				Type: v2.Cluster_EDS,
 				EdsClusterConfig: &v2.Cluster_EdsClusterConfig{
-					EdsConfig:   apiconfigsource("xds_cluster"), // hard coded by initconfig
+					EdsConfig:   apiconfigsource("contour"), // hard coded by initconfig
 					ServiceName: "default/kuard/https",
 				},
 				ConnectTimeout: 250 * time.Millisecond,

--- a/internal/e2e/lds_test.go
+++ b/internal/e2e/lds_test.go
@@ -319,11 +319,11 @@ func httpfilter(routename string) *v2.Filter {
 						ConfigSourceSpecifier: &v2.ConfigSource_ApiConfigSource{
 							ApiConfigSource: &v2.ApiConfigSource{
 								ApiType:      v2.ApiConfigSource_GRPC,
-								ClusterNames: []string{"xds_cluster"},
+								ClusterNames: []string{"contour"},
 								GrpcServices: []*v2.GrpcService{{
 									TargetSpecifier: &v2.GrpcService_EnvoyGrpc_{
 										EnvoyGrpc: &v2.GrpcService_EnvoyGrpc{
-											ClusterName: "xds_cluster",
+											ClusterName: "contour",
 										},
 									},
 								}},

--- a/internal/envoy/config.go
+++ b/internal/envoy/config.go
@@ -54,20 +54,20 @@ const yamlConfig = `dynamic_resources:
   lds_config:
     api_config_source:
       api_type: GRPC
-      cluster_names: [xds_cluster]
+      cluster_names: [contour]
       grpc_services:
       - envoy_grpc:
-          cluster_name: xds_cluster
+          cluster_name: contour
   cds_config:
     api_config_source:
       api_type: GRPC
-      cluster_names: [xds_cluster]
+      cluster_names: [contour]
       grpc_services:
       - envoy_grpc:
-          cluster_name: xds_cluster
+          cluster_name: contour
 static_resources:
   clusters:
-  - name: xds_cluster
+  - name: contour
     connect_timeout: { seconds: 5 }
     type: STATIC
     hosts:

--- a/internal/envoy/config_test.go
+++ b/internal/envoy/config_test.go
@@ -30,20 +30,20 @@ func TestConfigWriter_WriteYAML(t *testing.T) {
   lds_config:
     api_config_source:
       api_type: GRPC
-      cluster_names: [xds_cluster]
+      cluster_names: [contour]
       grpc_services:
       - envoy_grpc:
-          cluster_name: xds_cluster
+          cluster_name: contour
   cds_config:
     api_config_source:
       api_type: GRPC
-      cluster_names: [xds_cluster]
+      cluster_names: [contour]
       grpc_services:
       - envoy_grpc:
-          cluster_name: xds_cluster
+          cluster_name: contour
 static_resources:
   clusters:
-  - name: xds_cluster
+  - name: contour
     connect_timeout: { seconds: 5 }
     type: STATIC
     hosts:


### PR DESCRIPTION
Fixes #229.

Rename cluster, use `contour` intead of `xds_cluster`.
It should not bring functional changes.

Signed-off-by: Jesús García Crespo <jesus@sevein.com>