### PR TITLE
internal/contour: make IngressClass configurable

### DIFF
--- a/cmd/contour/contour.go
+++ b/cmd/contour/contour.go
@@ -72,6 +72,7 @@ func main() {
 	serve.Flag("envoy-http-port", "Envoy HTTP listener port").IntVar(&t.HTTPPort)
 	serve.Flag("envoy-https-port", "Envoy HTTPS listener port").IntVar(&t.HTTPSPort)
 	serve.Flag("use-proxy-protocol", "Use PROXY protocol for all listeners").BoolVar(&t.UseProxyProto)
+	serve.Flag("ingress-class-name", "Contour IngressClass name").StringVar(&t.IngressClass)
 
 	args := os.Args[1:]
 	switch kingpin.MustParse(app.Parse(args)) {


### PR DESCRIPTION
Fixes #255 

By default, the "kubernetes.io/ingress.class" was checked against
a hardcoded value. This value is now in a constant and overridable
at runtime.

Signed-off-by: Nicolas Bernard <nikkau@nikkau.net>