### PR TITLE
all: normalise logrus use

### DIFF
--- a/cmd/contour/contour.go
+++ b/cmd/contour/contour.go
@@ -85,15 +85,15 @@ func main() {
 		var g workgroup.Group
 
 		// buffer notifications to t to ensure they are handled sequentially.
-		buf := k8s.NewBuffer(&g, t, log.WithField("context", "buffer"), 128)
+		buf := k8s.NewBuffer(&g, t, log, 128)
 
 		client := newClient(*kubeconfig, *inCluster)
 
 		wl := log.WithField("context", "watch")
-		k8s.WatchServices(&g, client, wl.WithField("resource", "service"), buf)
-		k8s.WatchEndpoints(&g, client, wl.WithField("resource", "endpoints"), buf)
-		k8s.WatchIngress(&g, client, wl.WithField("resource", "ingress"), buf)
-		k8s.WatchSecrets(&g, client, wl.WithField("resource", "secrets"), buf)
+		k8s.WatchServices(&g, client, wl, buf)
+		k8s.WatchEndpoints(&g, client, wl, buf)
+		k8s.WatchIngress(&g, client, wl, buf)
+		k8s.WatchSecrets(&g, client, wl, buf)
 
 		g.Add(func(stop <-chan struct{}) {
 			log := log.WithField("context", "grpc")

--- a/internal/contour/translator_test.go
+++ b/internal/contour/translator_test.go
@@ -114,8 +114,7 @@ func TestTranslatorAddService(t *testing.T) {
 		want: []*v2.Cluster{},
 	}}
 
-	log := logrus.New()
-	log.Out = &testWriter{t}
+	log := testLogger(t)
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			tr := &Translator{
@@ -181,8 +180,7 @@ func TestTranslatorUpdateService(t *testing.T) {
 		},
 	}
 
-	log := logrus.New()
-	log.Out = &testWriter{t}
+	log := testLogger(t)
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			tr := &Translator{
@@ -264,8 +262,7 @@ func TestTranslatorRemoveService(t *testing.T) {
 		},
 	}
 
-	log := logrus.New()
-	log.Out = &testWriter{t}
+	log := testLogger(t)
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			tr := &Translator{
@@ -327,8 +324,7 @@ func TestTranslatorAddEndpoints(t *testing.T) {
 		},
 	}}
 
-	log := logrus.New()
-	log.Out = &testWriter{t}
+	log := testLogger(t)
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			tr := &Translator{
@@ -442,8 +438,7 @@ func TestTranslatorRemoveEndpoints(t *testing.T) {
 		},
 	}
 
-	log := logrus.New()
-	log.Out = &testWriter{t}
+	log := testLogger(t)
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			tr := &Translator{
@@ -1019,8 +1014,7 @@ func TestTranslatorAddIngress(t *testing.T) {
 		ingress_https: []route.VirtualHost{},
 	}}
 
-	log := logrus.New()
-	log.Out = &testWriter{t}
+	log := testLogger(t)
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			tr := &Translator{
@@ -1133,8 +1127,7 @@ func TestTranslatorRemoveIngress(t *testing.T) {
 		},
 	}
 
-	log := logrus.New()
-	log.Out = &testWriter{t}
+	log := testLogger(t)
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			tr := &Translator{
@@ -1891,6 +1884,12 @@ func ingressrulevalue(backend *v1beta1.IngressBackend) v1beta1.IngressRuleValue 
 			}},
 		},
 	}
