### PR TITLE
Enable statsd metric output

### DIFF
--- a/cmd/contour/contour.go
+++ b/cmd/contour/contour.go
@@ -58,6 +58,9 @@ func main() {
 	bootstrap.Flag("admin-port", "Envoy admin interface port").IntVar(&config.AdminPort)
 	bootstrap.Flag("xds-address", "xDS gRPC API address").StringVar(&config.XDSAddress)
 	bootstrap.Flag("xds-port", "xDS gRPC API port").IntVar(&config.XDSGRPCPort)
+	bootstrap.Flag("statsd-enabled", "enable statsd output").BoolVar(&config.StatsdEnabled)
+	bootstrap.Flag("statsd-address", "statsd address").StringVar(&config.StatsdAddress)
+	bootstrap.Flag("statsd-port", "statsd port").IntVar(&config.StatsdPort)
 
 	cli := app.Command("cli", "A CLI client for the Heptio Contour Kubernetes ingress controller.")
 	var client Client

--- a/internal/envoy/config.go
+++ b/internal/envoy/config.go
@@ -48,6 +48,18 @@ type ConfigWriter struct {
 	// XDSGRPCPort is the management server port that provides the v2 gRPC API.
 	// Defaults to 8001.
 	XDSGRPCPort int
+
+	// StatsdEnabled enables metrics output via statsd
+	// Defaults to false.
+	StatsdEnabled bool
+
+	// StatsdAddress is the UDP address of the statsd endpoint
+	// Defaults to 127.0.0.1.
+	StatsdAddress string
+
+	// StatsdPort is port of the statsd endpoint
+	// Defaults to 9125.
+	StatsdPort int
 }
 
 const yamlConfig = `dynamic_resources:
@@ -87,7 +99,15 @@ static_resources:
           max_connections: 100000
           max_pending_requests: 100000
           max_requests: 60000000
-          max_retries: 50
+          max_retries: 50{{ if .StatsdEnabled }}
+stats_sinks:
+  - name: envoy.statsd
+    config:
+      address:
+        socket_address:
+          protocol: UDP
+          address: {{ if .StatsdAddress }}{{ .StatsdAddress }}{{ else }}127.0.0.1{{ end }}
+          port_value: {{ if .StatsdPort }}{{ .StatsdPort }}{{ else }}9125{{ end }}{{ end }}
 admin:
   access_log_path: {{ if .AdminAccessLogPath }}{{ .AdminAccessLogPath }}{{ else }}/dev/null{{ end }}
   address:


### PR DESCRIPTION
This enables statsd metric output. The end goal is to add the [statsd exporter](https://github.com/prometheus/statsd_exporter) to allow Prometheus to scrape for metrics and add Histogram support since it's not included natively in Envoy. 

Signed-off-by: Steve Sloka <steves@heptio.com>