### PR TITLE
Initial implementation of RouteCRD for Ingress routes

### DIFF
--- a/deployment/example-workload/kuard-minikube-route.yaml
+++ b/deployment/example-workload/kuard-minikube-route.yaml
@@ -34,17 +34,15 @@ spec:
   sessionAffinity: None
   type: ClusterIP
 ---
-apiVersion: extensions/v1beta1
-kind: Ingress
-metadata:
+apiVersion: contour.heptio.com/v1alpha1
+kind: Route
+metadata: 
   name: kuard
-  labels:
-    app: kuard
-spec:
-  rules:
-  - host: k8s.local
-    http:
-      paths:
-      - backend:
-          serviceName: kuard
+  namespace: default
+spec: 
+  host: k8s.local
+  routes: 
+    - pathPrefix: /
+      upstreams: 
+        - serviceName: kuard
           servicePort: 80

--- a/deployment/example-workload/kuard-route.yaml
+++ b/deployment/example-workload/kuard-route.yaml
@@ -1,10 +1,46 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  labels:
+    app: kuard
+  name: kuard
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: kuard
+  template:
+    metadata:
+      labels:
+        app: kuard
+    spec:
+      containers:
+      - image: gcr.io/kuar-demo/kuard-amd64:1
+        name: kuard
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: kuard
+  name: kuard
+spec:
+  ports:
+  - port: 80
+    protocol: TCP
+    targetPort: 8080
+  selector:
+    app: kuard
+  sessionAffinity: None
+  type: ClusterIP
+---
 apiVersion: contour.heptio.com/v1alpha1
 kind: Route
 metadata: 
   name: kuard
   namespace: default
 spec: 
-  host: 
+  host: kuard.containersteve.com
   routes: 
     - pathPrefix: /
       upstreams: 

--- a/deployment/example-workload/kuard.yaml
+++ b/deployment/example-workload/kuard.yaml
@@ -41,6 +41,10 @@ metadata:
   labels:
     app: kuard
 spec:
-  backend:
-    serviceName: kuard
-    servicePort: 80
+  rules:
+  - host: kuard.containersteve.com
+    http:
+      paths:
+      - backend:
+          serviceName: kuard
+          servicePort: 80


### PR DESCRIPTION
This is a basic implementation of RouteCRDs to match http only current state of ingress. One note is it does not (yet) support multiple upstreams which will be handled in a future PR. 

Signed-off-by: Steve Sloka <steves@heptio.com>