### PR TITLE
internal/envoy: use strict DNS for resolving the cluster

### DIFF
--- a/internal/envoy/config.go
+++ b/internal/envoy/config.go
@@ -69,7 +69,7 @@ static_resources:
   clusters:
   - name: contour
     connect_timeout: { seconds: 5 }
-    type: STATIC
+    type: STRICT_DNS
     hosts:
     - socket_address:
         address: {{ if .XDSAddress }}{{ .XDSAddress }}{{ else }}127.0.0.1{{ end }}

--- a/internal/envoy/config_test.go
+++ b/internal/envoy/config_test.go
@@ -45,7 +45,7 @@ static_resources:
   clusters:
   - name: contour
     connect_timeout: { seconds: 5 }
-    type: STATIC
+    type: STRICT_DNS
     hosts:
     - socket_address:
         address: 127.0.0.1


### PR DESCRIPTION
Fixes #228.

This enable us to define the contour cluster as a DNS name. I have confirmed
that `STRICT_DNS` also works when the address is an IP.

As mentioned by @davecheney before, with #158 and #228 fixed we should be able
to split Contour and Envoy into separate pods. Proof of concept:
https://gist.github.com/sevein/d30e1791fbc0db786884360486e70737.

Signed-off-by: Jesús García Crespo <jesus@sevein.com>