### PR TITLE
internal/contour: consolidate annotation processing into a new file.

### DIFF
--- a/internal/contour/annotations.go
+++ b/internal/contour/annotations.go
@@ -18,9 +18,15 @@ import (
 	"time"
 
 	"github.com/gogo/protobuf/types"
+	"k8s.io/api/extensions/v1beta1"
 )
 
 const (
+	// set docs/annotations.md for details of how these annotations
+	// are applied by Contour.
+
+	kubernetesIngressAllowHttp = "kubernetes.io/ingress.allow-http"
+
 	annotationRequestTimeout = "contour.heptio.com/request-timeout"
 	annotationRetryOn        = "contour.heptio.com/retry-on"
 	annotationNumRetries     = "contour.heptio.com/num-retries"
@@ -67,4 +73,10 @@ func parseAnnotationUInt32(annotations map[string]string, annotation string) *ty
 		return nil
 	}
 	return &types.UInt32Value{Value: uint32(v)}
+}
+
+// httpAllowed returns true unless the kubernetes.io/ingress.allow-http annotation is
+// present and set to false.
+func httpAllowed(i *v1beta1.Ingress) bool {
+	return !(i.Annotations["kubernetes.io/ingress.allow-http"] == "false")
 }

--- a/internal/contour/annotations.go
+++ b/internal/contour/annotations.go
@@ -1,0 +1,70 @@
+// Copyright © 2018 Heptio
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package contour
+
+import (
+	"strconv"
+	"time"
+
+	"github.com/gogo/protobuf/types"
+)
+
+const (
+	annotationRequestTimeout = "contour.heptio.com/request-timeout"
+	annotationRetryOn        = "contour.heptio.com/retry-on"
+	annotationNumRetries     = "contour.heptio.com/num-retries"
+	annotationPerTryTimeout  = "contour.heptio.com/per-try-timeout"
+
+	// By default envoy applies a 15 second timeout to all backend requests.
+	// The explicit value 0 turns off the timeout, implying "never time out"
+	// https://www.envoyproxy.io/docs/envoy/v1.5.0/api-v2/rds.proto#routeaction
+	infiniteTimeout = time.Duration(0)
+)
+
+// parseAnnotationTimeout parses the annotations map for a contour.heptio.com/request-timeout
+// value. If the value is not present, false is returned and the timeout value should be
+// ignored. If the value is present, but malformed, the timeout value is valid, and represents
+// infinite timeout.
+func parseAnnotationTimeout(annotations map[string]string, annotation string) (time.Duration, bool) {
+	timeoutStr := annotations[annotationRequestTimeout]
+	// Error or unspecified is interpreted as no timeout specified, use envoy defaults
+	if timeoutStr == "" {
+		return 0, false
+	}
+	// Interpret "infinity" explicitly as an infinite timeout, which envoy config
+	// expects as a timeout of 0. This could be specified with the duration string
+	// "0s" but want to give an explicit out for operators.
+	if timeoutStr == "infinity" {
+		return infiniteTimeout, true
+	}
+
+	timeoutParsed, err := time.ParseDuration(timeoutStr)
+	if err != nil {
+		// TODO(cmalonty) plumb a logger in here so we can log this error.
+		// Assuming infinite duration is going to surprise people less for
+		// a not-parseable duration than a implicit 15 second one.
+		return infiniteTimeout, true
+	}
+	return timeoutParsed, true
+}
+
+// parseAnnotationUint32 parsers the annotation map for the supplied annotation key.
+// If the value is not present, or malformed, then nil is returned.
+func parseAnnotationUInt32(annotations map[string]string, annotation string) *types.UInt32Value {
+	v, err := strconv.ParseUint(annotations[annotation], 10, 32)
+	if err != nil {
+		return nil
+	}
+	return &types.UInt32Value{Value: uint32(v)}
+}

