### PR TITLE
internal/contour: 301 upgrade routes on a per ingress basis

### DIFF
--- a/internal/contour/listener.go
+++ b/internal/contour/listener.go
@@ -38,7 +38,6 @@ const (
 
 // ListenerCache manages the contents of the gRPC LDS cache.
 type ListenerCache struct {
-
 	// Envoy's HTTP (non TLS) listener address.
 	// If not set, defaults to DEFAULT_HTTP_LISTENER_ADDRESS.
 	HTTPAddress string

--- a/internal/contour/virtualhost_test.go
+++ b/internal/contour/virtualhost_test.go
@@ -176,9 +176,8 @@ func TestVirtualHostCacheRecomputevhost(t *testing.T) {
 				Domains: []string{"httpbin.org"},
 				Routes: []route.Route{{
 					Match:  prefixmatch("/"), // match all
-					Action: clusteraction("default/httpbin-org/80"),
+					Action: redirecthttps(),
 				}},
-				RequireTls: route.VirtualHost_ALL,
 			}},
 			ingress_https: []route.VirtualHost{{
 				Name:    "httpbin.org",
@@ -687,4 +686,13 @@ func clusteractiontimeout(name string, timeout time.Duration) *route.Route_Route
 	c := clusteraction(name)
 	c.Route.Timeout = &timeout
 	return c
+}
+
+// redirecthttps returns a 301 redirect to the HTTPS scheme.
+func redirecthttps() *route.Route_Redirect {
+	return &route.Route_Redirect{
+		Redirect: &route.RedirectAction{
+			HttpsRedirect: true,
+		},
+	}
 }

--- a/internal/e2e/cds_test.go
+++ b/internal/e2e/cds_test.go
@@ -445,7 +445,6 @@ func TestIssue247(t *testing.T) {
 	defer done()
 
 	t.Run("single unnamed service with a named target port", func(t *testing.T) {
-
 		// spec:
 		//   ports:
 		//   - port: 80


### PR DESCRIPTION
Fixes #250

Prior this PR if _any_ ingress which mentioned a vhost used the
ingress.kubernetes.io/force-ssl-redirect: "true" annotation, then all
routes would be 301 upgraded via the route.virtualhost.requireTls flag.

This PR changes the behaviour so per ingress (that is all routes in an
ingress object), not per vhost, the annotation is applied and this
causes the route.RouteRoute action to be replaced with a
route.Route_Redirect action. This has the same net effect as the
requireTls virtualhost flag, but is applied per route.

Signed-off-by: Dave Cheney <dave@cheney.net>