### PR TITLE
cmd/contour: moving flag.Parse out of init()

### DIFF
--- a/cmd/contour/contour.go
+++ b/cmd/contour/contour.go
@@ -36,13 +36,6 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-// this is necessary due to #113 wherein glog neccessitates a call to flag.Parse
-// before any logging statements can be invoked. (See also https://github.com/golang/glog/blob/master/glog.go#L679)
-// unsure why this seemingly unnecessary prerequisite is in place but there must be some sane reason.
-func init() {
-	flag.Parse()
-}
-
 func main() {
 	log := logrus.StandardLogger()
 	t := &contour.Translator{
@@ -122,6 +115,13 @@ func main() {
 
 		// buffer notifications to t to ensure they are handled sequentially.
 		buf := k8s.NewBuffer(&g, t, log, 128)
+
+		// client-go uses glog which requires initialisation as a side effect of calling
+		// flag.Parse (see #118 and https://github.com/golang/glog/blob/master/glog.go#L679)
+		// However, kingpin owns our flag parsing, so we defer calling flag.Parse until
+		// this point to avoid the Go flag package from rejecting flags which are defined
+		// in kingpin. See #371
+		flag.Parse()
 
 		client := newClient(*kubeconfig, *inCluster)
 


### PR DESCRIPTION
Fixes #371 

This must be done as glog requires flag.Parse before being used by anything else for logging purposes. However, doing this before any flags are defined with kingpin will override our flags, thus flag.Parse must be called after our kingpin calls, but before creating a new client.

Signed-off-by: David Muckle <dvdmuckle@dvdmuckle.xyz>