### PR TITLE
internal/debug: move debug service to an internal package

### DIFF
--- a/cmd/contour/contour.go
+++ b/cmd/contour/contour.go
@@ -21,6 +21,7 @@ import (
 	"path/filepath"
 	"strconv"
 
+	"github.com/heptio/contour/internal/debug"
 	clientset "github.com/heptio/contour/internal/generated/clientset/versioned"
 	kingpin "gopkg.in/alecthomas/kingpin.v2"
 
@@ -79,7 +80,7 @@ func main() {
 	xdsPort := serve.Flag("xds-port", "xDS gRPC API port").Default("8001").Int()
 
 	// configuration parameters for debug service
-	debug := debugService{
+	debug := debug.Service{
 		FieldLogger: log.WithField("context", "debugsvc"),
 	}
 


### PR DESCRIPTION
This is in preparation for adding a /debug/dag handler.

Signed-off-by: Dave Cheney <dave@cheney.net>