### PR TITLE
internal/contour: refactor backend timeout handling

### DIFF
--- a/internal/contour/translator_test.go
+++ b/internal/contour/translator_test.go
@@ -455,9 +455,6 @@ func TestTranslatorRemoveEndpoints(t *testing.T) {
 }
 
 func TestTranslatorAddIngress(t *testing.T) {
-	duration20seconds := time.Duration(20 * time.Second)
-	duration0seconds := time.Duration(0)
-
 	tests := []struct {
 		name          string
 		setup         func(*Translator)
@@ -965,7 +962,7 @@ func TestTranslatorAddIngress(t *testing.T) {
 			Domains: []string{"*"},
 			Routes: []*v2.Route{{
 				Match:  prefixmatch("/"), // match all
-				Action: clusteractiontimeout("default/backend/80", &duration20seconds),
+				Action: clusteractiontimeout("default/backend/80", 20*time.Second),
 			}},
 		}},
 		ingress_https: []*v2.VirtualHost{},
@@ -987,8 +984,8 @@ func TestTranslatorAddIngress(t *testing.T) {
 			Name:    "*",
 			Domains: []string{"*"},
 			Routes: []*v2.Route{{
-				Match:  prefixmatch("/"), // match all
-				Action: clusteractiontimeout("default/backend/80", &duration0seconds),
+				Match:  prefixmatch("/"),                                          // match all
+				Action: clusteractiontimeout("default/backend/80", 0*time.Second), // infinity
 			}},
 		}},
 		ingress_https: []*v2.VirtualHost{},
@@ -1010,8 +1007,8 @@ func TestTranslatorAddIngress(t *testing.T) {
 			Name:    "*",
 			Domains: []string{"*"},
 			Routes: []*v2.Route{{
-				Match:  prefixmatch("/"), // match all
-				Action: clusteractiontimeout("default/backend/80", &duration0seconds),
+				Match:  prefixmatch("/"),                                          // match all
+				Action: clusteractiontimeout("default/backend/80", 0*time.Second), // infinity
 			}},
 		}},
 		ingress_https: []*v2.VirtualHost{},

--- a/internal/contour/virtualhost_test.go
+++ b/internal/contour/virtualhost_test.go
@@ -630,40 +630,43 @@ func TestValidTLSSpecforVhost(t *testing.T) {
 }
 
 func TestGetRequestTimeout(t *testing.T) {
-	var tenSeconds = 10 * time.Second
-
 	tests := map[string]struct {
 		a    map[string]string
-		want *time.Duration
-		// ok   bool
+		want time.Duration
+		ok   bool
 	}{
 		"nada": {
 			a:    nil,
-			want: nil,
+			want: 0,
+			ok:   false,
 		},
 		"empty": {
 			a:    map[string]string{requestTimeout: ""}, // not even sure this is possible via the API
-			want: nil,
+			want: 0,
+			ok:   false,
 		},
 		"infinity": {
 			a:    map[string]string{requestTimeout: "infinity"},
-			want: &infiniteTimeout,
+			want: 0,
+			ok:   true,
 		},
 		"10 seconds": {
 			a:    map[string]string{requestTimeout: "10s"},
-			want: &tenSeconds,
+			want: 10 * time.Second,
+			ok:   true,
 		},
 		"invalid": {
 			a:    map[string]string{requestTimeout: "10"}, // 10 what?
-			want: &infiniteTimeout,
+			want: 0,
+			ok:   true,
 		},
 	}
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			got := getRequestTimeout(tc.a)
-			if got != tc.want { // || ok != tc.ok {
-				t.Fatalf("getRequestTimeout(%q): want: %v, %v, got: %v, %v", tc.a, tc.want, false, got, false)
+			got, ok := getRequestTimeout(tc.a)
+			if got != tc.want || ok != tc.ok {
+				t.Fatalf("getRequestTimeout(%q): want: %v, %v, got: %v, %v", tc.a, tc.want, tc.ok, got, ok)
 			}
 		})
 	}

--- a/internal/contour/virtualhost_test.go
+++ b/internal/contour/virtualhost_test.go
@@ -671,3 +671,26 @@ func TestGetRequestTimeout(t *testing.T) {
 		})
 	}
 }
+
+// clusteraction returns a route action for the supplied cluster name.
+func clusteraction(name string) *v2.Route_Route {
+	return &v2.Route_Route{
+		Route: &v2.RouteAction{
+			ClusterSpecifier: &v2.RouteAction_Cluster{
+				Cluster: name,
+			},
+		},
+	}
+}
+
+// clusteractiontimeout returns a cluster action with the specified timeout.
+// A timeout of 0 means infinity. If you do not want to specify a timeout, use
+// clusteraction instead.
+func clusteractiontimeout(name string, timeout time.Duration) *v2.Route_Route {
+	// TODO(cmaloney): Pull timeout off of the backend cluster annotation
+	// and use it over the value retrieved from the ingress annotation if
+	// specified.
+	c := clusteraction(name)
+	c.Route.Timeout = &timeout
+	return c
+}


### PR DESCRIPTION
Updates #164 

This PR refactors the `getRequestTimeout` function to return a timeout value, not a pointer to a timeout. This helps with writing unit tests.

In the process this made the usage of `getRequestTimeout` within `recomputevhost` more verbose. This is handled by moving the complexity of generating a `*v2.Route_Route` to its own helper which takes an ingress and a backend and applies the required business logic.