### PR TITLE
internal/contour: generate stable service names for unnamed service ports

### DIFF
--- a/internal/contour/clusterloadassignment.go
+++ b/internal/contour/clusterloadassignment.go
@@ -14,8 +14,6 @@
 package contour
 
 import (
-	"strconv"
-
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2/endpoint"
@@ -63,13 +61,6 @@ func (cc *ClusterLoadAssignmentCache) recomputeClusterLoadAssignment(oldep, newe
 			// if this endpoint's service's port has a name, then the endpoint
 			// controller will apply the name here. The name may appear once per subset.
 			name := p.Name
-			if name == "" {
-				// if the port's name is not set then the service's port is unnamed
-				// and there is only one port, and it only deploys to an unnamed
-				// container port, therefore the name generated for the service in CDS
-				// will be the port number.
-				name = strconv.Itoa(int(p.Port))
-			}
 			cla, ok := clas[name]
 			if !ok {
 				cla = clusterloadassignment(servicename(newep.ObjectMeta, name))
@@ -96,13 +87,6 @@ func (cc *ClusterLoadAssignmentCache) recomputeClusterLoadAssignment(oldep, newe
 			// if this endpoint's service's port has a name, then the endpoint
 			// controller will apply the name here. The name may appear once per subset.
 			name := p.Name
-			if name == "" {
-				// if the port's name is not set then the service's port is unnamed
-				// and there is only one port, and it only deploys to an unnamed
-				// container port, therefore the name generated for the service in CDS
-				// will be the port number.
-				name = strconv.Itoa(int(p.Port))
-			}
 			if _, ok := clas[name]; !ok {
 				// port is not present in the list added / updated, so remove it
 				cc.Remove(servicename(oldep.ObjectMeta, name))

--- a/internal/contour/clusterloadassignment_test.go
+++ b/internal/contour/clusterloadassignment_test.go
@@ -32,7 +32,7 @@ func TestClusterLoadAssignmentCacheRecomputeClusterLoadAssignment(t *testing.T) 
 				Ports:     ports(8080),
 			}),
 			want: []*v2.ClusterLoadAssignment{
-				clusterloadassignment("default/simple/8080", lbendpoint("192.168.183.24", 8080)),
+				clusterloadassignment("default/simple", lbendpoint("192.168.183.24", 8080)),
 			},
 		},
 		"multiple addresses": {
@@ -46,7 +46,7 @@ func TestClusterLoadAssignmentCacheRecomputeClusterLoadAssignment(t *testing.T) 
 				Ports: ports(80),
 			}),
 			want: []*v2.ClusterLoadAssignment{
-				clusterloadassignment("default/httpbin-org/80",
+				clusterloadassignment("default/httpbin-org",
 					lbendpoint("23.23.247.89", 80),
 					lbendpoint("50.17.192.147", 80),
 					lbendpoint("50.17.206.192", 80),

--- a/internal/contour/translator.go
+++ b/internal/contour/translator.go
@@ -370,6 +370,15 @@ func apiconfigsource(clusters ...string) *core.ConfigSource {
 	}
 }
 
-func servicename(meta metav1.ObjectMeta, port string) string {
-	return meta.Namespace + "/" + meta.Name + "/" + port
+// servicename returns a fixed name for this service and portname
+func servicename(meta metav1.ObjectMeta, portname string) string {
+	sn := []string{
+		meta.Namespace,
+		meta.Name,
+		"",
+	}[:2]
+	if portname != "" {
+		sn = append(sn, portname)
+	}
+	return strings.Join(sn, "/")
 }

--- a/internal/contour/translator_test.go
+++ b/internal/contour/translator_test.go
@@ -40,7 +40,7 @@ func TestTranslatorAddService(t *testing.T) {
 			TargetPort: intstr.FromInt(6502),
 		}),
 		want: []*v2.Cluster{
-			cluster("default/simple/80", "default/simple/6502"),
+			cluster("default/simple/80", "default/simple"),
 		},
 	}, {
 		name: "long namespace and service name",
@@ -56,7 +56,7 @@ func TestTranslatorAddService(t *testing.T) {
 		want: []*v2.Cluster{
 			cluster(
 				"beurocratic-company-test-domain-1/tiny-cog-depa-52e801/80",
-				"beurocratic-company-test-domain-1/tiny-cog-department-test-instance/6502", // ServiceName is not subject to the 60 char limit
+				"beurocratic-company-test-domain-1/tiny-cog-department-test-instance", // ServiceName is not subject to the 60 char limit
 			),
 		},
 	}, {
@@ -104,7 +104,7 @@ func TestTranslatorAddService(t *testing.T) {
 			TargetPort: intstr.FromString("9001"),
 		}),
 		want: []*v2.Cluster{
-			cluster("default/simple/8080", "default/simple/9001"),
+			cluster("default/simple/8080", "default/simple"),
 		},
 	}, {
 		name: "one udp service",
@@ -250,7 +250,7 @@ func TestTranslatorRemoveService(t *testing.T) {
 				TargetPort: intstr.FromInt(6502),
 			}),
 			want: []*v2.Cluster{
-				cluster("default/simple/80", "default/simple/6502"),
+				cluster("default/simple/80", "default/simple"),
 			},
 		},
 		"remove non existant": {
@@ -298,7 +298,7 @@ func TestTranslatorAddEndpoints(t *testing.T) {
 			Ports:     ports(8080),
 		}),
 		want: []*v2.ClusterLoadAssignment{
-			clusterloadassignment("default/simple/8080", lbendpoint("192.168.183.24", 8080)),
+			clusterloadassignment("default/simple", lbendpoint("192.168.183.24", 8080)),
 		},
 	}, {
 		name: "multiple addresses",
@@ -317,7 +317,7 @@ func TestTranslatorAddEndpoints(t *testing.T) {
 			Ports: ports(80),
 		}),
 		want: []*v2.ClusterLoadAssignment{
-			clusterloadassignment("default/httpbin-org/80",
+			clusterloadassignment("default/httpbin-org",
 				lbendpoint("23.23.247.89", 80),
 				lbendpoint("50.17.192.147", 80),
 				lbendpoint("50.17.206.192", 80),
@@ -383,7 +383,7 @@ func TestTranslatorRemoveEndpoints(t *testing.T) {
 				Ports:     ports(8080),
 			}),
 			want: []*v2.ClusterLoadAssignment{
-				clusterloadassignment("default/simple/8080", lbendpoint("192.168.183.24", 8080)),
+				clusterloadassignment("default/simple", lbendpoint("192.168.183.24", 8080)),
 			},
 		},
 		"remove non existant": {


### PR DESCRIPTION
Fixes #247

Fingers crossed this finally closes the last issue with the EDS and CDS
servicename's not matching.

On the CDS side, the cluster.service_name field is always defined from
the namespace/name of the service document, and, if provided a slash and
the name of the service port. If this is blank, then the slash is also
elided. The end result is in the case that there is a single serviceport
in the service spec, the service_name generated for that CDS entry will
be simple "namespace/name". In all other cases, the api server requires
that service ports be named, so the CDS's service_name entry will be
"namespace/name/serviceportname".

On the EDS side, we only have the contents written by the endpoint
controller, but that is enough. If the service's port was named in the
service document, then that name will be present in the endpoint
document. If not, then the name field will be blank, which generates a
corresponding service name of "namespace/name", matching the logic
described above in CDS.

Signed-off-by: Dave Cheney <dave@cheney.net>