### PR TITLE
internal/grpc: wait for request before responding

### DIFF
--- a/cmd/contour/contour.go
+++ b/cmd/contour/contour.go
@@ -87,16 +87,16 @@ func main() {
 		writeBootstrapConfig(&config, *path)
 	case cds.FullCommand():
 		stream := client.ClusterStream()
-		watchstream(stream)
+		watchstream(stream, clusterType)
 	case eds.FullCommand():
 		stream := client.EndpointStream()
-		watchstream(stream)
+		watchstream(stream, endpointType)
 	case lds.FullCommand():
 		stream := client.ListenerStream()
-		watchstream(stream)
+		watchstream(stream, listenerType)
 	case rds.FullCommand():
 		stream := client.RouteStream()
-		watchstream(stream)
+		watchstream(stream, routeType)
 	case serve.FullCommand():
 		log.Infof("args: %v", args)
 		var g workgroup.Group

--- a/internal/e2e/cds_test.go
+++ b/internal/e2e/cds_test.go
@@ -484,7 +484,9 @@ func fetchCDS(t *testing.T, cc *grpc.ClientConn) *v2.DiscoveryResponse {
 	ctx := context.Background()
 	ctx, cancel := context.WithTimeout(ctx, 100*time.Millisecond)
 	defer cancel()
-	resp, err := rds.FetchClusters(ctx, new(v2.DiscoveryRequest))
+	resp, err := rds.FetchClusters(ctx, &v2.DiscoveryRequest{
+		TypeUrl: clusterType,
+	})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/e2e/eds_test.go
+++ b/internal/e2e/eds_test.go
@@ -164,7 +164,9 @@ func fetchEDS(t *testing.T, cc *grpc.ClientConn) *v2.DiscoveryResponse {
 	ctx := context.Background()
 	ctx, cancel := context.WithTimeout(ctx, 100*time.Millisecond)
 	defer cancel()
-	resp, err := rds.FetchEndpoints(ctx, new(v2.DiscoveryRequest))
+	resp, err := rds.FetchEndpoints(ctx, &v2.DiscoveryRequest{
+		TypeUrl: endpointType,
+	})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/e2e/lds_test.go
+++ b/internal/e2e/lds_test.go
@@ -249,7 +249,9 @@ func fetchLDS(t *testing.T, cc *grpc.ClientConn) *v2.DiscoveryResponse {
 	ctx := context.Background()
 	ctx, cancel := context.WithTimeout(ctx, 100*time.Millisecond)
 	defer cancel()
-	resp, err := rds.FetchListeners(ctx, new(v2.DiscoveryRequest))
+	resp, err := rds.FetchListeners(ctx, &v2.DiscoveryRequest{
+		TypeUrl: listenerType,
+	})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/e2e/rds_test.go
+++ b/internal/e2e/rds_test.go
@@ -722,7 +722,9 @@ func fetchRDS(t *testing.T, cc *grpc.ClientConn) *v2.DiscoveryResponse {
 	ctx := context.Background()
 	ctx, cancel := context.WithTimeout(ctx, 100*time.Millisecond)
 	defer cancel()
-	resp, err := rds.FetchRoutes(ctx, new(v2.DiscoveryRequest))
+	resp, err := rds.FetchRoutes(ctx, &v2.DiscoveryRequest{
+		TypeUrl: routeType,
+	})
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Updates #273, #277

This PR improves the xDS protocol support in Contour. Contour now waits
for an DiscoveryRequest before responding.

In plumbing DiscoveryRequest down a few more layers this has removed
some custom loggers and provided access to the ResourceName needed for #277.

Signed-off-by: Dave Cheney <dave@cheney.net>