### PR TITLE
internal/grpc: filter stream requests by DiscoveryRequest.ResourceNames

### DIFF
--- a/internal/contour/cache.go
+++ b/internal/contour/cache.go
@@ -46,7 +46,7 @@ func (c *cache) remove(name string) {
 }
 
 // Values returns a slice of the value stored in the cache.
-func (c *cache) Values() []proto.Message {
+func (c *cache) Values(filter func(string) bool) []proto.Message {
 	c.mu.Lock()
 	values := make([]proto.Message, 0, len(c.entries))
 	for _, v := range c.entries {

--- a/internal/contour/cluster_test.go
+++ b/internal/contour/cluster_test.go
@@ -312,7 +312,7 @@ func TestClusterCacheRecomputeService(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			var cc ClusterCache
 			cc.recomputeService(tc.oldObj, tc.newObj)
-			got := cc.Values()
+			got := contents(&cc)
 			sort.Stable(clusterByName(got))
 			if !reflect.DeepEqual(tc.want, got) {
 				t.Fatalf("expected:\n%v\ngot:\n%v\n", tc.want, got)

--- a/internal/contour/clusterloadassignment_test.go
+++ b/internal/contour/clusterloadassignment_test.go
@@ -79,7 +79,7 @@ func TestClusterLoadAssignmentCacheRecomputeClusterLoadAssignment(t *testing.T) 
 		t.Run(name, func(t *testing.T) {
 			var cc ClusterLoadAssignmentCache
 			cc.recomputeClusterLoadAssignment(tc.oldep, tc.newep)
-			got := cc.Values()
+			got := contents(&cc)
 			sort.Stable(clusterLoadAssignmentsByName(got))
 			if !reflect.DeepEqual(tc.want, got) {
 				t.Fatalf("expected:\n%v\ngot:\n%v", tc.want, got)

--- a/internal/contour/listener_test.go
+++ b/internal/contour/listener_test.go
@@ -557,15 +557,15 @@ func TestValidTLSIngress(t *testing.T) {
 
 func assertCacheEmpty(t *testing.T, lc *ListenerCache) {
 	t.Helper()
-	if len(lc.Values()) > 0 {
-		t.Fatalf("len(lc.values): expected 0, got %d", len(lc.Values()))
+	if len(contents(lc)) > 0 {
+		t.Fatalf("len(lc.values): expected 0, got %d", len(contents(lc)))
 	}
 }
 
 func assertCacheNotEmpty(t *testing.T, lc *ListenerCache) {
 	t.Helper()
-	if len(lc.Values()) == 0 {
-		t.Fatalf("len(lc.values): expected > 0, got %d", len(lc.Values()))
+	if len(contents(lc)) == 0 {
+		t.Fatalf("len(lc.values): expected > 0, got %d", len(contents(lc)))
 	}
 }
 

--- a/internal/contour/translator_test.go
+++ b/internal/contour/translator_test.go
@@ -125,7 +125,7 @@ func TestTranslatorAddService(t *testing.T) {
 				FieldLogger: log,
 			}
 			tr.OnAdd(tc.svc)
-			got := tr.ClusterCache.Values()
+			got := contents(&tr.ClusterCache)
 			sort.Stable(clusterByName(got))
 			if !reflect.DeepEqual(tc.want, got) {
 				t.Fatalf("\nwant: %v\n got: %v", tc.want, got)
@@ -195,7 +195,7 @@ func TestTranslatorUpdateService(t *testing.T) {
 			}
 			tr.OnAdd(tc.oldObj)
 			tr.OnUpdate(tc.oldObj, tc.newObj)
-			got := tr.ClusterCache.Values()
+			got := contents(&tr.ClusterCache)
 			sort.Stable(clusterByName(got))
 			if !reflect.DeepEqual(tc.want, got) {
 				t.Fatalf("\nwant: %v\n got: %v", tc.want, got)
@@ -278,7 +278,7 @@ func TestTranslatorRemoveService(t *testing.T) {
 			}
 			tc.setup(tr)
 			tr.OnDelete(tc.svc)
-			got := tr.ClusterCache.Values()
+			got := contents(&tr.ClusterCache)
 			sort.Stable(clusterByName(got))
 			if !reflect.DeepEqual(tc.want, got) {
 				t.Fatalf("\nwant: %v\n got: %v", tc.want, got)
@@ -341,7 +341,7 @@ func TestTranslatorAddEndpoints(t *testing.T) {
 			}
 			tr.OnAdd(tc.svc)
 			tr.OnAdd(tc.ep)
-			got := tr.ClusterLoadAssignmentCache.Values()
+			got := contents(&tr.ClusterLoadAssignmentCache)
 			sort.Stable(clusterLoadAssignmentsByName(got))
 			if !reflect.DeepEqual(tc.want, got) {
 				t.Fatalf("got: %v, want: %v", got, tc.want)
@@ -456,7 +456,7 @@ func TestTranslatorRemoveEndpoints(t *testing.T) {
 			}
 			tc.setup(tr)
 			tr.OnDelete(tc.ep)
-			got := tr.ClusterLoadAssignmentCache.Values()
+			got := contents(&tr.ClusterLoadAssignmentCache)
 			sort.Stable(clusterLoadAssignmentsByName(got))
 			if !reflect.DeepEqual(tc.want, got) {
 				t.Fatalf("\nwant: %v\n got: %v", tc.want, got)
@@ -1116,13 +1116,13 @@ func TestTranslatorAddIngress(t *testing.T) {
 				tc.setup(tr)
 			}
 			tr.OnAdd(tc.ing)
-			got := tr.VirtualHostCache.HTTP.Values()
+			got := contents(&tr.VirtualHostCache.HTTP)
 			sort.Stable(virtualHostsByName(got))
 			if !reflect.DeepEqual(tc.ingress_http, got) {
 				t.Fatalf("(ingress_http) want:\n%v\n got:\n%v", tc.ingress_http, got)
 			}
 
-			got = tr.VirtualHostCache.HTTPS.Values()
+			got = contents(&tr.VirtualHostCache.HTTPS)
 			sort.Stable(virtualHostsByName(got))
 			if !reflect.DeepEqual(tc.ingress_https, got) {
 				t.Fatalf("(ingress_https) want:\n%v\n got:\n%v", tc.ingress_https, got)
@@ -1199,13 +1199,13 @@ func TestTranslatorUpdateIngress(t *testing.T) {
 			}
 			tr.OnAdd(tc.before)
 			tr.OnUpdate(tc.before, tc.after)
-			got := tr.VirtualHostCache.HTTP.Values()
+			got := contents(&tr.VirtualHostCache.HTTP)
 			sort.Stable(virtualHostsByName(got))
 			if !reflect.DeepEqual(tc.ingress_http, got) {
 				t.Fatalf("(ingress_http): got: %v, want: %v", got, tc.ingress_http)
 			}
 
-			got = tr.VirtualHostCache.HTTPS.Values()
+			got = contents(&tr.VirtualHostCache.HTTPS)
 			sort.Stable(virtualHostsByName(got))
 			if !reflect.DeepEqual(tc.ingress_https, got) {
 				t.Fatalf("(ingress_https): got: %v, want: %v", got, tc.ingress_https)
@@ -1314,13 +1314,13 @@ func TestTranslatorRemoveIngress(t *testing.T) {
 			}
 			tc.setup(tr)
 			tr.OnDelete(tc.ing)
-			got := tr.VirtualHostCache.HTTP.Values()
+			got := contents(&tr.VirtualHostCache.HTTP)
 			sort.Stable(virtualHostsByName(got))
 			if !reflect.DeepEqual(tc.ingress_http, got) {
 				t.Fatalf("(ingress_http): got: %v, want: %v", got, tc.ingress_http)
 			}
 
-			got = tr.VirtualHostCache.HTTPS.Values()
+			got = contents(&tr.VirtualHostCache.HTTPS)
 			sort.Stable(virtualHostsByName(got))
 			if !reflect.DeepEqual(tc.ingress_https, got) {
 				t.Fatalf("(ingress_https): got: %v, want: %v", got, tc.ingress_https)
@@ -2274,4 +2274,10 @@ type testWriter struct {
 func (t *testWriter) Write(buf []byte) (int, error) {
 	t.Logf("%s", buf)
 	return len(buf), nil
+}
+
+func contents(v interface {
+	Values(func(string) bool) []proto.Message
+}) []proto.Message {
+	return v.Values(func(string) bool { return true })
 }

--- a/internal/contour/virtualhost_test.go
+++ b/internal/contour/virtualhost_test.go
@@ -583,13 +583,13 @@ func TestVirtualHostCacheRecomputevhost(t *testing.T) {
 				FieldLogger: log,
 			}
 			tr.recomputevhost(tc.vhost, tc.ingresses)
-			got := tr.VirtualHostCache.HTTP.Values()
+			got := contents(&tr.VirtualHostCache.HTTP)
 			sort.Stable(virtualHostsByName(got))
 			if !reflect.DeepEqual(tc.ingress_http, got) {
 				t.Fatalf("recomputevhost(%v):\n (ingress_http) want:\n%+v\n got:\n%+v", tc.vhost, tc.ingress_http, got)
 			}
 
-			got = tr.VirtualHostCache.HTTPS.Values()
+			got = contents(&tr.VirtualHostCache.HTTPS)
 			sort.Stable(virtualHostsByName(got))
 			if !reflect.DeepEqual(tc.ingress_https, got) {
 				t.Fatalf("recomputevhost(%v):\n (ingress_https) want:\n%#v\ngot:\n%#v", tc.vhost, tc.ingress_https, got)

--- a/internal/grpc/resources.go
+++ b/internal/grpc/resources.go
@@ -50,7 +50,7 @@ type CDS struct {
 }
 
 // Values returns a sorted list of Clusters.
-func (c *CDS) Values() []proto.Message {
+func (c *CDS) Values(filter func(string) bool) []proto.Message {
 	v := c.cache.Values()
 	sort.Stable(clusterByName(v))
 	return v
@@ -70,7 +70,7 @@ type EDS struct {
 }
 
 // Values returns a sorted list of ClusterLoadAssignments.
-func (e *EDS) Values() []proto.Message {
+func (e *EDS) Values(filter func(string) bool) []proto.Message {
 	v := e.cache.Values()
 	sort.Stable(clusterLoadAssignmentsByName(v))
 	return v
@@ -92,7 +92,7 @@ type LDS struct {
 }
 
 // Values returns a sorted list of Listeners.
-func (l *LDS) Values() []proto.Message {
+func (l *LDS) Values(filter func(string) bool) []proto.Message {
 	v := l.cache.Values()
 	sort.Stable(listenersByName(v))
 	return v
@@ -119,7 +119,7 @@ type RDS struct {
 }
 
 // Values returns a sorted list of RouteConfigurations.
-func (r *RDS) Values() []proto.Message {
+func (r *RDS) Values(filter func(string) bool) []proto.Message {
 	// TODO(dfc) avoid this expensive sort
 	toRouteVirtualHosts := func(ms []proto.Message) []route.VirtualHost {
 		r := make([]route.VirtualHost, 0, len(ms))

--- a/internal/grpc/resources.go
+++ b/internal/grpc/resources.go
@@ -20,7 +20,6 @@ import (
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
 
 	"github.com/gogo/protobuf/proto"
-	"github.com/gogo/protobuf/types"
 	"github.com/heptio/contour/internal/contour"
 )
 
@@ -50,20 +49,6 @@ type CDS struct {
 	cache
 }
 
-// Resources returns the contents of CDS"s cache as a []types.Any.
-func (c *CDS) Resources() ([]types.Any, error) {
-	v := c.Values()
-	resources := make([]types.Any, len(v))
-	for i := range v {
-		value, err := proto.Marshal(v[i])
-		if err != nil {
-			return nil, err
-		}
-		resources[i] = types.Any{TypeUrl: c.TypeURL(), Value: value}
-	}
-	return resources, nil
-}
-
 // Values returns a sorted list of Clusters.
 func (c *CDS) Values() []proto.Message {
 	v := c.cache.Values()
@@ -82,20 +67,6 @@ func (c clusterByName) Less(i, j int) bool { return c[i].(*v2.Cluster).Name < c[
 // EDS implements the EDS v2 gRPC API.
 type EDS struct {
 	cache
-}
-
-// Resources returns the contents of EDS"s cache as a []types.Any.
-func (e *EDS) Resources() ([]types.Any, error) {
-	v := e.Values()
-	resources := make([]types.Any, len(v))
-	for i := range v {
-		value, err := proto.Marshal(v[i])
-		if err != nil {
-			return nil, err
-		}
-		resources[i] = types.Any{TypeUrl: e.TypeURL(), Value: value}
-	}
-	return resources, nil
 }
 
 // Values returns a sorted list of ClusterLoadAssignments.
@@ -118,20 +89,6 @@ func (c clusterLoadAssignmentsByName) Less(i, j int) bool {
 // LDS implements the LDS v2 gRPC API.
 type LDS struct {
 	cache
-}
-
-// Resources returns the contents of LDS"s cache as a []types.Any.
-func (l *LDS) Resources() ([]types.Any, error) {
-	v := l.Values()
-	resources := make([]types.Any, len(v))
-	for i := range v {
-		value, err := proto.Marshal(v[i])
-		if err != nil {
-			return nil, err
-		}
-		resources[i] = types.Any{TypeUrl: l.TypeURL(), Value: value}
-	}
-	return resources, nil
 }
 
 // Values returns a sorted list of Listeners.
@@ -159,20 +116,6 @@ type RDS struct {
 		Values() []proto.Message
 	}
 	*contour.Cond
-}
-
-// Resources returns the contents of RDS"s cache as a []types.Any.
-func (r *RDS) Resources() ([]types.Any, error) {
-	v := r.Values()
-	resources := make([]types.Any, len(v))
-	for i := range v {
-		value, err := proto.Marshal(v[i])
-		if err != nil {
-			return nil, err
-		}
-		resources[i] = types.Any{TypeUrl: r.TypeURL(), Value: value}
-	}
-	return resources, nil
 }
 
 // Values returns a sorted list of RouteConfigurations.

--- a/internal/grpc/resources.go
+++ b/internal/grpc/resources.go
@@ -51,11 +51,8 @@ type CDS struct {
 }
 
 // Resources returns the contents of CDS"s cache as a []types.Any.
-// TODO(dfc) cache the results of Resources in the ClusterCache so
-// we can avoid the error handling.
 func (c *CDS) Resources() ([]types.Any, error) {
 	v := c.Values()
-	sort.Stable(clusterByName(v))
 	resources := make([]types.Any, len(v))
 	for i := range v {
 		value, err := proto.Marshal(v[i])
@@ -65,6 +62,13 @@ func (c *CDS) Resources() ([]types.Any, error) {
 		resources[i] = types.Any{TypeUrl: c.TypeURL(), Value: value}
 	}
 	return resources, nil
+}
+
+// Values returns a sorted list of Clusters.
+func (c *CDS) Values() []proto.Message {
+	v := c.cache.Values()
+	sort.Stable(clusterByName(v))
+	return v
 }
 
 func (c *CDS) TypeURL() string { return clusterType }
@@ -81,11 +85,8 @@ type EDS struct {
 }
 
 // Resources returns the contents of EDS"s cache as a []types.Any.
-// TODO(dfc) cache the results of Resources in the ClusterLoadAssignmentCache so
-// we can avoid the error handling.
 func (e *EDS) Resources() ([]types.Any, error) {
 	v := e.Values()
-	sort.Stable(clusterLoadAssignmentsByName(v))
 	resources := make([]types.Any, len(v))
 	for i := range v {
 		value, err := proto.Marshal(v[i])
@@ -95,6 +96,13 @@ func (e *EDS) Resources() ([]types.Any, error) {
 		resources[i] = types.Any{TypeUrl: e.TypeURL(), Value: value}
 	}
 	return resources, nil
+}
+
+// Values returns a sorted list of ClusterLoadAssignments.
+func (e *EDS) Values() []proto.Message {
+	v := e.cache.Values()
+	sort.Stable(clusterLoadAssignmentsByName(v))
+	return v
 }
 
 func (e *EDS) TypeURL() string { return endpointType }
@@ -113,11 +121,8 @@ type LDS struct {
 }
 
 // Resources returns the contents of LDS"s cache as a []types.Any.
-// TODO(dfc) cache the results of Resources in the ListenerCache so
-// we can avoid the error handling.
 func (l *LDS) Resources() ([]types.Any, error) {
 	v := l.Values()
-	sort.Stable(listenersByName(v))
 	resources := make([]types.Any, len(v))
 	for i := range v {
 		value, err := proto.Marshal(v[i])
@@ -127,6 +132,13 @@ func (l *LDS) Resources() ([]types.Any, error) {
 		resources[i] = types.Any{TypeUrl: l.TypeURL(), Value: value}
 	}
 	return resources, nil
+}
+
+// Values returns a sorted list of Listeners.
+func (l *LDS) Values() []proto.Message {
+	v := l.cache.Values()
+	sort.Stable(listenersByName(v))
+	return v
 }
 
 func (l *LDS) TypeURL() string { return listenerType }
@@ -150,8 +162,6 @@ type RDS struct {
 }
 
 // Resources returns the contents of RDS"s cache as a []types.Any.
-// TODO(dfc) cache the results of Resources in the VirtualHostCache so
-// we can avoid the error handling.
 func (r *RDS) Resources() ([]types.Any, error) {
 	v := r.Values()
 	resources := make([]types.Any, len(v))
@@ -165,6 +175,7 @@ func (r *RDS) Resources() ([]types.Any, error) {
 	return resources, nil
 }
 
+// Values returns a sorted list of RouteConfigurations.
 func (r *RDS) Values() []proto.Message {
 	// TODO(dfc) avoid this expensive sort
 	toRouteVirtualHosts := func(ms []proto.Message) []route.VirtualHost {

--- a/internal/grpc/server.go
+++ b/internal/grpc/server.go
@@ -58,14 +58,14 @@ func NewAPI(log logrus.FieldLogger, t *contour.Translator) *grpc.Server {
 
 type grpcServer struct {
 	logrus.FieldLogger
-	count     uint64               // connection count, incremented atomically
-	resources map[string]resourcer // registered resource types
+	count     uint64              // connection count, incremented atomically
+	resources map[string]resource // registered resource types
 }
 
 func newgrpcServer(log logrus.FieldLogger, t *contour.Translator) *grpcServer {
 	return &grpcServer{
 		FieldLogger: log,
-		resources: map[string]resourcer{
+		resources: map[string]resource{
 			clusterType: &CDS{
 				cache: &t.ClusterCache,
 			},
@@ -84,10 +84,16 @@ func newgrpcServer(log logrus.FieldLogger, t *contour.Translator) *grpcServer {
 	}
 }
 
-// A resourcer provides resources formatted as []types.Any.
-type resourcer interface {
-	Values() []proto.Message
+// A resource provides resources formatted as []types.Any.
+type resource interface {
+	// Values returns a slice of proto.Message implementations that match
+	// the provided filter.
+	Values(func(string) bool) []proto.Message
+
+	// TypeURL returns the typeURL of messages returned from Values.
 	TypeURL() string
+
+	// Register registers the channel for change notifications.
 	Register(chan int, int)
 }
 
@@ -112,9 +118,10 @@ func (s *grpcServer) fetch(req *v2.DiscoveryRequest) (*v2.DiscoveryResponse, err
 	s.WithField("connection", atomic.AddUint64(&s.count, 1)).WithField("version_info", req.VersionInfo).WithField("resource_names", req.ResourceNames).WithField("type_url", req.TypeUrl).WithField("response_nonce", req.ResponseNonce).WithField("error_detail", req.ErrorDetail).Info("fetch")
 	r, ok := s.resources[req.TypeUrl]
 	if !ok {
-		return nil, fmt.Errorf("no resourcer registered for typeURL %q", req.TypeUrl)
+		return nil, fmt.Errorf("no resource registered for typeURL %q", req.TypeUrl)
 	}
-	resources, err := toAny(r)
+	filter := func(string) bool { return true }
+	resources, err := toAny(r, filter)
 	return &v2.DiscoveryResponse{
 		VersionInfo: "0",
 		Resources:   resources,
@@ -170,14 +177,15 @@ func (s *grpcServer) stream(st grpcStream) (err error) {
 		}
 		r, ok := s.resources[req.TypeUrl]
 		if !ok {
-			return fmt.Errorf("no resourcer registered for typeURL %q", req.TypeUrl)
+			return fmt.Errorf("no resource registered for typeURL %q", req.TypeUrl)
 		}
 		log.WithField("version_info", req.VersionInfo).WithField("resource_names", req.ResourceNames).WithField("type_url", req.TypeUrl).WithField("response_nonce", req.ResponseNonce).WithField("error_detail", req.ErrorDetail).Info("stream_wait")
 
 		r.Register(ch, last)
 		select {
 		case last = <-ch:
-			resources, err := toAny(r)
+			filter := func(string) bool { return true }
+			resources, err := toAny(r, filter)
 			if err != nil {
 				return err
 			}
@@ -198,8 +206,8 @@ func (s *grpcServer) stream(st grpcStream) (err error) {
 
 // toAny converts the contens of a resourcer's Values to the
 // respective slice of types.Any.
-func toAny(res resourcer) ([]types.Any, error) {
-	v := res.Values()
+func toAny(res resource, filter func(string) bool) ([]types.Any, error) {
+	v := res.Values(filter)
 	resources := make([]types.Any, len(v))
 	for i := range v {
 		value, err := proto.Marshal(v[i])

--- a/internal/grpc/server.go
+++ b/internal/grpc/server.go
@@ -86,15 +86,10 @@ func newgrpcServer(log logrus.FieldLogger, t *contour.Translator) *grpcServer {
 
 // A resource provides resources formatted as []types.Any.
 type resource interface {
-	// Values returns a slice of proto.Message implementations that match
-	// the provided filter.
-	Values(func(string) bool) []proto.Message
+	cache
 
 	// TypeURL returns the typeURL of messages returned from Values.
 	TypeURL() string
-
-	// Register registers the channel for change notifications.
-	Register(chan int, int)
 }
 
 func (s *grpcServer) FetchClusters(_ context.Context, req *v2.DiscoveryRequest) (*v2.DiscoveryResponse, error) {

--- a/internal/grpc/server.go
+++ b/internal/grpc/server.go
@@ -26,7 +26,6 @@ import (
 	envoy_service_v2 "github.com/envoyproxy/go-control-plane/envoy/service/load_stats/v2"
 	"github.com/sirupsen/logrus"
 
-	"github.com/gogo/protobuf/proto"
 	"github.com/gogo/protobuf/types"
 	"github.com/heptio/contour/internal/contour"
 )
@@ -35,36 +34,6 @@ const (
 	// somewhat arbitrary limit to handle many, many, EDS streams
 	grpcMaxConcurrentStreams = 1 << 20
 )
-
-// ClusterCache holds a set of computed v2.Cluster resources.
-type ClusterCache interface {
-	// Values returns a copy of the contents of the cache.
-	// The slice and its contents should be treated as read-only.
-	Values() []proto.Message
-
-	// Register registers ch to receive a value when Notify is called.
-	Register(chan int, int)
-}
-
-// ClusterLoadAssignmentCache holds a set of computed v2.ClusterLoadAssignment resources.
-type ClusterLoadAssignmentCache interface {
-	// Values returns a copy of the contents of the cache.
-	// The slice and its contents should be treated as read-only.
-	Values() []proto.Message
-
-	// Register registers ch to receive a value when Notify is called.
-	Register(chan int, int)
-}
-
-// ListenerCache holds a set of computed v2.Listener resources.
-type ListenerCache interface {
-	// Values returns a copy of the contents of the cache.
-	// The slice and its contents should be treated as read-only.
-	Values() []proto.Message
-
-	// Register registers ch to receive a value when Notify is called.
-	Register(chan int, int)
-}
 
 // NewAPI returns a *grpc.Server which responds to the Envoy v2 xDS gRPC API.
 func NewAPI(log logrus.FieldLogger, t *contour.Translator) *grpc.Server {
@@ -97,13 +66,13 @@ func newgrpcServer(log logrus.FieldLogger, t *contour.Translator) *grpcServer {
 		FieldLogger: log,
 		resources: map[string]resourcer{
 			clusterType: &CDS{
-				ClusterCache: &t.ClusterCache,
+				cache: &t.ClusterCache,
 			},
 			endpointType: &EDS{
-				ClusterLoadAssignmentCache: &t.ClusterLoadAssignmentCache,
+				cache: &t.ClusterLoadAssignmentCache,
 			},
 			listenerType: &LDS{
-				ListenerCache: &t.ListenerCache,
+				cache: &t.ListenerCache,
 			},
 			routeType: &RDS{
 				HTTP:  &t.VirtualHostCache.HTTP,

--- a/internal/grpc/server.go
+++ b/internal/grpc/server.go
@@ -139,7 +139,7 @@ func (s *grpcServer) StreamEndpoints(srv v2.EndpointDiscoveryService_StreamEndpo
 }
 
 func (s *grpcServer) StreamLoadStats(srv envoy_service_v2.LoadReportingService_StreamLoadStatsServer) error {
-	return grpc.Errorf(codes.Unimplemented, "FetchListeners Unimplemented")
+	return grpc.Errorf(codes.Unimplemented, "StreamLoadStats Unimplemented")
 }
 
 func (s *grpcServer) StreamListeners(srv v2.ListenerDiscoveryService_StreamListenersServer) error {
@@ -217,4 +217,18 @@ func toAny(res resource, filter func(string) bool) ([]types.Any, error) {
 		resources[i] = types.Any{TypeUrl: res.TypeURL(), Value: value}
 	}
 	return resources, nil
+}
+
+// toFilter converts a slice of strings into a filter function.
+// If the slice is empty, then a filter function that matches everything
+// is returned.
+func toFilter(names []string) func(string) bool {
+	if len(names) == 0 {
+		return func(string) bool { return true }
+	}
+	m := make(map[string]bool)
+	for _, n := range names {
+		m[n] = true
+	}
+	return func(name string) bool { return m[name] }
 }


### PR DESCRIPTION
Updates #277 

This PR creates the scaffolding to allow Stream listeners to filter the resources sent back to them on the Contour side using a filter function constructed from the DiscoverRequest.ResourceName slice (or match everything if the slice is empty).

Currently the filters are not applied at the contour/cache level, but once they are resources presented to the grpc layer will be filtered by ResourceNames. This will also mean, if no events match the filter provided, then the update can be skipped. This will be the subject of a later PR.