### PR TITLE
Expose /stats from customizable port

### DIFF
--- a/cmd/contour/contour.go
+++ b/cmd/contour/contour.go
@@ -56,6 +56,8 @@ func main() {
 	path := bootstrap.Arg("path", "Configuration file.").Required().String()
 	bootstrap.Flag("admin-address", "Envoy admin interface address").StringVar(&config.AdminAddress)
 	bootstrap.Flag("admin-port", "Envoy admin interface port").IntVar(&config.AdminPort)
+	bootstrap.Flag("stats-address", "Envoy /stats interface address").IntVar(&config.StatsAddress)
+	bootstrap.Flag("stats-port", "Envoy /stats interface port").IntVar(&config.StatsPort)
 	bootstrap.Flag("xds-address", "xDS gRPC API address").StringVar(&config.XDSAddress)
 	bootstrap.Flag("xds-port", "xDS gRPC API port").IntVar(&config.XDSGRPCPort)
 	bootstrap.Flag("statsd-enabled", "enable statsd output").BoolVar(&config.StatsdEnabled)

--- a/internal/envoy/config_test.go
+++ b/internal/envoy/config_test.go
@@ -64,6 +64,40 @@ static_resources:
           max_pending_requests: 100000
           max_requests: 60000000
           max_retries: 50
+  - name: service_stats
+    connect_timeout: 0.250s
+    type: LOGICAL_DNS
+    lb_policy: ROUND_ROBIN
+    hosts:
+      - socket_address:
+          protocol: TCP
+          address: 127.0.0.1
+          port_value: 9001
+  listeners:
+    - address:
+        socket_address:
+          protocol: TCP
+          address: 0.0.0.0 
+          port_value: 8001
+      filter_chains:
+        - filters:
+            - name: envoy.http_connection_manager
+              config:
+                codec_type: AUTO
+                stat_prefix: ingress_http
+                route_config:
+                  virtual_hosts:
+                    - name: backend
+                      domains:
+                        - "*"
+                      routes:
+                        - match:
+                            prefix: /stats
+                          route:
+                            cluster: service_stats
+                http_filters:
+                  - name: envoy.router
+                    config:
 admin:
   access_log_path: /dev/null
   address:


### PR DESCRIPTION
Creating a static route for `/stats` on an interface over port `:8001` and restricting access to other admin functionality from being exposed. 

Signed-off-by: Steve Sloka <steves@heptio.com>