### PR TITLE
Implemented status / Refactored distribution logic

### DIFF
--- a/cmd/contour/contour.go
+++ b/cmd/contour/contour.go
@@ -47,9 +47,6 @@ func init() {
 
 func main() {
 	log := logrus.StandardLogger()
-	t := &contour.Translator{
-		FieldLogger: log.WithField("context", "translator"),
-	}
 
 	app := kingpin.New("contour", "Heptio Contour Kubernetes ingress controller.")
 	bootstrap := app.Command("bootstrap", "Generate bootstrap configuration.")
@@ -66,6 +63,13 @@ func main() {
 	kubeconfig := serve.Flag("kubeconfig", "path to kubeconfig (if not in running inside a cluster)").Default(filepath.Join(os.Getenv("HOME"), ".kube", "config")).String()
 	xdsAddr := serve.Flag("xds-address", "xDS gRPC API address").Default("127.0.0.1").String()
 	xdsPort := serve.Flag("xds-port", "xDS gRPC API port").Default("8001").Int()
+
+	kubeclient, contourClient := newClient(*kubeconfig, *inCluster)
+
+	t := &contour.Translator{
+		FieldLogger:   log.WithField("context", "translator"),
+		ContourClient: contourClient,
+	}
 
 	// translator configuration
 	serve.Flag("envoy-http-address", "Envoy HTTP listener address").StringVar(&t.HTTPAddress)
@@ -88,13 +92,11 @@ func main() {
 		// buffer notifications to t to ensure they are handled sequentially.
 		buf := k8s.NewBuffer(&g, t, log, 128)
 
-		client, contourClient := newClient(*kubeconfig, *inCluster)
-
 		wl := log.WithField("context", "watch")
-		k8s.WatchServices(&g, client, wl, buf)
-		k8s.WatchEndpoints(&g, client, wl, buf)
-		k8s.WatchIngress(&g, client, wl, buf)
-		k8s.WatchSecrets(&g, client, wl, buf)
+		k8s.WatchServices(&g, kubeclient, wl, buf)
+		k8s.WatchEndpoints(&g, kubeclient, wl, buf)
+		k8s.WatchIngress(&g, kubeclient, wl, buf)
+		k8s.WatchSecrets(&g, kubeclient, wl, buf)
 		k8s.WatchRoutes(&g, contourClient, wl, buf)
 
 		g.Add(func(stop <-chan struct{}) {

--- a/internal/contour/translator.go
+++ b/internal/contour/translator.go
@@ -286,7 +286,7 @@ func (t *Translator) updateRouteStatus(status k8s.RouteStatus) error {
 	if err != nil {
 		return err
 	}
-	_, err = client.Patch(updated.Name, types.StrategicMergePatchType, patchBytes)
+	_, err = client.Patch(updated.Name, types.MergePatchType, patchBytes)
 	return err
 }
 

--- a/internal/contour/translator.go
+++ b/internal/contour/translator.go
@@ -20,14 +20,21 @@ import (
 	"crypto/sha256"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 	v1alpha1 "github.com/heptio/contour/pkg/apis/contour/v1alpha1"
 	"github.com/sirupsen/logrus"
 
+	"encoding/json"
+
+	"github.com/heptio/contour/internal/k8s"
+	clientset "github.com/heptio/contour/pkg/generated/clientset/versioned"
 	"k8s.io/api/core/v1"
 	"k8s.io/api/extensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/strategicpatch"
 	"k8s.io/client-go/tools/cache"
 )
 
@@ -48,6 +55,8 @@ type Translator struct {
 	VirtualHostCache
 
 	cache translatorCache
+
+	ContourClient clientset.Interface
 }
 
 func (t *Translator) OnAdd(obj interface{}) {
@@ -228,7 +237,15 @@ func (t *Translator) addRoute(r *v1alpha1.Route) {
 		host = "*"
 	}
 
-	t.recomputevhostcrd(host, t.cache.vhostscrd[host])
+	routeStatus := t.recomputevhostcrd(host, t.cache.vhostscrd[host])
+
+	for _, r := range routeStatus {
+
+		err := t.updateRouteStatus(r)
+		if err != nil {
+			t.FieldLogger.Infof("Error updating status: ", err)
+		}
+	}
 }
 
 func (t *Translator) removeRoute(r *v1alpha1.Route) {
@@ -244,6 +261,33 @@ func (t *Translator) removeRoute(r *v1alpha1.Route) {
 	}
 
 	t.recomputevhostcrd(host, t.cache.vhostscrd[host])
+}
+
+// updateRouteStatus updated the Status of the Route CRD
+func (t *Translator) updateRouteStatus(status k8s.RouteStatus) error {
+	client := t.ContourClient.ContourV1alpha1().Routes(status.Namespace)
+	existing, err := client.Get(status.RouteName, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+	existingBytes, err := json.Marshal(existing)
+	if err != nil {
+		return err
+	}
+
+	updated := existing.DeepCopy()
+	updated.Status.CurrentStatus = status.StatusMessage
+	updated.Status.LastProcessTime = time.Now().UTC().String()
+	updatedBytes, err := json.Marshal(updated)
+	if err != nil {
+		return err
+	}
+	patchBytes, err := strategicpatch.CreateTwoWayMergePatch(existingBytes, updatedBytes, v1alpha1.Route{})
+	if err != nil {
+		return err
+	}
+	_, err = client.Patch(updated.Name, types.StrategicMergePatchType, patchBytes)
+	return err
 }
 
 type translatorCache struct {

--- a/internal/contour/virtualhost_test.go
+++ b/internal/contour/virtualhost_test.go
@@ -611,9 +611,12 @@ func TestVirtualHostCacheRecomputevhostCRD(t *testing.T) {
 										{
 											Name: "default/backend/80",
 											Weight: &google_protobuf1.UInt32Value{
-												Value: uint32(100),
+												Value: uint32(1),
 											},
 										},
+									},
+									TotalWeight: &google_protobuf1.UInt32Value{
+										Value: uint32(1),
 									},
 								},
 							},
@@ -658,9 +661,12 @@ func TestVirtualHostCacheRecomputevhostCRD(t *testing.T) {
 										{
 											Name: "default/httpbin-org/80",
 											Weight: &google_protobuf1.UInt32Value{
-												Value: uint32(100),
+												Value: uint32(1),
 											},
 										},
+									},
+									TotalWeight: &google_protobuf1.UInt32Value{
+										Value: uint32(1),
 									},
 								},
 							},
@@ -714,9 +720,12 @@ func TestVirtualHostCacheRecomputevhostCRD(t *testing.T) {
 										{
 											Name: "default/peter/80",
 											Weight: &google_protobuf1.UInt32Value{
-												Value: uint32(100),
+												Value: uint32(1),
 											},
 										},
+									},
+									TotalWeight: &google_protobuf1.UInt32Value{
+										Value: uint32(1),
 									},
 								},
 							},
@@ -732,9 +741,12 @@ func TestVirtualHostCacheRecomputevhostCRD(t *testing.T) {
 										{
 											Name: "default/paul/80",
 											Weight: &google_protobuf1.UInt32Value{
-												Value: uint32(100),
+												Value: uint32(1),
 											},
 										},
+									},
+									TotalWeight: &google_protobuf1.UInt32Value{
+										Value: uint32(1),
 									},
 								},
 							},
