### PR TITLE
Upgrade to Envoy v1.6.0

### DIFF
--- a/deployment/deployment-grpc-v2/02-contour.yaml
+++ b/deployment/deployment-grpc-v2/02-contour.yaml
@@ -21,7 +21,7 @@ spec:
         prometheus.io/format: "prometheus"
     spec:
       containers:
-      - image: docker.io/envoyproxy/envoy-alpine:e6ff690611b8a3373f6d66066b52d613873e446e
+      - image: docker.io/envoyproxy/envoy-alpine:v1.6.0
         name: envoy
         ports:
         - containerPort: 8080

--- a/deployment/ds-grpc-v2/02-contour.yaml
+++ b/deployment/ds-grpc-v2/02-contour.yaml
@@ -22,7 +22,7 @@ spec:
         prometheus.io/format: "prometheus"
     spec:
       containers:
-      - image: docker.io/envoyproxy/envoy-alpine:e6ff690611b8a3373f6d66066b52d613873e446e
+      - image: docker.io/envoyproxy/envoy-alpine:v1.6.0
         name: envoy
         ports:
         - containerPort: 8080

--- a/deployment/ds-hostnet/02-contour.yaml
+++ b/deployment/ds-hostnet/02-contour.yaml
@@ -23,7 +23,7 @@ spec:
     spec:
       hostNetwork: true
       containers:
-      - image: docker.io/envoyproxy/envoy-alpine:e6ff690611b8a3373f6d66066b52d613873e446e
+      - image: docker.io/envoyproxy/envoy-alpine:v1.6.0
         name: envoy
         ports:
         - containerPort: 8080

--- a/deployment/render/daemonset-norbac.yaml
+++ b/deployment/render/daemonset-norbac.yaml
@@ -36,7 +36,7 @@ spec:
         prometheus.io/format: "prometheus"
     spec:
       containers:
-      - image: docker.io/envoyproxy/envoy-alpine:e6ff690611b8a3373f6d66066b52d613873e446e
+      - image: docker.io/envoyproxy/envoy-alpine:v1.6.0
         name: envoy
         ports:
         - containerPort: 8080

--- a/deployment/render/daemonset-rbac.yaml
+++ b/deployment/render/daemonset-rbac.yaml
@@ -36,7 +36,7 @@ spec:
         prometheus.io/format: "prometheus"
     spec:
       containers:
-      - image: docker.io/envoyproxy/envoy-alpine:e6ff690611b8a3373f6d66066b52d613873e446e
+      - image: docker.io/envoyproxy/envoy-alpine:v1.6.0
         name: envoy
         ports:
         - containerPort: 8080

--- a/deployment/render/deployment-norbac.yaml
+++ b/deployment/render/deployment-norbac.yaml
@@ -35,7 +35,7 @@ spec:
         prometheus.io/format: "prometheus"
     spec:
       containers:
-      - image: docker.io/envoyproxy/envoy-alpine:e6ff690611b8a3373f6d66066b52d613873e446e
+      - image: docker.io/envoyproxy/envoy-alpine:v1.6.0
         name: envoy
         ports:
         - containerPort: 8080

--- a/deployment/render/deployment-rbac.yaml
+++ b/deployment/render/deployment-rbac.yaml
@@ -35,7 +35,7 @@ spec:
         prometheus.io/format: "prometheus"
     spec:
       containers:
-      - image: docker.io/envoyproxy/envoy-alpine:e6ff690611b8a3373f6d66066b52d613873e446e
+      - image: docker.io/envoyproxy/envoy-alpine:v1.6.0
         name: envoy
         ports:
         - containerPort: 8080


### PR DESCRIPTION
Envoy v1.6.0 has been released: https://github.com/envoyproxy/envoy/releases/tag/v1.6.0

Closes #280 