### PR TITLE
internal/k8s: disable shared informer resync timer

### DIFF
--- a/internal/k8s/watcher.go
+++ b/internal/k8s/watcher.go
@@ -57,7 +57,7 @@ func WatchIngressRoutes(g *workgroup.Group, client *clientset.Clientset, log log
 
 func watch(g *workgroup.Group, c cache.Getter, log logrus.FieldLogger, resource string, objType runtime.Object, rs ...cache.ResourceEventHandler) {
 	lw := cache.NewListWatchFromClient(c, resource, v1.NamespaceAll, fields.Everything())
-	sw := cache.NewSharedInformer(lw, objType, 30*time.Minute)
+	sw := cache.NewSharedInformer(lw, objType, time.Duration(0)) // resync timer disabled
 	for _, r := range rs {
 		sw.AddEventHandler(r)
 	}


### PR DESCRIPTION
Fixes #130

Disable (I hope, there is no documentation on the method) the resync
timer on each of the watchers.

Signed-off-by: Dave Cheney <dave@cheney.net>