@@ -779,9 +791,12 @@ func TestVirtualHostCacheRecomputevhostCRD(t *testing.T) {
 										{
 											Name: "default/my-service-name/80",
 											Weight: &google_protobuf1.UInt32Value{
-												Value: uint32(100),
+												Value: uint32(1),
 											},
 										},
+									},
+									TotalWeight: &google_protobuf1.UInt32Value{
+										Value: uint32(1),
 									},
 								},
 							},
@@ -846,9 +861,12 @@ func TestVirtualHostCacheRecomputevhostCRD(t *testing.T) {
 										{
 											Name: "kube-system/admin/80",
 											Weight: &google_protobuf1.UInt32Value{
-												Value: uint32(100),
+												Value: uint32(1),
 											},
 										},
+									},
+									TotalWeight: &google_protobuf1.UInt32Value{
+										Value: uint32(1),
 									},
 								},
 							},
@@ -864,9 +882,12 @@ func TestVirtualHostCacheRecomputevhostCRD(t *testing.T) {
 										{
 											Name: "default/default/80",
 											Weight: &google_protobuf1.UInt32Value{
-												Value: uint32(100),
+												Value: uint32(1),
 											},
 										},
+									},
+									TotalWeight: &google_protobuf1.UInt32Value{
+										Value: uint32(1),
 									},
 								},
 							},
