### PR TITLE
Makefile: add vet step to check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ test: install
 vet: | test
 	go vet ./...
 
-check: test vet
+check: | test vet
 	@echo Checking code is gofmted
 	@bash -c 'if [ -n "$(gofmt -s -l .)" ]; then echo "Go code is not formatted:"; gofmt -s -d -e .; exit 1;fi'
 	@echo Checking rendered files are up to date

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,10 @@
 test: install
 	go test ./...
 
-check: test
+vet: | test
+	go vet ./...
+
+check: test vet
 	@echo Checking code is gofmted
 	@bash -c 'if [ -n "$(gofmt -s -l .)" ]; then echo "Go code is not formatted:"; gofmt -s -d -e .; exit 1;fi'
 	@echo Checking rendered files are up to date

--- a/internal/contour/example_test.go
+++ b/internal/contour/example_test.go
@@ -22,7 +22,8 @@ import (
 )
 
 func ExampleCond() {
-	ctx, _ := context.WithTimeout(context.Background(), 1*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
 	ch := make(chan int, 1)
 	last := 0
 	var c contour.Cond

--- a/internal/contour/listener_test.go
+++ b/internal/contour/listener_test.go
@@ -28,7 +28,7 @@ import (
 )
 
 func TestRecomputeListener(t *testing.T) {
-	tests := map[string]struct {
+	tests := map[string]*struct {
 		ingresses map[metadata]*v1beta1.Ingress
 		add       []*v2.Listener
 		remove    []string
@@ -146,7 +146,7 @@ func TestRecomputeListener(t *testing.T) {
 }
 
 func TestRecomputeTLSListener(t *testing.T) {
-	tests := map[string]struct {
+	tests := map[string]*struct {
 		ingresses map[metadata]*v1beta1.Ingress
 		secrets   map[metadata]*v1.Secret
 		add       []*v2.Listener

--- a/internal/grpc/grpc_test.go
+++ b/internal/grpc/grpc_test.go
@@ -120,7 +120,8 @@ func TestGRPCStreaming(t *testing.T) {
 			cc := newClient(t)
 			defer cc.Close()
 			lds := v2.NewListenerDiscoveryServiceClient(cc)
-			ctx, _ := context.WithTimeout(context.Background(), 100*time.Millisecond)
+			ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+			defer cancel()
 			stream, err := lds.StreamListeners(ctx)
 			check(t, err)
 			checktimeout(t, stream) // check that the first receive times out, there is no default listener
@@ -147,7 +148,8 @@ func TestGRPCStreaming(t *testing.T) {
 					}},
 				},
 			})
-			ctx, _ = context.WithTimeout(context.Background(), 100*time.Millisecond)
+			ctx, cancel = context.WithTimeout(context.Background(), 100*time.Millisecond)
+			defer cancel()
 			stream, err = lds.StreamListeners(ctx)
 			check(t, err)
 			checkrecv(t, stream) // check we receive one notification


### PR DESCRIPTION
Always run go vet ./... as part of CI.

Address current crop of vet issues.

Signed-off-by: Dave Cheney <dave@cheney.net>