### PR TITLE
Add docs on how to get Envoy stats with prometheus

### DIFF
--- a/deployment/deployment-grpc-v2/02-contour.yaml
+++ b/deployment/deployment-grpc-v2/02-contour.yaml
@@ -14,6 +14,11 @@ spec:
     metadata:
       labels:
         app: contour
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "9001"
+        prometheus.io/path: "/stats"
+        prometheus.io/format: "prometheus"
     spec:
       containers:
       - image: docker.io/envoyproxy/envoy-alpine:latest

--- a/deployment/ds-grpc-v2/02-contour.yaml
+++ b/deployment/ds-grpc-v2/02-contour.yaml
@@ -15,6 +15,11 @@ spec:
     metadata:
       labels:
         app: contour
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "9001"
+        prometheus.io/path: "/stats"
+        prometheus.io/format: "prometheus"
     spec:
       containers:
       - image: docker.io/envoyproxy/envoy-alpine:latest

--- a/deployment/ds-hostnet/02-contour.yaml
+++ b/deployment/ds-hostnet/02-contour.yaml
@@ -15,6 +15,11 @@ spec:
     metadata:
       labels:
         app: contour
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "9001"
+        prometheus.io/path: "/stats"
+        prometheus.io/format: "prometheus"
     spec:
       hostNetwork: true
       containers:

--- a/deployment/render/daemonset-norbac.yaml
+++ b/deployment/render/daemonset-norbac.yaml
@@ -29,6 +29,11 @@ spec:
     metadata:
       labels:
         app: contour
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "9001"
+        prometheus.io/path: "/stats"
+        prometheus.io/format: "prometheus"
     spec:
       containers:
       - image: docker.io/envoyproxy/envoy-alpine:latest

--- a/deployment/render/daemonset-rbac.yaml
+++ b/deployment/render/daemonset-rbac.yaml
@@ -29,6 +29,11 @@ spec:
     metadata:
       labels:
         app: contour
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "9001"
+        prometheus.io/path: "/stats"
+        prometheus.io/format: "prometheus"
     spec:
       containers:
       - image: docker.io/envoyproxy/envoy-alpine:latest

--- a/deployment/render/deployment-norbac.yaml
+++ b/deployment/render/deployment-norbac.yaml
@@ -28,6 +28,11 @@ spec:
     metadata:
       labels:
         app: contour
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "9001"
+        prometheus.io/path: "/stats"
+        prometheus.io/format: "prometheus"
     spec:
       containers:
       - image: docker.io/envoyproxy/envoy-alpine:latest

--- a/deployment/render/deployment-rbac.yaml
+++ b/deployment/render/deployment-rbac.yaml
@@ -28,6 +28,11 @@ spec:
     metadata:
       labels:
         app: contour
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "9001"
+        prometheus.io/path: "/stats"
+        prometheus.io/format: "prometheus"
     spec:
       containers:
       - image: docker.io/envoyproxy/envoy-alpine:latest

--- a/docs/prometheus.md
+++ b/docs/prometheus.md
@@ -1,15 +1,15 @@
 # Prometheus
 
-With Contour it is possible to get metrics from Envoy. In order for this to work properly,
-you must expose the Envoy admin socket and configure the Prometheus service discovery correctly.
+With Contour you can get metrics from Envoy. To do so you must expose the Envoy
+admin socket and configure the Prometheus service discovery correctly.
 
-The admin socket can be made public by running
+Make the admin socket public:
 
 ```
 sed 's#"bootstrap", "/config/contour.yaml"#"bootstrap", "/config/contour.yaml", "--admin-address", "0.0.0.0"#g' <your-contour-deployment>.yaml
 ```
 
-Prometheus needs to have a configuration block that looks like this:
+Prometheus needs a configuration block that looks like this:
 
 ```yaml
     - job_name: 'kubernetes-pods'

--- a/docs/prometheus.md
+++ b/docs/prometheus.md
@@ -1,0 +1,47 @@
+# Prometheus
+
+With Contour it is possible to get metrics from Envoy. In order for this to work properly,
+you must expose the Envoy admin socket and configure the Prometheus service discovery correctly.
+
+The admin socket can be made public by running
+
+```
+sed 's#"bootstrap", "/config/contour.yaml"#"bootstrap", "/config/contour.yaml", "--admin-address", "0.0.0.0"#g' <your-contour-deployment>.yaml
+```
+
+Prometheus needs to have a configuration block that looks like this:
+
+```yaml
+    - job_name: 'kubernetes-pods'
+      kubernetes_sd_configs:
+      - role: pod
+      relabel_configs:
+      - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
+        action: keep
+        regex: true
+      - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_path]
+        action: replace
+        target_label: __metrics_path__
+        regex: (.+)
+      - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_format]
+        action: replace
+        target_label: __param_format
+        regex: (.+)
+      - source_labels: [__address__, __meta_kubernetes_pod_annotation_prometheus_io_port]
+        action: replace
+        regex: ([^:]+)(?::\d+)?;(\d+)
+        replacement: $1:$2
+        target_label: __address__
+      - action: labelmap
+        regex: __meta_kubernetes_pod_label_(.+)
+      - source_labels: [__meta_kubernetes_namespace]
+        action: replace
+        target_label: kubernetes_namespace
+      - source_labels: [__meta_kubernetes_pod_name]
+        action: replace
+        target_label: kubernetes_pod_name
+```
+
+The main difference from the [offical Prometheus Kubernetes sample config](https://github.com/prometheus/prometheus/blob/master/documentation/examples/prometheus-kubernetes.yml)
+is the added interpretation of the `__meta_kubernetes_pod_annotation_prometheus_io_format` label, because Envoy
+currently requires a [`format=prometheus` url parameter to return the stats in Prometheus format.](https://github.com/envoyproxy/envoy/issues/2182)


### PR DESCRIPTION
This PR adds docs on how to get envoy stats with Prometheus. It also adds Prometheus annotations for all deployments/daemonsets.

What's not ideal about this approach is that

* It requires a non-standard Prometheus config
* It requires exposing the Envoy admin socket which is especially bad when running with host network

I saw metrics are on the roadmap, what do you think about resolving the two above mentioned issues by proxying the Envoy stats with Contour?