### PR TITLE
internal/envoy: omit statsd listener and cluster unless enabled

### DIFF
--- a/internal/envoy/config.go
+++ b/internal/envoy/config.go
@@ -36,7 +36,7 @@ type ConfigWriter struct {
 	AdminPort int
 
 	// StatsAddress is the address that the /stats path will listen on.
-	// Defaults to 127.0.0.1 and is only enabled if StatsdEnabled is true.
+	// Defaults to 0.0.0.0 and is only enabled if StatsdEnabled is true.
 	StatsAddress int
 
 	// StatsPort is the port that the /stats path will listen on.
@@ -121,7 +121,7 @@ static_resources:
     - address:
         socket_address:
           protocol: TCP
-          address: {{ if .StatsAddress }}{{ .StatsAddress }}{{ else }}127.0.0.1{{ end }} 
+          address: {{ if .StatsAddress }}{{ .StatsAddress }}{{ else }}0.0.0.0{{ end }}
           port_value: {{ if .StatsPort }}{{ .StatsPort }}{{ else }}8002{{ end }}
       filter_chains:
         - filters:

--- a/internal/envoy/config_test.go
+++ b/internal/envoy/config_test.go
@@ -135,7 +135,7 @@ static_resources:
     - address:
         socket_address:
           protocol: TCP
-          address: 127.0.0.1 
+          address: 0.0.0.0
           port_value: 8002
       filter_chains:
         - filters:


### PR DESCRIPTION
Updates #376

Omit the statsd listener and cluster unless its enabled.

Also:

- bind the stats listener to 127.0.0.1 by default, which matches the
statsd collector which is also listening on 127.0.0.1.
- add tests for enabled and disabled configurations

Signed-off-by: Dave Cheney <dave@cheney.net>