### PR TITLE
deployment: pin envoy version to known hash

### DIFF
--- a/deployment/deployment-grpc-v2/02-contour.yaml
+++ b/deployment/deployment-grpc-v2/02-contour.yaml
@@ -21,7 +21,7 @@ spec:
         prometheus.io/format: "prometheus"
     spec:
       containers:
-      - image: docker.io/envoyproxy/envoy-alpine:latest
+      - image: docker.io/envoyproxy/envoy-alpine:e6ff690611b8a3373f6d66066b52d613873e446e
         name: envoy
         ports:
         - containerPort: 8080

--- a/deployment/ds-grpc-v2/02-contour.yaml
+++ b/deployment/ds-grpc-v2/02-contour.yaml
@@ -22,7 +22,7 @@ spec:
         prometheus.io/format: "prometheus"
     spec:
       containers:
-      - image: docker.io/envoyproxy/envoy-alpine:latest
+      - image: docker.io/envoyproxy/envoy-alpine:e6ff690611b8a3373f6d66066b52d613873e446e
         name: envoy
         ports:
         - containerPort: 8080

--- a/deployment/ds-hostnet/02-contour.yaml
+++ b/deployment/ds-hostnet/02-contour.yaml
@@ -23,7 +23,7 @@ spec:
     spec:
       hostNetwork: true
       containers:
-      - image: docker.io/envoyproxy/envoy-alpine:latest
+      - image: docker.io/envoyproxy/envoy-alpine:e6ff690611b8a3373f6d66066b52d613873e446e
         name: envoy
         ports:
         - containerPort: 8080

--- a/deployment/render/daemonset-norbac.yaml
+++ b/deployment/render/daemonset-norbac.yaml
@@ -36,7 +36,7 @@ spec:
         prometheus.io/format: "prometheus"
     spec:
       containers:
-      - image: docker.io/envoyproxy/envoy-alpine:latest
+      - image: docker.io/envoyproxy/envoy-alpine:e6ff690611b8a3373f6d66066b52d613873e446e
         name: envoy
         ports:
         - containerPort: 8080

--- a/deployment/render/daemonset-rbac.yaml
+++ b/deployment/render/daemonset-rbac.yaml
@@ -36,7 +36,7 @@ spec:
         prometheus.io/format: "prometheus"
     spec:
       containers:
-      - image: docker.io/envoyproxy/envoy-alpine:latest
+      - image: docker.io/envoyproxy/envoy-alpine:e6ff690611b8a3373f6d66066b52d613873e446e
         name: envoy
         ports:
         - containerPort: 8080

--- a/deployment/render/deployment-norbac.yaml
+++ b/deployment/render/deployment-norbac.yaml
@@ -35,7 +35,7 @@ spec:
         prometheus.io/format: "prometheus"
     spec:
       containers:
-      - image: docker.io/envoyproxy/envoy-alpine:latest
+      - image: docker.io/envoyproxy/envoy-alpine:e6ff690611b8a3373f6d66066b52d613873e446e
         name: envoy
         ports:
         - containerPort: 8080

--- a/deployment/render/deployment-rbac.yaml
+++ b/deployment/render/deployment-rbac.yaml
@@ -35,7 +35,7 @@ spec:
         prometheus.io/format: "prometheus"
     spec:
       containers:
-      - image: docker.io/envoyproxy/envoy-alpine:latest
+      - image: docker.io/envoyproxy/envoy-alpine:e6ff690611b8a3373f6d66066b52d613873e446e
         name: envoy
         ports:
         - containerPort: 8080

--- a/release-0.4.md
+++ b/release-0.4.md
@@ -68,12 +68,19 @@ Fixes #250.
 
 ## Upgrading
 
+Until Envoy 1.6 is released it is recommended to pin the version of Envoy used in your deployments to a known hash.
+The recommended hash is
+```
+spec:
+  containers:
+  - image: docker.io/envoyproxy/envoy-alpine:e6ff690611b8a3373f6d66066b52d613873e446e
+```
 Consult the [upgrade notes][0] for how to update your Deployment or Daemonset manifests to the YAML bootstrap configuration format.
 
 [0]: docs/upgrade.md
 [1]: https://kubernetes.io/docs/concepts/services-networking/ingress/#tls
 [2]: docs/tls.md
-[3]: docs/troubleshooting.mdA
+[3]: docs/troubleshooting.md
 [4]: annotations.md
 [5]: https://blog.pcisecuritystandards.org/are-you-ready-for-30-june-2018-sayin-goodbye-to-ssl-early-tls
 [6]: https://github.com/heptio/contour/graphs/contributors


### PR DESCRIPTION
Fixes #142

Pin envoyproxy/envoy-alpine to the March 12 tagged version.

There is nothing special about this tag, other than it works.

Signed-off-by: Dave Cheney <dave@cheney.net>