### PR TITLE
cmd/contour: move envoy's stats listener to port 8002

### DIFF
--- a/internal/envoy/config.go
+++ b/internal/envoy/config.go
@@ -40,7 +40,7 @@ type ConfigWriter struct {
 	StatsAddress int
 
 	// StatsPort is the port that the /stats path will listen on.
-	// Defaults to 8001.
+	// Defaults to 8002.
 	StatsPort int
 
 	// XDSAddress is the TCP address of the XDS management server. For JSON configurations
@@ -122,7 +122,7 @@ static_resources:
         socket_address:
           protocol: TCP
           address: {{ if .StatsAddress }}{{ .StatsAddress }}{{ else }}0.0.0.0{{ end }} 
-          port_value: {{ if .StatsPort }}{{ .StatsPort }}{{ else }}8001{{ end }}
+          port_value: {{ if .StatsPort }}{{ .StatsPort }}{{ else }}8002{{ end }}
       filter_chains:
         - filters:
             - name: envoy.http_connection_manager

--- a/internal/envoy/config_test.go
+++ b/internal/envoy/config_test.go
@@ -78,7 +78,7 @@ static_resources:
         socket_address:
           protocol: TCP
           address: 0.0.0.0 
-          port_value: 8001
+          port_value: 8002
       filter_chains:
         - filters:
             - name: envoy.http_connection_manager


### PR DESCRIPTION
Port 8001 is used by contour, when envoy and contour are colated in a
single pod, this causes a port conflict with the stats listener iff
envoy starts before contour (the owernship rules between binding to
0.0.0.0 and 127.0.0.1 are somewhat opaque)

Move the stats listener to 8002.

Signed-off-by: Dave Cheney <dave@cheney.net>