### PR TITLE
Add domain alias host:port on vhost create

### DIFF
--- a/internal/contour/translator_test.go
+++ b/internal/contour/translator_test.go
@@ -601,7 +601,7 @@ func TestTranslatorAddIngress(t *testing.T) {
 		ingress_http: []proto.Message{
 			&route.VirtualHost{
 				Name:    "httpbin.org",
-				Domains: []string{"httpbin.org"},
+				Domains: []string{"httpbin.org", "httpbin.org:80"},
 				Routes: []route.Route{{
 					Match:  prefixmatch("/"), // match all
 					Action: clusteraction("default/httpbin-org/80"),
@@ -633,7 +633,7 @@ func TestTranslatorAddIngress(t *testing.T) {
 		ingress_http: []proto.Message{
 			&route.VirtualHost{
 				Name:    "httpbin.org",
-				Domains: []string{"httpbin.org"},
+				Domains: []string{"httpbin.org", "httpbin.org:80"},
 				Routes: []route.Route{{
 					Match:  prefixmatch("/ip"), // if the field does not contact any regex characters, we treat it as a prefix
 					Action: clusteraction("default/httpbin-org/80"),
@@ -665,7 +665,7 @@ func TestTranslatorAddIngress(t *testing.T) {
 		ingress_http: []proto.Message{
 			&route.VirtualHost{
 				Name:    "httpbin.org",
-				Domains: []string{"httpbin.org"},
+				Domains: []string{"httpbin.org", "httpbin.org:80"},
 				Routes: []route.Route{{
 					Match:  regexmatch("/get.*"),
 					Action: clusteraction("default/httpbin-org/80"),
@@ -690,7 +690,7 @@ func TestTranslatorAddIngress(t *testing.T) {
 		ingress_http: []proto.Message{
 			&route.VirtualHost{
 				Name:    "httpbin.org",
-				Domains: []string{"httpbin.org"},
+				Domains: []string{"httpbin.org", "httpbin.org:80"},
 				Routes: []route.Route{{
 					Match:  prefixmatch("/"),
 					Action: clusteraction("default/httpbin-org/http"),
@@ -725,7 +725,7 @@ func TestTranslatorAddIngress(t *testing.T) {
 		ingress_http: []proto.Message{
 			&route.VirtualHost{
 				Name:    "httpbin.org",
-				Domains: []string{"httpbin.org"},
+				Domains: []string{"httpbin.org", "httpbin.org:80"},
 				Routes: []route.Route{{
 					Match:  prefixmatch("/peter"),
 					Action: clusteraction("default/peter/80"),
@@ -760,14 +760,14 @@ func TestTranslatorAddIngress(t *testing.T) {
 		ingress_http: []proto.Message{
 			&route.VirtualHost{
 				Name:    "admin.httpbin.org",
-				Domains: []string{"admin.httpbin.org"},
+				Domains: []string{"admin.httpbin.org", "admin.httpbin.org:80"},
 				Routes: []route.Route{{
 					Match:  prefixmatch("/"),
 					Action: clusteraction("default/paul/paul"),
 				}},
 			}, &route.VirtualHost{
 				Name:    "httpbin.org",
-				Domains: []string{"httpbin.org"},
+				Domains: []string{"httpbin.org", "httpbin.org:80"},
 				Routes: []route.Route{{
 					Match:  prefixmatch("/"),
 					Action: clusteraction("default/peter/80"),
@@ -777,7 +777,7 @@ func TestTranslatorAddIngress(t *testing.T) {
 		ingress_https: []proto.Message{
 			&route.VirtualHost{
 				Name:    "admin.httpbin.org",
-				Domains: []string{"admin.httpbin.org"},
+				Domains: []string{"admin.httpbin.org", "admin.httpbin.org:443"},
 				Routes: []route.Route{{
 					Match:  prefixmatch("/"),
 					Action: clusteraction("default/paul/paul"),
@@ -812,7 +812,7 @@ func TestTranslatorAddIngress(t *testing.T) {
 		ingress_https: []proto.Message{
 			&route.VirtualHost{
 				Name:    "admin.httpbin.org",
-				Domains: []string{"admin.httpbin.org"},
+				Domains: []string{"admin.httpbin.org", "admin.httpbin.org:443"},
 				Routes: []route.Route{{
 					Match:  prefixmatch("/"),
 					Action: clusteraction("default/paul/paul"),
@@ -836,7 +836,7 @@ func TestTranslatorAddIngress(t *testing.T) {
 		ingress_http: []proto.Message{
 			&route.VirtualHost{
 				Name:    "d31bb322ca62bb395acad00b3cbf45a3aa1010ca28dca7cddb4f7db786fa",
-				Domains: []string{"my-very-very-long-service-host-name.subdomain.boring-dept.my.company"},
+				Domains: []string{"my-very-very-long-service-host-name.subdomain.boring-dept.my.company", "my-very-very-long-service-host-name.subdomain.boring-dept.my.company:80"},
 				Routes: []route.Route{{
 					Match:  prefixmatch("/"),
 					Action: clusteraction("default/my-service-name/80"),
@@ -889,7 +889,7 @@ func TestTranslatorAddIngress(t *testing.T) {
 		ingress_http: []proto.Message{
 			&route.VirtualHost{
 				Name:    "httpbin.org",
-				Domains: []string{"httpbin.org"},
+				Domains: []string{"httpbin.org", "httpbin.org:80"},
 				Routes: []route.Route{{
 					Match:  prefixmatch("/admin"),
 					Action: clusteraction("kube-system/admin/admin"),
@@ -976,7 +976,7 @@ func TestTranslatorAddIngress(t *testing.T) {
 		ingress_http: []proto.Message{
 			&route.VirtualHost{
 				Name:    "httpbin.davecheney.com",
-				Domains: []string{"httpbin.davecheney.com"},
+				Domains: []string{"httpbin.davecheney.com", "httpbin.davecheney.com:80"},
 				Routes: []route.Route{{
 					Match:  prefixmatch("/.well-known/acme-challenge"),
 					Action: clusteraction("kube-lego/kube-lego-nginx/8080"),
@@ -986,7 +986,7 @@ func TestTranslatorAddIngress(t *testing.T) {
 				}},
 			}, &route.VirtualHost{
 				Name:    "httpbin2.davecheney.com",
-				Domains: []string{"httpbin2.davecheney.com"},
+				Domains: []string{"httpbin2.davecheney.com", "httpbin2.davecheney.com:80"},
 				Routes: []route.Route{{
 					Match:  prefixmatch("/.well-known/acme-challenge"),
 					Action: clusteraction("kube-lego/kube-lego-nginx/8080"),
@@ -1182,7 +1182,7 @@ func TestTranslatorUpdateIngress(t *testing.T) {
 			ingress_http: []proto.Message{
 				&route.VirtualHost{
 					Name:    "kuard.db.gd-ms.com",
-					Domains: []string{"kuard.db.gd-ms.com"},
+					Domains: []string{"kuard.db.gd-ms.com", "kuard.db.gd-ms.com:80"},
 					Routes: []route.Route{{
 						Match:  prefixmatch("/"), // match all
 						Action: clusteraction("default/kuard/80"),
@@ -1283,7 +1283,7 @@ func TestTranslatorRemoveIngress(t *testing.T) {
 			ingress_http: []proto.Message{
 				&route.VirtualHost{
 					Name:    "httpbin.org",
-					Domains: []string{"httpbin.org"},
+					Domains: []string{"httpbin.org", "httpbin.org:80"},
 					Routes: []route.Route{{
 						Match:  prefixmatch("/"),
 						Action: clusteraction("default/peter/80"),
@@ -1677,7 +1677,7 @@ func TestTranslatorAddIngressRoute(t *testing.T) {
 			ingress_http: []proto.Message{
 				&route.VirtualHost{
 					Name:    "foo.bar",
-					Domains: []string{"foo.bar"},
+					Domains: []string{"foo.bar", "foo.bar:80"},
 					Routes: []route.Route{{
 						Match: prefixmatch("/"),
 						Action: &route.Route_Route{
@@ -1728,7 +1728,7 @@ func TestTranslatorAddIngressRoute(t *testing.T) {
 			ingress_http: []proto.Message{
 				&route.VirtualHost{
 					Name:    "foo.bar",
-					Domains: []string{"foo.bar"},
+					Domains: []string{"foo.bar", "foo.bar:80"},
 					Routes: []route.Route{{
 						Match: prefixmatch("/zed"),
 						Action: &route.Route_Route{
@@ -1788,7 +1788,7 @@ func TestTranslatorAddIngressRoute(t *testing.T) {
 			ingress_http: []proto.Message{
 				&route.VirtualHost{
 					Name:    "foo.bar",
-					Domains: []string{"foo.bar"},
+					Domains: []string{"foo.bar", "foo.bar:80"},
 					Routes: []route.Route{{
 						Match: prefixmatch("/zed"),
 						Action: &route.Route_Route{
@@ -3062,7 +3062,7 @@ func TestTranslatorRemoveIngressRoute(t *testing.T) {
 			ingress_http: []proto.Message{
 				&route.VirtualHost{
 					Name:    "httpbin.org",
-					Domains: []string{"httpbin.org"},
+					Domains: []string{"httpbin.org", "httpbin.org:80"},
 					Routes: []route.Route{{
 						Match: prefixmatch("/"),
 						Action: &route.Route_Route{

--- a/internal/contour/virtualhost_test.go
+++ b/internal/contour/virtualhost_test.go
@@ -82,7 +82,7 @@ func TestVirtualHostCacheRecomputevhost(t *testing.T) {
 			ingress_http: []proto.Message{
 				&route.VirtualHost{
 					Name:    "httpbin.org",
-					Domains: []string{"httpbin.org"},
+					Domains: []string{"httpbin.org", "httpbin.org:80"},
 					Routes: []route.Route{{
 						Match:  prefixmatch("/"), // match all
 						Action: clusteraction("default/httpbin-org/80"),
@@ -112,7 +112,7 @@ func TestVirtualHostCacheRecomputevhost(t *testing.T) {
 			ingress_http: []proto.Message{
 				&route.VirtualHost{
 					Name:    "httpbin.org",
-					Domains: []string{"httpbin.org"},
+					Domains: []string{"httpbin.org", "httpbin.org:80"},
 					Routes: []route.Route{{
 						Match:  prefixmatch("/"), // match all
 						Action: clusteraction("default/httpbin-org/80"),
@@ -122,7 +122,7 @@ func TestVirtualHostCacheRecomputevhost(t *testing.T) {
 			ingress_https: []proto.Message{
 				&route.VirtualHost{
 					Name:    "httpbin.org",
-					Domains: []string{"httpbin.org"},
+					Domains: []string{"httpbin.org", "httpbin.org:443"},
 					Routes: []route.Route{{
 						Match:  prefixmatch("/"), // match all
 						Action: clusteraction("default/httpbin-org/80"),
@@ -155,7 +155,7 @@ func TestVirtualHostCacheRecomputevhost(t *testing.T) {
 			ingress_https: []proto.Message{
 				&route.VirtualHost{
 					Name:    "httpbin.org",
-					Domains: []string{"httpbin.org"},
+					Domains: []string{"httpbin.org", "httpbin.org:443"},
 					Routes: []route.Route{{
 						Match:  prefixmatch("/"), // match all
 						Action: clusteraction("default/httpbin-org/80"),
@@ -187,7 +187,7 @@ func TestVirtualHostCacheRecomputevhost(t *testing.T) {
 			ingress_http: []proto.Message{
 				&route.VirtualHost{
 					Name:    "httpbin.org",
-					Domains: []string{"httpbin.org"},
+					Domains: []string{"httpbin.org", "httpbin.org:80"},
 					Routes: []route.Route{{
 						Match:  prefixmatch("/"), // match all
 						Action: redirecthttps(),
@@ -197,7 +197,7 @@ func TestVirtualHostCacheRecomputevhost(t *testing.T) {
 			ingress_https: []proto.Message{
 				&route.VirtualHost{
 					Name:    "httpbin.org",
-					Domains: []string{"httpbin.org"},
+					Domains: []string{"httpbin.org", "httpbin.org:443"},
 					Routes: []route.Route{{
 						Match:  prefixmatch("/"), // match all
 						Action: clusteraction("default/httpbin-org/80"),
@@ -229,7 +229,7 @@ func TestVirtualHostCacheRecomputevhost(t *testing.T) {
 			ingress_http: []proto.Message{
 				&route.VirtualHost{
 					Name:    "httpbin.org",
-					Domains: []string{"httpbin.org"},
+					Domains: []string{"httpbin.org", "httpbin.org:80"},
 					Routes: []route.Route{{
 						Match:  prefixmatch("/ip"), // if the field does not contact any regex characters, we treat it as a prefix
 						Action: clusteraction("default/httpbin-org/80"),
@@ -262,7 +262,7 @@ func TestVirtualHostCacheRecomputevhost(t *testing.T) {
 			ingress_http: []proto.Message{
 				&route.VirtualHost{
 					Name:    "httpbin.org",
-					Domains: []string{"httpbin.org"},
+					Domains: []string{"httpbin.org", "httpbin.org:80"},
 					Routes: []route.Route{{
 						Match:  regexmatch("/get.*"),
 						Action: clusteraction("default/httpbin-org/80"),
@@ -288,7 +288,7 @@ func TestVirtualHostCacheRecomputevhost(t *testing.T) {
 			ingress_http: []proto.Message{
 				&route.VirtualHost{
 					Name:    "httpbin.org",
-					Domains: []string{"httpbin.org"},
+					Domains: []string{"httpbin.org", "httpbin.org:80"},
 					Routes: []route.Route{{
 						Match:  prefixmatch("/"),
 						Action: clusteraction("default/httpbin-org/http"),
@@ -324,7 +324,7 @@ func TestVirtualHostCacheRecomputevhost(t *testing.T) {
 			ingress_http: []proto.Message{
 				&route.VirtualHost{
 					Name:    "httpbin.org",
-					Domains: []string{"httpbin.org"},
+					Domains: []string{"httpbin.org", "httpbin.org:80"},
 					Routes: []route.Route{{
 						Match:  prefixmatch("/peter"),
 						Action: clusteraction("default/peter/80"),
@@ -356,7 +356,7 @@ func TestVirtualHostCacheRecomputevhost(t *testing.T) {
 			ingress_http: []proto.Message{
 				&route.VirtualHost{
 					Name:    "httpbin.org",
-					Domains: []string{"httpbin.org"},
+					Domains: []string{"httpbin.org", "httpbin.org:80"},
 					Routes: []route.Route{{
 						Match:  prefixmatch("/"),
 						Action: clusteraction("default/peter/80"),
@@ -385,7 +385,7 @@ func TestVirtualHostCacheRecomputevhost(t *testing.T) {
 			ingress_http: []proto.Message{
 				&route.VirtualHost{
 					Name:    "admin.httpbin.org",
-					Domains: []string{"admin.httpbin.org"},
+					Domains: []string{"admin.httpbin.org", "admin.httpbin.org:80"},
 					Routes: []route.Route{{
 						Match:  prefixmatch("/"),
 						Action: clusteraction("default/paul/paul"),
@@ -411,7 +411,7 @@ func TestVirtualHostCacheRecomputevhost(t *testing.T) {
 			ingress_http: []proto.Message{
 				&route.VirtualHost{
 					Name:    "d31bb322ca62bb395acad00b3cbf45a3aa1010ca28dca7cddb4f7db786fa",
-					Domains: []string{"my-very-very-long-service-host-name.subdomain.boring-dept.my.company"},
+					Domains: []string{"my-very-very-long-service-host-name.subdomain.boring-dept.my.company", "my-very-very-long-service-host-name.subdomain.boring-dept.my.company:80"},
 					Routes: []route.Route{{
 						Match:  prefixmatch("/"),
 						Action: clusteraction("default/my-service-name/80"),
@@ -462,7 +462,7 @@ func TestVirtualHostCacheRecomputevhost(t *testing.T) {
 			ingress_http: []proto.Message{
 				&route.VirtualHost{
 					Name:    "httpbin.org",
-					Domains: []string{"httpbin.org"},
+					Domains: []string{"httpbin.org", "httpbin.org:80"},
 					Routes: []route.Route{{
 						Match:  prefixmatch("/admin"),
 						Action: clusteraction("kube-system/admin/admin"),
@@ -528,7 +528,7 @@ func TestVirtualHostCacheRecomputevhost(t *testing.T) {
 			ingress_http: []proto.Message{
 				&route.VirtualHost{
 					Name:    "httpbin.davecheney.com",
-					Domains: []string{"httpbin.davecheney.com"},
+					Domains: []string{"httpbin.davecheney.com", "httpbin.davecheney.com:80"},
 					Routes: []route.Route{{
 						Match:  prefixmatch("/.well-known/acme-challenge"),
 						Action: clusteraction("kube-lego/kube-lego-nginx/8080"),
@@ -602,7 +602,7 @@ func TestVirtualHostCacheRecomputevhost(t *testing.T) {
 			ingress_http: []proto.Message{
 				&route.VirtualHost{
 					Name:    "echo.websocket.org",
-					Domains: []string{"echo.websocket.org"},
+					Domains: []string{"echo.websocket.org", "echo.websocket.org:80"},
 					Routes: []route.Route{{
 						Match:  prefixmatch("/ws1"),
 						Action: websocketaction("default/ws1/80"),
@@ -642,7 +642,7 @@ func TestVirtualHostCacheRecomputevhost(t *testing.T) {
 			ingress_http: []proto.Message{
 				&route.VirtualHost{
 					Name:    "echo.websocket.org",
-					Domains: []string{"echo.websocket.org"},
+					Domains: []string{"echo.websocket.org", "echo.websocket.org:80"},
 					Routes: []route.Route{{
 						Match:  prefixmatch("/ws1"),
 						Action: websocketaction("default/ws1/80"),
@@ -652,7 +652,7 @@ func TestVirtualHostCacheRecomputevhost(t *testing.T) {
 			ingress_https: []proto.Message{
 				&route.VirtualHost{
 					Name:    "echo.websocket.org",
-					Domains: []string{"echo.websocket.org"},
+					Domains: []string{"echo.websocket.org", "echo.websocket.org:443"},
 					Routes: []route.Route{{
 						Match:  prefixmatch("/ws1"),
 						Action: websocketaction("default/ws1/80"),
@@ -874,7 +874,7 @@ func TestVirtualHostCacheRecomputevhostIngressRoute(t *testing.T) {
 			ingress_http: []proto.Message{
 				&route.VirtualHost{
 					Name:    "httpbin.org",
-					Domains: []string{"httpbin.org"},
+					Domains: []string{"httpbin.org", "httpbin.org:80"},
 					Routes: []route.Route{{
 						Match: prefixmatch("/"), // match all
 						Action: &route.Route_Route{
@@ -934,7 +934,7 @@ func TestVirtualHostCacheRecomputevhostIngressRoute(t *testing.T) {
 			ingress_http: []proto.Message{
 				&route.VirtualHost{
 					Name:    "httpbin.org",
-					Domains: []string{"httpbin.org"},
+					Domains: []string{"httpbin.org", "httpbin.org:80"},
 					Routes: []route.Route{{
 						Match: prefixmatch("/peter"),
 						Action: &route.Route_Route{
@@ -1003,7 +1003,7 @@ func TestVirtualHostCacheRecomputevhostIngressRoute(t *testing.T) {
 			ingress_http: []proto.Message{
 				&route.VirtualHost{
 					Name:    "d31bb322ca62bb395acad00b3cbf45a3aa1010ca28dca7cddb4f7db786fa",
-					Domains: []string{"my-very-very-long-service-host-name.subdomain.boring-dept.my.company"},
+					Domains: []string{"my-very-very-long-service-host-name.subdomain.boring-dept.my.company", "my-very-very-long-service-host-name.subdomain.boring-dept.my.company:80"},
 					Routes: []route.Route{{
 						Match: prefixmatch("/"),
 						Action: &route.Route_Route{
@@ -1076,7 +1076,7 @@ func TestVirtualHostCacheRecomputevhostIngressRoute(t *testing.T) {
 			ingress_http: []proto.Message{
 				&route.VirtualHost{
 					Name:    "httpbin.org",
-					Domains: []string{"httpbin.org"},
+					Domains: []string{"httpbin.org", "httpbin.org:80"},
 					Routes: []route.Route{{
 						Match: prefixmatch("/admin"),
 						Action: &route.Route_Route{
@@ -1197,7 +1197,7 @@ func TestVirtualHostCacheRecomputevhostIngressRoute(t *testing.T) {
 			ingress_http: []proto.Message{
 				&route.VirtualHost{
 					Name:    "httpbin.org",
-					Domains: []string{"httpbin.org"},
+					Domains: []string{"httpbin.org", "httpbin.org:80"},
 					Routes: []route.Route{{
 						Match: prefixmatch("/"), // match all
 						Action: &route.Route_Route{
@@ -1259,7 +1259,7 @@ func TestVirtualHostCacheRecomputevhostIngressRoute(t *testing.T) {
 			ingress_http: []proto.Message{
 				&route.VirtualHost{
 					Name:    "httpbin.org",
-					Domains: []string{"httpbin.org"},
+					Domains: []string{"httpbin.org", "httpbin.org:80"},
 					Routes: []route.Route{{
 						Match: prefixmatch("/"), // match all
 						Action: &route.Route_Route{
@@ -1322,7 +1322,7 @@ func TestVirtualHostCacheRecomputevhostIngressRoute(t *testing.T) {
 			ingress_http: []proto.Message{
 				&route.VirtualHost{
 					Name:    "httpbin.org",
-					Domains: []string{"httpbin.org"},
+					Domains: []string{"httpbin.org", "httpbin.org:80"},
 					Routes: []route.Route{{
 						Match: prefixmatch("/"), // match all
 						Action: &route.Route_Route{
@@ -1389,7 +1389,7 @@ func TestVirtualHostCacheRecomputevhostIngressRoute(t *testing.T) {
 			ingress_http: []proto.Message{
 				&route.VirtualHost{
 					Name:    "httpbin.org",
-					Domains: []string{"httpbin.org"},
+					Domains: []string{"httpbin.org", "httpbin.org:80"},
 					Routes: []route.Route{{
 						Match: prefixmatch("/"), // match all
 						Action: &route.Route_Route{

--- a/internal/e2e/rds_test.go
+++ b/internal/e2e/rds_test.go
@@ -236,7 +236,7 @@ func TestEditIngressInPlace(t *testing.T) {
 				Name: "ingress_http",
 				VirtualHosts: []route.VirtualHost{{
 					Name:    "hello.example.com",
-					Domains: []string{"hello.example.com"},
+					Domains: []string{"hello.example.com", "hello.example.com:80"},
 					Routes: []route.Route{{
 						Match:  prefixmatch("/"),
 						Action: routecluster("default/wowie/80"),
@@ -285,7 +285,7 @@ func TestEditIngressInPlace(t *testing.T) {
 				Name: "ingress_http",
 				VirtualHosts: []route.VirtualHost{{
 					Name:    "hello.example.com",
-					Domains: []string{"hello.example.com"},
+					Domains: []string{"hello.example.com", "hello.example.com:80"},
 					Routes: []route.Route{{
 						Match:  prefixmatch("/whoop"),
 						Action: routecluster("default/kerpow/9000"),
@@ -342,7 +342,7 @@ func TestEditIngressInPlace(t *testing.T) {
 				Name: "ingress_http",
 				VirtualHosts: []route.VirtualHost{{
 					Name:    "hello.example.com",
-					Domains: []string{"hello.example.com"},
+					Domains: []string{"hello.example.com", "hello.example.com:80"},
 					Routes: []route.Route{{
 						Match:  prefixmatch("/whoop"),
 						Action: redirecthttps(),
@@ -401,7 +401,7 @@ func TestEditIngressInPlace(t *testing.T) {
 				Name: "ingress_http",
 				VirtualHosts: []route.VirtualHost{{
 					Name:    "hello.example.com",
-					Domains: []string{"hello.example.com"},
+					Domains: []string{"hello.example.com", "hello.example.com:80"},
 					Routes: []route.Route{{
 						Match:  prefixmatch("/whoop"),
 						Action: redirecthttps(),
@@ -414,7 +414,7 @@ func TestEditIngressInPlace(t *testing.T) {
 				Name: "ingress_https",
 				VirtualHosts: []route.VirtualHost{{
 					Name:    "hello.example.com",
-					Domains: []string{"hello.example.com"},
+					Domains: []string{"hello.example.com", "hello.example.com:443"},
 					Routes: []route.Route{{
 						Match:  prefixmatch("/whoop"),
 						Action: routecluster("default/kerpow/9000"),
@@ -582,7 +582,7 @@ func TestSSLRedirectOverlay(t *testing.T) {
 
 	assertRDS(t, cc, []route.VirtualHost{{ // ingress_http
 		Name:    "example.com",
-		Domains: []string{"example.com"},
+		Domains: []string{"example.com", "example.com:80"},
 		Routes: []route.Route{{
 			Match:  prefixmatch("/.well-known/acme-challenge/gVJl5NWL2owUqZekjHkt_bo3OHYC2XNDURRRgLI5JTk"),
 			Action: routecluster("nginx-ingress/challenge-service/8009"),
@@ -592,7 +592,7 @@ func TestSSLRedirectOverlay(t *testing.T) {
 		}},
 	}}, []route.VirtualHost{{ // ingress_https
 		Name:    "example.com",
-		Domains: []string{"example.com"},
+		Domains: []string{"example.com", "example.com:443"},
 		Routes: []route.Route{{
 			Match:  prefixmatch("/"), // match all
 			Action: routecluster("default/app-service/8080"),
@@ -689,7 +689,7 @@ func TestIssue257(t *testing.T) {
 
 	assertRDS(t, cc, []route.VirtualHost{{
 		Name:    "kuard.db.gd-ms.com",
-		Domains: []string{"kuard.db.gd-ms.com"},
+		Domains: []string{"kuard.db.gd-ms.com", "kuard.db.gd-ms.com:80"},
 		Routes: []route.Route{{
 			Match:  prefixmatch("/"), // match all
 			Action: routecluster("default/kuard/80"),
@@ -762,7 +762,7 @@ func TestRDSFilter(t *testing.T) {
 				Name: "ingress_http",
 				VirtualHosts: []route.VirtualHost{{ // ingress_http
 					Name:    "example.com",
-					Domains: []string{"example.com"},
+					Domains: []string{"example.com", "example.com:80"},
 					Routes: []route.Route{{
 						Match:  prefixmatch("/.well-known/acme-challenge/gVJl5NWL2owUqZekjHkt_bo3OHYC2XNDURRRgLI5JTk"),
 						Action: routecluster("nginx-ingress/challenge-service/8009"),
@@ -784,7 +784,7 @@ func TestRDSFilter(t *testing.T) {
 				Name: "ingress_https",
 				VirtualHosts: []route.VirtualHost{{ // ingress_https
 					Name:    "example.com",
-					Domains: []string{"example.com"},
+					Domains: []string{"example.com", "example.com:443"},
 					Routes: []route.Route{{
 						Match:  prefixmatch("/"), // match all
 						Action: routecluster("default/app-service/8080"),
@@ -830,7 +830,7 @@ func TestWebsocketRoutes(t *testing.T) {
 
 	assertRDS(t, cc, []route.VirtualHost{{
 		Name:    "websocket.hello.world",
-		Domains: []string{"websocket.hello.world"},
+		Domains: []string{"websocket.hello.world", "websocket.hello.world:80"},
 		Routes: []route.Route{{
 			Match:  prefixmatch("/"), // match all
 			Action: websocketroute("default/ws/80"),


### PR DESCRIPTION
Adds both host and host:port to a virtualhost's route domains,
enabling routing when a client includes the port in the ```Host```
header.

Fixes #390

Signed-off-by: Matthew Alberts <malberts@cloudflare.com>