### PR TITLE
deployment: switch the order of envoy and contour containers

### DIFF
--- a/deployment/deployment-grpc-v2/02-contour.yaml
+++ b/deployment/deployment-grpc-v2/02-contour.yaml
@@ -21,6 +21,11 @@ spec:
         prometheus.io/format: "prometheus"
     spec:
       containers:
+      - image: gcr.io/heptio-images/contour:master
+        imagePullPolicy: Always
+        name: contour
+        command: ["contour"]
+        args: ["serve", "--incluster"]
       - image: docker.io/envoyproxy/envoy-alpine:v1.6.0
         name: envoy
         ports:
@@ -33,11 +38,6 @@ spec:
         volumeMounts:
         - name: contour-config
           mountPath: /config
-      - image: gcr.io/heptio-images/contour:master
-        imagePullPolicy: Always
-        name: contour
-        command: ["contour"]
-        args: ["serve", "--incluster"]
       initContainers:
       - image: gcr.io/heptio-images/contour:master
         imagePullPolicy: Always

--- a/deployment/ds-grpc-v2/02-contour.yaml
+++ b/deployment/ds-grpc-v2/02-contour.yaml
@@ -22,6 +22,11 @@ spec:
         prometheus.io/format: "prometheus"
     spec:
       containers:
+      - image: gcr.io/heptio-images/contour:master
+        imagePullPolicy: Always
+        name: contour
+        command: ["contour"]
+        args: ["serve", "--incluster"]
       - image: docker.io/envoyproxy/envoy-alpine:v1.6.0
         name: envoy
         ports:
@@ -34,11 +39,6 @@ spec:
         volumeMounts:
         - name: contour-config
           mountPath: /config
-      - image: gcr.io/heptio-images/contour:master
-        imagePullPolicy: Always
-        name: contour
-        command: ["contour"]
-        args: ["serve", "--incluster"]
       initContainers:
       - image: gcr.io/heptio-images/contour:master
         imagePullPolicy: Always

--- a/deployment/ds-hostnet/02-contour.yaml
+++ b/deployment/ds-hostnet/02-contour.yaml
@@ -23,6 +23,14 @@ spec:
     spec:
       hostNetwork: true
       containers:
+      - image: gcr.io/heptio-images/contour:master
+        imagePullPolicy: Always
+        ports:
+        - containerPort: 8000
+          name: contour
+        name: contour
+        command: ["contour"]
+        args: ["serve", "--incluster"]
       - image: docker.io/envoyproxy/envoy-alpine:v1.6.0
         name: envoy
         ports:
@@ -35,14 +43,6 @@ spec:
         volumeMounts:
         - name: contour-config
           mountPath: /config
-      - image: gcr.io/heptio-images/contour:master
-        imagePullPolicy: Always
-        ports:
-        - containerPort: 8000
-          name: contour
-        name: contour
-        command: ["contour"]
-        args: ["serve", "--incluster"]
       initContainers:
       - image: gcr.io/heptio-images/contour:master
         imagePullPolicy: Always

--- a/deployment/render/daemonset-norbac.yaml
+++ b/deployment/render/daemonset-norbac.yaml
@@ -50,6 +50,11 @@ spec:
         prometheus.io/format: "prometheus"
     spec:
       containers:
+      - image: gcr.io/heptio-images/contour:master
+        imagePullPolicy: Always
+        name: contour
+        command: ["contour"]
+        args: ["serve", "--incluster"]
       - image: docker.io/envoyproxy/envoy-alpine:v1.6.0
         name: envoy
         ports:
@@ -62,11 +67,6 @@ spec:
         volumeMounts:
         - name: contour-config
           mountPath: /config
-      - image: gcr.io/heptio-images/contour:master
-        imagePullPolicy: Always
-        name: contour
-        command: ["contour"]
-        args: ["serve", "--incluster"]
       initContainers:
       - image: gcr.io/heptio-images/contour:master
         imagePullPolicy: Always

--- a/deployment/render/daemonset-rbac.yaml
+++ b/deployment/render/daemonset-rbac.yaml
@@ -50,6 +50,11 @@ spec:
         prometheus.io/format: "prometheus"
     spec:
       containers:
+      - image: gcr.io/heptio-images/contour:master
+        imagePullPolicy: Always
+        name: contour
+        command: ["contour"]
+        args: ["serve", "--incluster"]
       - image: docker.io/envoyproxy/envoy-alpine:v1.6.0
         name: envoy
         ports:
@@ -62,11 +67,6 @@ spec:
         volumeMounts:
         - name: contour-config
           mountPath: /config
-      - image: gcr.io/heptio-images/contour:master
-        imagePullPolicy: Always
-        name: contour
-        command: ["contour"]
-        args: ["serve", "--incluster"]
       initContainers:
       - image: gcr.io/heptio-images/contour:master
         imagePullPolicy: Always

--- a/deployment/render/deployment-norbac.yaml
+++ b/deployment/render/deployment-norbac.yaml
@@ -49,6 +49,11 @@ spec:
         prometheus.io/format: "prometheus"
     spec:
       containers:
+      - image: gcr.io/heptio-images/contour:master
+        imagePullPolicy: Always
+        name: contour
+        command: ["contour"]
+        args: ["serve", "--incluster"]
       - image: docker.io/envoyproxy/envoy-alpine:v1.6.0
         name: envoy
         ports:
@@ -61,11 +66,6 @@ spec:
         volumeMounts:
         - name: contour-config
           mountPath: /config
-      - image: gcr.io/heptio-images/contour:master
-        imagePullPolicy: Always
-        name: contour
-        command: ["contour"]
-        args: ["serve", "--incluster"]
       initContainers:
       - image: gcr.io/heptio-images/contour:master
         imagePullPolicy: Always

--- a/deployment/render/deployment-rbac.yaml
+++ b/deployment/render/deployment-rbac.yaml
@@ -49,6 +49,11 @@ spec:
         prometheus.io/format: "prometheus"
     spec:
       containers:
+      - image: gcr.io/heptio-images/contour:master
+        imagePullPolicy: Always
+        name: contour
+        command: ["contour"]
+        args: ["serve", "--incluster"]
       - image: docker.io/envoyproxy/envoy-alpine:v1.6.0
         name: envoy
         ports:
@@ -61,11 +66,6 @@ spec:
         volumeMounts:
         - name: contour-config
           mountPath: /config
-      - image: gcr.io/heptio-images/contour:master
-        imagePullPolicy: Always
-        name: contour
-        command: ["contour"]
-        args: ["serve", "--incluster"]
       initContainers:
       - image: gcr.io/heptio-images/contour:master
         imagePullPolicy: Always


### PR DESCRIPTION
Updates #420

Prior to this PR the envoy container appeared first in the
deployment.spec so would likely start before the contour container. This
would cause envoy to fail to be able to contact contour immediately upon
startup and would then fall back to a retry behaviour.

With this change, contour appears first in the spec so will likely start
before contour, which agrevates a failure mode reported in issue #420.

Signed-off-by: Dave Cheney <dave@cheney.net>