### PR TITLE
Bump up Go version in containers to 1.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 go_import_path: github.com/heptio/contour
 go:
-  - 1.9.x
+  - 1.10.x
 
 sudo: false
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.9
+FROM golang:1.10
 WORKDIR /go/src/github.com/heptio/contour
 
 RUN go get github.com/golang/dep/cmd/dep
@@ -9,6 +9,6 @@ COPY cmd cmd
 COPY internal internal
 RUN CGO_ENABLED=0 GOOS=linux go install -ldflags="-w -s" -v github.com/heptio/contour/cmd/contour
 
-FROM alpine:latest  
+FROM alpine:latest
 RUN apk --no-cache add ca-certificates
 COPY --from=0 /go/bin/contour /bin/contour


### PR DESCRIPTION
Resolves #267 
Basically no change to codebase, everything seems to work the same.
I've also gone through the go 1.10 changelogs, not finding any changes that will affect the project.

Signed-off-by: Emman <eygohlolz@gmail.com>