--- a/internal/contour/annotations.go
+++ b/internal/contour/annotations.go
@@ -26,6 +26,7 @@ const (
 	// are applied by Contour.
 
 	kubernetesIngressAllowHttp = "kubernetes.io/ingress.allow-http"
+	kubernetesIngressForceSSL  = "ingress.kubernetes.io/force-ssl-redirect"
 
 	annotationRequestTimeout = "contour.heptio.com/request-timeout"
 	annotationRetryOn        = "contour.heptio.com/retry-on"
@@ -79,4 +80,10 @@ func parseAnnotationUInt32(annotations map[string]string, annotation string) *ty
 // present and set to false.
 func httpAllowed(i *v1beta1.Ingress) bool {
 	return !(i.Annotations["kubernetes.io/ingress.allow-http"] == "false")
+}
+
+// tlsRequired returns true iff the ingress.kubernetes.io/force-ssl-redirect annotation is
+// present and set to true.
+func tlsRequired(i *v1beta1.Ingress) bool {
+	return i.Annotations["ingress.kubernetes.io/force-ssl-redirect"] == "true"
 }

--- a/internal/contour/annotations_test.go
+++ b/internal/contour/annotations_test.go
@@ -1,0 +1,109 @@
+// Copyright © 2018 Heptio
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package contour
+
+import (
+	"math"
+	"testing"
+	"time"
+
+	"github.com/gogo/protobuf/types"
+)
+
+func TestParseAnnotationTimeout(t *testing.T) {
+	tests := map[string]struct {
+		a    map[string]string
+		want time.Duration
+		ok   bool
+	}{
+		"nada": {
+			a:    nil,
+			want: 0,
+			ok:   false,
+		},
+		"empty": {
+			a:    map[string]string{annotationRequestTimeout: ""}, // not even sure this is possible via the API
+			want: 0,
+			ok:   false,
+		},
+		"infinity": {
+			a:    map[string]string{annotationRequestTimeout: "infinity"},
+			want: 0,
+			ok:   true,
+		},
+		"10 seconds": {
+			a:    map[string]string{annotationRequestTimeout: "10s"},
+			want: 10 * time.Second,
+			ok:   true,
+		},
+		"invalid": {
+			a:    map[string]string{annotationRequestTimeout: "10"}, // 10 what?
+			want: 0,
+			ok:   true,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			got, ok := parseAnnotationTimeout(tc.a, annotationRequestTimeout)
+			if got != tc.want || ok != tc.ok {
+				t.Fatalf("parseAnnotationTimeout(%q): want: %v, %v, got: %v, %v", tc.a, tc.want, tc.ok, got, ok)
+			}
+		})
+	}
+}
+
+func TestParseAnnotationUInt32(t *testing.T) {
+	tests := map[string]struct {
+		a     map[string]string
+		want  uint32
+		isNil bool
+	}{
+		"nada": {
+			a:     nil,
+			isNil: true,
+		},
+		"empty": {
+			a:     map[string]string{annotationRequestTimeout: ""}, // not even sure this is possible via the API
+			isNil: true,
+		},
+		"smallest": {
+			a:    map[string]string{annotationRequestTimeout: "0"},
+			want: 0,
+		},
+		"middle value": {
+			a:    map[string]string{annotationRequestTimeout: "20"},
+			want: 20,
+		},
+		"biggest": {
+			a:    map[string]string{annotationRequestTimeout: "4294967295"},
+			want: math.MaxUint32,
+		},
+		"invalid": {
+			a:     map[string]string{annotationRequestTimeout: "10seconds"}, // not a duration
+			isNil: true,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := parseAnnotationUInt32(tc.a, annotationRequestTimeout)
+			full := types.UInt32Value{Value: tc.want}
+
+			if ((got == nil) != tc.isNil) || (got != nil && *got != full) {
+				t.Fatalf("parseAnnotationUInt32(%q): want: %v, isNil: %v, got: %v", tc.a, tc.want, tc.isNil, got)
+			}
+		})
+	}
+}

