### PR TITLE
Add targets to build and push containers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,10 @@
+PROJECT = contour
+REGISTRY ?= gcr.io/heptio-images
+IMAGE := $(REGISTRY)/$(PROJECT)
+
+GIT_REF = $(shell git rev-parse --short=8 --verify HEAD)
+VERSION ?= $(GIT_REF)
+
 test: install
 	go test ./...
 
@@ -13,3 +20,13 @@ check: | test vet
 install:
 	go install -v -tags "oidc gcp" ./...
 
+container:
+	docker build . -t $(IMAGE):$(VERSION)
+
+push: container
+	docker push $(IMAGE):$(VERSION)
+	@if git describe --tags --exact-match >/dev/null 2>&1; \
+	then \
+		docker tag $(IMAGE):$(VERSION) $(IMAGE):latest; \
+		docker push $(IMAGE):latest; \
+	fi


### PR DESCRIPTION
This PR adds some pretty basic targets for building and pushing docker images and should make this process a bit more straight forward.

By default they build an image with the version set to the truncated commit SHA. If we are building a tagged release we also tag the image `latest`.

Signed-off-by: Curt Micol <asenchi@heptio.com>