### PR TITLE
gopkg.toml: pin google.golang.org/grpc to version 1.10.0

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -369,8 +369,8 @@
     "tap",
     "transport"
   ]
-  revision = "d11072e7ca9811b1100b80ca0269ac831f06d024"
-  version = "v1.11.3"
+  revision = "8e4536a86ab602859c20df5ebfd0bd4228d08655"
+  version = "v1.10.0"
 
 [[projects]]
   name = "gopkg.in/alecthomas/kingpin.v2"
@@ -539,6 +539,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "e03b207fad9aef0d607df0f317143734b9f50311bf585a4a76b39dec3155a3c1"
+  inputs-digest = "2d83c88fd630d759268929519d4bdabf27489d03a78f8f68b5a48340b06032ff"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -13,3 +13,7 @@
 [[constraint]]
   name = "github.com/sirupsen/logrus"
   version = "^1.0.5"
+
+[[constraint]]
+  name = "google.golang.org/grpc"
+  version = "=v1.10.0"


### PR DESCRIPTION
Updates #327

Pin grpc library to v1.10.0 (was 1.11.3) to revert the test flakes since #321.

Signed-off-by: Dave Cheney <dave@cheney.net>