--- a/internal/contour/listener.go
+++ b/internal/contour/listener.go
@@ -101,7 +101,7 @@ func (lc *ListenerCache) recomputeListener0(ingresses map[metadata]*v1beta1.Ingr
 
 	var valid int
 	for _, i := range ingresses {
-		if validIngress(i) {
+		if httpAllowed(i) {
 			valid++
 		}
 	}
@@ -138,16 +138,6 @@ func (lc *ListenerCache) httpPort() uint32 {
 		return uint32(lc.HTTPPort)
 	}
 	return DEFAULT_HTTP_LISTENER_PORT
-}
-
-// validIngress returns true if this is a valid non ssl ingress object.
-// ingresses are invalid if they contain annotations which exclude them from
-// the ingress_http listener.
-func validIngress(i *v1beta1.Ingress) bool {
-	if i.Annotations["kubernetes.io/ingress.allow-http"] == "false" {
-		return false
-	}
-	return true
 }
 
 // recomputeTLSListener0 recomputes the SSL listener for port 8443

--- a/internal/contour/listener_test.go
+++ b/internal/contour/listener_test.go
@@ -443,59 +443,6 @@ func TestListenerCacheRecomputeTLSListener(t *testing.T) {
 	assertCacheNotEmpty(t, lc) // we've got the secret and the ingress, we should have at least one listener
 }
 
-func TestValidIngress(t *testing.T) {
-	tests := map[string]struct {
-		i     *v1beta1.Ingress
-		valid bool
-	}{
-		"basic ingress": {
-			i: &v1beta1.Ingress{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "simple",
-					Namespace: "default",
-				},
-				Spec: v1beta1.IngressSpec{
-					TLS: []v1beta1.IngressTLS{{
-						Hosts:      []string{"whatever.example.com"},
-						SecretName: "secret",
-					}},
-					Backend: backend("backend", intstr.FromInt(80)),
-				},
-			},
-			valid: true,
-		},
-		"kubernetes.io/ingress.allow-http: \"false\"": {
-			i: &v1beta1.Ingress{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "simple",
-					Namespace: "default",
-					Annotations: map[string]string{
-						"kubernetes.io/ingress.allow-http": "false",
-					},
-				},
-				Spec: v1beta1.IngressSpec{
-					TLS: []v1beta1.IngressTLS{{
-						Hosts:      []string{"whatever.example.com"},
-						SecretName: "secret",
-					}},
-					Backend: backend("backend", intstr.FromInt(80)),
-				},
-			},
-			valid: false,
-		},
-	}
-
-	for name, tc := range tests {
-		t.Run(name, func(t *testing.T) {
-			got := validIngress(tc.i)
-			want := tc.valid
-			if got != want {
-				t.Fatalf("validIngress: got: %v, want: %v", got, want)
-			}
-		})
-	}
-}
-
 func TestValidTLSIngress(t *testing.T) {
 	tests := map[string]struct {
 		i     *v1beta1.Ingress

--- a/internal/contour/virtualhost.go
+++ b/internal/contour/virtualhost.go
@@ -68,7 +68,7 @@ func (v *VirtualHostCache) recomputevhost(vhost string, ingresses map[metadata]*
 			// skip this vhosts ingress_http route.
 			continue
 		}
-		requireTLS := i.Annotations["ingress.kubernetes.io/force-ssl-redirect"] == "true"
+		requireTLS := tlsRequired(i)
 		if i.Spec.Backend != nil && len(ingresses) == 1 {
 			r := route.Route{
 				Match:  prefixmatch("/"),

--- a/internal/contour/virtualhost.go
+++ b/internal/contour/virtualhost.go
@@ -64,7 +64,7 @@ func (v *VirtualHostCache) recomputevhost(vhost string, ingresses map[metadata]*
 	// now handle ingress_http (non tls) routes.
 	vv = virtualhost(vhost)
 	for _, i := range ingresses {
-		if i.Annotations["kubernetes.io/ingress.allow-http"] == "false" {
+		if !httpAllowed(i) {
 			// skip this vhosts ingress_http route.
 			continue
 		}

--- a/internal/contour/virtualhost.go
+++ b/internal/contour/virtualhost.go
@@ -15,12 +15,9 @@ package contour
 
 import (
 	"sort"
-	"strconv"
 	"strings"
-	"time"
 
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
-	"github.com/gogo/protobuf/types"
 	"k8s.io/api/extensions/v1beta1"
 )
 
@@ -29,55 +26,6 @@ type VirtualHostCache struct {
 	HTTP  virtualHostCache
 	HTTPS virtualHostCache
 	Cond
-}
-
-const (
-	annotationRequestTimeout = "contour.heptio.com/request-timeout"
-	annotationRetryOn        = "contour.heptio.com/retry-on"
-	annotationNumRetries     = "contour.heptio.com/num-retries"
-	annotationPerTryTimeout  = "contour.heptio.com/per-try-timeout"
-
-	// By default envoy applies a 15 second timeout to all backend requests.
-	// The explicit value 0 turns off the timeout, implying "never time out"
-	// https://www.envoyproxy.io/docs/envoy/v1.5.0/api-v2/rds.proto#routeaction
-	infiniteTimeout = time.Duration(0)
-)
-
-// parseAnnotationTimeout parses the annotations map for a contour.heptio.com/request-timeout
-// value. If the value is not present, false is returned and the timeout value should be
-// ignored. If the value is present, but malformed, the timeout value is valid, and represents
-// infinite timeout.
-func parseAnnotationTimeout(annotations map[string]string, annotation string) (time.Duration, bool) {
-	timeoutStr := annotations[annotationRequestTimeout]
-	// Error or unspecified is interpreted as no timeout specified, use envoy defaults
-	if timeoutStr == "" {
-		return 0, false
-	}
-	// Interpret "infinity" explicitly as an infinite timeout, which envoy config
-	// expects as a timeout of 0. This could be specified with the duration string
-	// "0s" but want to give an explicit out for operators.
-	if timeoutStr == "infinity" {
-		return infiniteTimeout, true
-	}
-
-	timeoutParsed, err := time.ParseDuration(timeoutStr)
-	if err != nil {
-		// TODO(cmalonty) plumb a logger in here so we can log this error.
-		// Assuming infinite duration is going to surprise people less for
-		// a not-parseable duration than a implicit 15 second one.
-		return infiniteTimeout, true
-	}
-	return timeoutParsed, true
-}
-
-// parseAnnotationUint32 parsers the annotation map for the supplied annotation key.
-// If the value is not present, or malformed, then nil is returned.
-func parseAnnotationUInt32(annotations map[string]string, annotation string) *types.UInt32Value {
-	v, err := strconv.ParseUint(annotations[annotation], 10, 32)
-	if err != nil {
-		return nil
-	}
-	return &types.UInt32Value{Value: uint32(v)}
 }
 
 // recomputevhost recomputes the ingress_http (HTTP) and ingress_https (HTTPS) record

--- a/internal/contour/virtualhost_test.go
+++ b/internal/contour/virtualhost_test.go
@@ -14,13 +14,11 @@
 package contour
 
 import (
-	"math"
 	"reflect"
 	"testing"
 	"time"
 
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
-	"github.com/gogo/protobuf/types"
 	"github.com/sirupsen/logrus"
 	"k8s.io/api/extensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -623,94 +621,6 @@ func TestValidTLSSpecforVhost(t *testing.T) {
 	}
 }
 
-func TestParseAnnotationTimeout(t *testing.T) {
-	tests := map[string]struct {
-		a    map[string]string
-		want time.Duration
-		ok   bool
-	}{
-		"nada": {
-			a:    nil,
-			want: 0,
-			ok:   false,
-		},
-		"empty": {
-			a:    map[string]string{annotationRequestTimeout: ""}, // not even sure this is possible via the API
-			want: 0,
-			ok:   false,
-		},
-		"infinity": {
-			a:    map[string]string{annotationRequestTimeout: "infinity"},
-			want: 0,
-			ok:   true,
-		},
-		"10 seconds": {
-			a:    map[string]string{annotationRequestTimeout: "10s"},
-			want: 10 * time.Second,
-			ok:   true,
-		},
-		"invalid": {
-			a:    map[string]string{annotationRequestTimeout: "10"}, // 10 what?
-			want: 0,
-			ok:   true,
-		},
-	}
-
-	for name, tc := range tests {
-		t.Run(name, func(t *testing.T) {
-			got, ok := parseAnnotationTimeout(tc.a, annotationRequestTimeout)
-			if got != tc.want || ok != tc.ok {
-				t.Fatalf("parseAnnotationTimeout(%q): want: %v, %v, got: %v, %v", tc.a, tc.want, tc.ok, got, ok)
-			}
-		})
-	}
-}
-
-func TestParseAnnotationUInt32(t *testing.T) {
-	tests := map[string]struct {
-		a     map[string]string
-		want  uint32
-		isNil bool
-	}{
-		"nada": {
-			a:     nil,
-			isNil: true,
-		},
-		"empty": {
-			a:     map[string]string{annotationRequestTimeout: ""}, // not even sure this is possible via the API
-			isNil: true,
-		},
-		"smallest": {
-			a:    map[string]string{annotationRequestTimeout: "0"},
-			want: 0,
-		},
-		"middle value": {
-			a:    map[string]string{annotationRequestTimeout: "20"},
-			want: 20,
-		},
-		"biggest": {
-			a:    map[string]string{annotationRequestTimeout: "4294967295"},
-			want: math.MaxUint32,
-		},
-		"invalid": {
-			a:     map[string]string{annotationRequestTimeout: "10seconds"}, // not a duration
-			isNil: true,
-		},
-	}
-
-	for name, tc := range tests {
-		t.Run(name, func(t *testing.T) {
-			got := parseAnnotationUInt32(tc.a, annotationRequestTimeout)
-			full := types.UInt32Value{Value: tc.want}
-
-			if ((got == nil) != tc.isNil) || (got != nil && *got != full) {
-				t.Fatalf("parseAnnotationUInt32(%q): want: %v, isNil: %v, got: %v", tc.a, tc.want, tc.isNil, got)
-			}
-		})
-	}
-}
-
-// clusteraction returns a route action for the supplied cluster name.
 // clusteraction returns a Route_Route action for the supplied cluster.
 func clusteraction(cluster string) *route.Route_Route {
 	return &route.Route_Route{


### PR DESCRIPTION
The ingress.class annotation is still unaccounted for, but this is overall an improvement and creates a place for annotation processing helpers in the future.