### PR TITLE
internal/contour: add additional checks for blank virtualhost items

### DIFF
--- a/internal/contour/cache.go
+++ b/internal/contour/cache.go
@@ -266,6 +266,7 @@ func (vc *virtualHostCache) Add(virtualhosts ...*route.VirtualHost) {
 	}
 	vc.Lock()
 	sort.Sort(virtualHostsByName(vc.values))
+next:
 	for _, v := range virtualhosts {
 		if v.Name == "" {
 			logrus.WithField("virtualhost", v).Println("skipping VirtualHost with empty name")
@@ -273,10 +274,12 @@ func (vc *virtualHostCache) Add(virtualhosts ...*route.VirtualHost) {
 		}
 		if len(v.Domains) == 0 {
 			logrus.WithField("virtualhost", v).Println("skipping VirtualHost with blank domain list")
+			continue
 		}
 		for _, d := range v.Domains {
 			if d == "" {
 				logrus.WithField("virtualhost", v).Println("skipping VirtualHost with blank entry in domain list")
+				continue next
 			}
 		}
 		vc.add(v)

--- a/internal/contour/cache.go
+++ b/internal/contour/cache.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
+	"github.com/sirupsen/logrus"
 )
 
 // clusterCache is a thread safe, atomic, copy on write cache of *v2.Cluster objects.
@@ -266,6 +267,18 @@ func (vc *virtualHostCache) Add(virtualhosts ...*route.VirtualHost) {
 	vc.Lock()
 	sort.Sort(virtualHostsByName(vc.values))
 	for _, v := range virtualhosts {
+		if v.Name == "" {
+			logrus.WithField("virtualhost", v).Println("skipping VirtualHost with empty name")
+			continue
+		}
+		if len(v.Domains) == 0 {
+			logrus.WithField("virtualhost", v).Println("skipping VirtualHost with blank domain list")
+		}
+		for _, d := range v.Domains {
+			if d == "" {
+				logrus.WithField("virtualhost", v).Println("skipping VirtualHost with blank entry in domain list")
+			}
+		}
 		vc.add(v)
 	}
 	vc.Unlock()

--- a/internal/contour/cache_test.go
+++ b/internal/contour/cache_test.go
@@ -352,7 +352,8 @@ func TestListenerCacheRemove(t *testing.T) {
 func TestVirtualHostCacheValuesReturnsACopyOfItsInternalSlice(t *testing.T) {
 	var cc virtualHostCache
 	c := &route.VirtualHost{
-		Name: "alpha",
+		Name:    "alpha",
+		Domains: []string{"alpha"},
 	}
 	cc.Add(c)
 
@@ -369,18 +370,22 @@ func TestVirtualHostCacheValuesReturnsACopyOfItsInternalSlice(t *testing.T) {
 func TestVirtualHostCacheAddInsertsTwoElementsInSortOrder(t *testing.T) {
 	var cc virtualHostCache
 	c1 := &route.VirtualHost{
-		Name: "beta",
+		Name:    "beta",
+		Domains: []string{"beta"},
 	}
 	cc.Add(c1)
 	c2 := &route.VirtualHost{
-		Name: "alpha",
+		Name:    "alpha",
+		Domains: []string{"alpha"},
 	}
 	cc.Add(c2)
 	got := cc.Values()
 	want := []route.VirtualHost{{
-		Name: "alpha",
+		Name:    "alpha",
+		Domains: []string{"alpha"},
 	}, {
-		Name: "beta",
+		Name:    "beta",
+		Domains: []string{"beta"},
 	}}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("VirtualHostCache.Add/Values returned elements missing or out of order, got: %v, want: %v", got, want)
@@ -415,13 +420,15 @@ func TestVirtualHostCacheAddOverwritesElementsWithTheSameName(t *testing.T) {
 func TestVirtualHostCacheAddIsCopyOnWrite(t *testing.T) {
 	var cc virtualHostCache
 	c1 := &route.VirtualHost{
-		Name: "alpha",
+		Name:    "alpha",
+		Domains: []string{"alpha"},
 	}
 	cc.Add(c1)
 	v1 := cc.Values()
 
 	c2 := &route.VirtualHost{
-		Name: "beta",
+		Name:    "beta",
+		Domains: []string{"beta"},
 	}
 	cc.Add(c2)
 	v2 := cc.Values()
@@ -434,7 +441,8 @@ func TestVirtualHostCacheAddIsCopyOnWrite(t *testing.T) {
 func TestVirtualHostCacheRemove(t *testing.T) {
 	var cc virtualHostCache
 	c1 := &route.VirtualHost{
-		Name: "alpha",
+		Name:    "alpha",
+		Domains: []string{"alpha"},
 	}
 	cc.Add(c1)
 	cc.Remove("alpha")

--- a/internal/contour/cache_test.go
+++ b/internal/contour/cache_test.go
@@ -417,6 +417,54 @@ func TestVirtualHostCacheAddOverwritesElementsWithTheSameName(t *testing.T) {
 	}
 }
 
+func TestVirtualHostCacheIngnoresInvalidVirtualHosts(t *testing.T) {
+	tests := map[string]struct {
+		vh *route.VirtualHost
+	}{
+		"missing name": {
+			&route.VirtualHost{
+				Name: "",
+			},
+		},
+		"missing domains": {
+			&route.VirtualHost{
+				Name:    "foo",
+				Domains: nil,
+			},
+		},
+		"empty domain": {
+			&route.VirtualHost{
+				Name:    "foo",
+				Domains: []string{"foo.example.com", "", "bar.example.com"},
+			},
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			var cc virtualHostCache
+			cc.Add(tc.vh)
+			got := cc.Values()
+			want := []route.VirtualHost{}
+			if !reflect.DeepEqual(got, want) {
+				t.Fatalf("VirtualHostCache.Add/Values accepted invalid VirtualHost, got: %v, want: %v", got, want)
+			}
+		})
+	}
+}
+
+func TestVirtualHostCacheIngnoreElementsWithBlankDomains(t *testing.T) {
+	var cc virtualHostCache
+	c1 := &route.VirtualHost{
+		Name: "alpha",
+	}
+	cc.Add(c1)
+	got := cc.Values()
+	want := []route.VirtualHost{}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("VirtualHostCache.Add/Values accepted invalid VirtualHost, got: %v, want: %v", got, want)
+	}
+}
+
 func TestVirtualHostCacheAddIsCopyOnWrite(t *testing.T) {
 	var cc virtualHostCache
 	c1 := &route.VirtualHost{


### PR DESCRIPTION
Fixes #257

Ensure that blank VirtualHost entries are not added to the cache. This
should prevent them making their way through to Envoy.