@@ -910,9 +931,12 @@ func TestVirtualHostCacheRecomputevhostCRD(t *testing.T) {
 										{
 											Name: "default/hello/80",
 											Weight: &google_protobuf1.UInt32Value{
-												Value: uint32(100),
+												Value: uint32(1),
 											},
 										},
+									},
+									TotalWeight: &google_protobuf1.UInt32Value{
+										Value: uint32(1),
 									},
 								},
 							},
@@ -961,15 +985,18 @@ func TestVirtualHostCacheRecomputevhostCRD(t *testing.T) {
 										{
 											Name: "default/httpbin-org/80",
 											Weight: &google_protobuf1.UInt32Value{
-												Value: uint32(50),
+												Value: uint32(1),
 											},
 										},
 										{
 											Name: "default/foo-org/8001",
 											Weight: &google_protobuf1.UInt32Value{
-												Value: uint32(50),
+												Value: uint32(1),
 											},
 										},
+									},
+									TotalWeight: &google_protobuf1.UInt32Value{
+										Value: uint32(2),
 									},
 								},
 							},
@@ -1025,9 +1052,12 @@ func TestVirtualHostCacheRecomputevhostCRD(t *testing.T) {
 										{
 											Name: "default/foo-org/8001",
 											Weight: &google_protobuf1.UInt32Value{
-												Value: uint32(67),
+												Value: uint32(0),
 											},
 										},
+									},
+									TotalWeight: &google_protobuf1.UInt32Value{
+										Value: uint32(33),
 									},
 								},
 							},
@@ -1088,6 +1118,9 @@ func TestVirtualHostCacheRecomputevhostCRD(t *testing.T) {
 											},
 										},
 									},
+									TotalWeight: &google_protobuf1.UInt32Value{
+										Value: uint32(66),
+									},
 								},
 							},
 						},
@@ -1112,7 +1145,6 @@ func TestVirtualHostCacheRecomputevhostCRD(t *testing.T) {
 								{
 									ServiceName: "httpbin-org",
 									ServicePort: 80,
-									Weight:      func(i int) *int { return &i }(33),
 								},
 								{
 									ServiceName: "foo-org",
@@ -1122,6 +1154,7 @@ func TestVirtualHostCacheRecomputevhostCRD(t *testing.T) {
 								{
 									ServiceName: "bar-org",
 									ServicePort: 8001,
+									Weight:      func(i int) *int { return &i }(33),
 								},
 							},
 						},
@@ -1141,7 +1174,7 @@ func TestVirtualHostCacheRecomputevhostCRD(t *testing.T) {
 										{
 											Name: "default/httpbin-org/80",
 											Weight: &google_protobuf1.UInt32Value{
-												Value: uint32(33),
+												Value: uint32(0),
 											},
 										},
 										{
@@ -1153,9 +1186,12 @@ func TestVirtualHostCacheRecomputevhostCRD(t *testing.T) {
 										{
 											Name: "default/bar-org/8001",
 											Weight: &google_protobuf1.UInt32Value{
-												Value: uint32(65),
+												Value: uint32(33),
 											},
 										},
+									},
+									TotalWeight: &google_protobuf1.UInt32Value{
+										Value: uint32(35),
 									},
 								},
 							},

--- a/internal/k8s/routeStatus.go
+++ b/internal/k8s/routeStatus.go
@@ -1,0 +1,26 @@
+// Copyright © 2018 Heptio
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package k8s
+
+// RouteStatus is the details of the status of a route
+type RouteStatus struct {
+	// Name of the RouteCRD
+	RouteName string
+	// Namespace the CRD exists within
+	Namespace string
+	// Status message to show on CRD
+	StatusMessage string
+	// Internal error generated
+	Error error
+}


### PR DESCRIPTION
This updates the upstream distribution logic to:

1. Enable CRD weights
2. If no weights are defined, then they are evenly distributed
3. If some weights are defined, then those that aren't are left at zero weight
4. Status fields are now updated

Signed-off-by: Steve Sloka <steves@heptio.com>