+}
+
+func testLogger(t *testing.T) logrus.FieldLogger {
+	log := logrus.New()
+	log.Out = &testWriter{t}
+	return log
 }
 
 type testWriter struct {

--- a/internal/grpc/grpc_test.go
+++ b/internal/grpc/grpc_test.go
@@ -32,15 +32,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
-type testWriter struct {
-	*testing.T
-}
-
-func (t *testWriter) Write(buf []byte) (int, error) {
-	t.Logf("%s", buf)
-	return len(buf), nil
-}
-
 func TestGRPCStreaming(t *testing.T) {
 	var l net.Listener
 
@@ -196,8 +187,7 @@ func TestGRPCStreaming(t *testing.T) {
 		},
 	}
 
-	log := logrus.New()
-	log.Out = &testWriter{t}
+	log := testLogger(t)
 	for name, fn := range tests {
 		t.Run(name, func(t *testing.T) {
 			tr = &contour.Translator{
@@ -332,4 +322,19 @@ func checktimeout(t *testing.T, stream interface {
 	if s.Code() != codes.DeadlineExceeded {
 		t.Fatalf("expected %q, got %q", codes.DeadlineExceeded, s.Code())
 	}
+}
+
+func testLogger(t *testing.T) logrus.FieldLogger {
+	log := logrus.New()
+	log.Out = &testWriter{t}
+	return log
+}
+
+type testWriter struct {
+	*testing.T
+}
+
+func (t *testWriter) Write(buf []byte) (int, error) {
+	t.Logf("%s", buf)
+	return len(buf), nil
 }

--- a/internal/k8s/buffer.go
+++ b/internal/k8s/buffer.go
@@ -39,10 +39,10 @@ type deleteEvent struct {
 }
 
 // NewBuffer returns a ResourceEventHandler which buffers and serialises ResourceEventHandler events.
-func NewBuffer(g *workgroup.Group, rh cache.ResourceEventHandler, log logrus.StdLogger, size int) cache.ResourceEventHandler {
+func NewBuffer(g *workgroup.Group, rh cache.ResourceEventHandler, log logrus.FieldLogger, size int) cache.ResourceEventHandler {
 	buf := &buffer{
 		ev:        make(chan interface{}, size),
-		StdLogger: log,
+		StdLogger: log.WithField("context", "buffer"),
 		rh:        rh,
 	}
 	g.Add(buf.loop)

--- a/internal/k8s/watcher.go
+++ b/internal/k8s/watcher.go
@@ -29,32 +29,33 @@ import (
 )
 
 // WatchServices creates a SharedInformer for v1.Services and registers it with g.
-func WatchServices(g *workgroup.Group, client *kubernetes.Clientset, log logrus.StdLogger, rs ...cache.ResourceEventHandler) {
+func WatchServices(g *workgroup.Group, client *kubernetes.Clientset, log logrus.FieldLogger, rs ...cache.ResourceEventHandler) {
 	watch(g, client.CoreV1().RESTClient(), log, "services", new(v1.Service), rs...)
 }
 
 // WatchEndpoints creates a SharedInformer for v1.Endpoints and registers it with g.
-func WatchEndpoints(g *workgroup.Group, client *kubernetes.Clientset, log logrus.StdLogger, rs ...cache.ResourceEventHandler) {
+func WatchEndpoints(g *workgroup.Group, client *kubernetes.Clientset, log logrus.FieldLogger, rs ...cache.ResourceEventHandler) {
 	watch(g, client.CoreV1().RESTClient(), log, "endpoints", new(v1.Endpoints), rs...)
 }
 
 // WatchIngress creates a SharedInformer for v1beta1.Ingress and registers it with g.
-func WatchIngress(g *workgroup.Group, client *kubernetes.Clientset, log logrus.StdLogger, rs ...cache.ResourceEventHandler) {
+func WatchIngress(g *workgroup.Group, client *kubernetes.Clientset, log logrus.FieldLogger, rs ...cache.ResourceEventHandler) {
 	watch(g, client.ExtensionsV1beta1().RESTClient(), log, "ingresses", new(v1beta1.Ingress), rs...)
 }
 
 // WatchSecrets creates a SharedInformer for v1.Secrets and registers it with g.
-func WatchSecrets(g *workgroup.Group, client *kubernetes.Clientset, log logrus.StdLogger, rs ...cache.ResourceEventHandler) {
+func WatchSecrets(g *workgroup.Group, client *kubernetes.Clientset, log logrus.FieldLogger, rs ...cache.ResourceEventHandler) {
 	watch(g, client.CoreV1().RESTClient(), log, "secrets", new(v1.Secret), rs...)
 }
 
-func watch(g *workgroup.Group, c cache.Getter, log logrus.StdLogger, resource string, objType runtime.Object, rs ...cache.ResourceEventHandler) {
+func watch(g *workgroup.Group, c cache.Getter, log logrus.FieldLogger, resource string, objType runtime.Object, rs ...cache.ResourceEventHandler) {
 	lw := cache.NewListWatchFromClient(c, resource, v1.NamespaceAll, fields.Everything())
 	sw := cache.NewSharedInformer(lw, objType, 30*time.Minute)
 	for _, r := range rs {
 		sw.AddEventHandler(r)
 	}
 	g.Add(func(stop <-chan struct{}) {
+		log := log.WithField("resource", resource)
 		log.Println("started")
 		defer log.Println("stopped")
 		sw.Run(stop)


### PR DESCRIPTION
Updates #162 

This PR finalises the use of logrus across the project. The various
TODO's related to logging can be taken care of in latter PRs.

The basic rules for using logrus in this project are

- A worker is reponsible for adding its own fields like `context` or
`resource`. Pass a `logrus.FieldLogger` to the worker's constructor and
let it add fields as necessary.
- The name of the `logrus.FieldLogger` or `logrus.StdLogger` should be
`log` in formal parameters and local variables.
- If the function is not expected to add more fields, the type of it's
logger should be `logrus.StdLogger`.
- `logrus.FieldLogger` / `logrus.StdLogger` should be embedded by value
into long lived types that need to log. They should apply necessary
fields during construction.

Signed-off-by: Dave Cheney <dave@cheney.net>