### PR TITLE
internal/dag: new package

### DIFF
--- a/internal/dag/dag.go
+++ b/internal/dag/dag.go
@@ -1,0 +1,231 @@
+// Copyright © 2018 Heptio
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package dag provides a data model, in the form of a directed acyclic graph,
+// of the relationship between Kubernetes Ingress, Service, and Secret objects.
+package dag
+
+import (
+	"fmt"
+
+	"k8s.io/api/core/v1"
+	"k8s.io/api/extensions/v1beta1"
+)
+
+// A DAG represents a directed acylic graph of objects representing the relationship
+// between Kubernetes Ingress objects, the backend Services, and Secret objects.
+// The DAG models these relationships as Roots and Vertices.
+//
+// A DAG is mutable and not thread safe.
+type DAG struct {
+	roots    map[string]*VirtualHost
+	secrets  map[meta]*Secret
+	services map[meta]*Service
+}
+
+// meta holds the name and namespace of a Kubernetes object.
+type meta struct {
+	name, namespace string
+}
+
+// Roots calls the function f for each Root registered from this DAG.
+func (d *DAG) Roots(f func(Vertex)) {
+	for _, r := range d.roots {
+		f(r)
+	}
+}
+
+// Vertices calls the function f for each Vertex registered with this DAG.
+// This includes Vertices which are not reachable from a Root, ie, those that
+// are orphaned.
+func (d *DAG) Vertices(f func(Vertex)) {
+	for _, v := range d.roots {
+		f(v)
+	}
+	for _, v := range d.secrets {
+		f(v)
+	}
+	for _, v := range d.services {
+		f(v)
+	}
+}
+
+// InsertSecret inserts a Secret into the DAG. If there is an existing Service with
+// the same name and namespace, it will be replaced.
+func (d *DAG) InsertSecret(s *v1.Secret) {
+
+	m := meta{name: s.Name, namespace: s.Namespace}
+
+	// lookup vertex in secrets map
+	v, ok := d.secrets[m]
+	if ok {
+		// found, that means v is already a child of any ingressVertex
+		// that requires it, just update the attached object and we're done
+		v.object = s
+		return
+	}
+
+	// the vertex was not present in the secret map which means it is not
+	// a attached to any ingressVertices.
+	v = &Secret{
+		object: s,
+	}
+	if d.secrets == nil {
+		d.secrets = make(map[meta]*Secret)
+	}
+	d.secrets[m] = v
+
+	// foreach root, if r.object references this secret, attach secret as child.
+}
+
+// InsertService inserts a Servce into the DAG. If there is an existing Service with
+// the same name and namespace, it will be replaced.
+func (d *DAG) InsertService(s *v1.Service) {
+
+	m := meta{name: s.Name, namespace: s.Namespace}
+
+	// lookup vertex in services map
+	v, ok := d.services[m]
+	if ok {
+		// found, that means v is already a child of any prefixVertex
+		// that requires it, just update the attached object and we're done
+		v.object = s
+		return
+	}
+
+	// the vertex was not present in the services map which means it is not
+	// a attached to any prefixVertex.
+	v = &Service{
+		object: s,
+	}
+	if d.services == nil {
+		d.services = make(map[meta]*Service)
+	}
+	d.services[m] = v
+
+	// foreach root, foreach prefixVertex, attach this vertex as a child if the
+	// name and namespace match.
+}
+
+func (d *DAG) InsertIngress(i *v1beta1.Ingress) {
+	for _, rule := range i.Spec.Rules {
+		if rule.Host == "" {
+			fmt.Println("skipping blank host", i.Name, i.Namespace)
+			continue
+		}
+		r := &VirtualHost{
+			object: i,
+			host:   rule.Host,
+		}
+
+		for _, tls := range i.Spec.TLS {
+			if tls.SecretName == "" {
+				continue
+			}
+			m := meta{name: tls.SecretName, namespace: i.Namespace}
+			s, ok := d.secrets[m]
+			if !ok {
+				continue
+			}
+			// add this secret as a child of the virtualhost so that
+			// the ingress_https vistor can find it.
+			r.children = append(r.children, s)
+		}
+
+		for _, p := range rule.IngressRuleValue.HTTP.Paths {
+			path := p.Path
+			if path == "" {
+				path = "/"
+			}
+			rr := &Route{
+				path: path,
+			}
+			m := meta{name: p.Backend.ServiceName, namespace: i.Namespace}
+			s, ok := d.services[m]
+			if !ok {
+				continue
+			}
+			// add this service as a child of the route
+			rr.children = append(rr.children, s)
+			// add this route as a child of the vhost
+			r.children = append(r.children, rr)
+		}
+
+		if d.roots == nil {
+			d.roots = make(map[string]*VirtualHost)
+		}
+		d.roots[rule.Host] = r
+	}
+}
+
+type Root interface {
+	Vertex
+}
+
+type Route struct {
+	vertices
+	path string
+}
+
+func (r *Route) Prefix() string { return r.path }
+
+type VirtualHost struct {
+	vertices
+	host   string
+	object *v1beta1.Ingress
+}
+
+func (v *VirtualHost) FQDN() string { return v.host }
+
+type Vertex interface {
+	ChildVertices(func(Vertex))
+}
+
+// Secret represents a K8s Sevice as a DAG vertex. A Serivce is
+// a leaf in the DAG.
+type Service struct {
+	leaf
+	object *v1.Service
+}
+
+func (s *Service) Name() string      { return s.object.Name }
+func (s *Service) Namespace() string { return s.object.Namespace }
+
+// Secret represents a K8s Secret as a DAG Vertex. A Secret is
+// a leaf in the DAG.
+type Secret struct {
+	leaf
+	object *v1.Secret
+}
+
+func (s *Secret) Name() string      { return s.object.Name }
+func (s *Secret) Namespace() string { return s.object.Namespace }
+
+// leaf is a helper type for vertices which hold no children.
+type leaf struct{}
+
+func (l *leaf) ChildVertices(func(Vertex)) {}
+
+func (l *leaf) HasChildren() bool { return false }
+
+type vertices struct {
+	children []Vertex
+}
+
+func (v *vertices) ChildVertices(f func(Vertex)) {
+	for _, c := range v.children {
+		f(c)
+	}
+}
+
+func (v *vertices) HasChildren() bool { return len(v.children) > 0 }

--- a/internal/dag/dag_test.go
+++ b/internal/dag/dag_test.go
@@ -24,11 +24,11 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
-// The DAG is senstive to ordering, adding an ingress, then a service,
-// should have the same result as adding a sevice, then an ingress, but
-// operationally triggers very different code paths. This Test case attemps
-// to cover all the permulations.
-func TestDAG(t *testing.T) {
+func TestInsert(t *testing.T) {
+	// The DAG is senstive to ordering, adding an ingress, then a service,
+	// should have the same result as adding a sevice, then an ingress, but
+	// operationally triggers very different code paths.
+
 	i1 := &v1beta1.Ingress{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "kuard",
@@ -37,53 +37,479 @@ func TestDAG(t *testing.T) {
 		Spec: v1beta1.IngressSpec{
 			Backend: backend("kuard", intstr.FromInt(8080))},
 	}
-	s1 := service("default", "kuard",
-		v1.ServicePort{
-			Protocol: "TCP",
-			Port:     8080,
+	// i2 is functionally identical to i1
+	i2 := &v1beta1.Ingress{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "kuard",
+			Namespace: "default",
 		},
-	)
+		Spec: v1beta1.IngressSpec{
+			Rules: []v1beta1.IngressRule{{
+				IngressRuleValue: ingressrulevalue(backend("kuard", intstr.FromInt(8080))),
+			}},
+		},
+	}
+	// i3 is similar to i2 but includes a hostname on the ingress rule
+	i3 := &v1beta1.Ingress{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "kuard",
+			Namespace: "default",
+		},
+		Spec: v1beta1.IngressSpec{
+			TLS: []v1beta1.IngressTLS{{
+				Hosts:      []string{"kuard.example.com"},
+				SecretName: "secret",
+			}},
+			Rules: []v1beta1.IngressRule{{
+				Host:             "kuard.example.com",
+				IngressRuleValue: ingressrulevalue(backend("kuard", intstr.FromInt(8080))),
+			}},
+		},
+	}
+	// i4 is like i1 except it uses a named service port
+	i4 := &v1beta1.Ingress{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "kuard",
+			Namespace: "default",
+		},
+		Spec: v1beta1.IngressSpec{
+			Backend: backend("kuard", intstr.FromString("http"))},
+	}
+	// i5 is functionally identical to i2
+	i5 := &v1beta1.Ingress{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "kuard",
+			Namespace: "default",
+		},
+		Spec: v1beta1.IngressSpec{
+			Rules: []v1beta1.IngressRule{{
+				IngressRuleValue: ingressrulevalue(backend("kuard", intstr.FromString("http"))),
+			}},
+		},
+	}
+	s1 := &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "kuard",
+			Namespace: "default",
+		},
+		Spec: v1.ServiceSpec{
+			Ports: []v1.ServicePort{{
+				Name:       "http",
+				Protocol:   "TCP",
+				Port:       8080,
+				TargetPort: intstr.FromInt(8080),
+			}},
+		},
+	}
+	// s2 is like s1 but with a different name
+	s2 := &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "kuarder",
+			Namespace: "default",
+		},
+		Spec: v1.ServiceSpec{
+			Ports: []v1.ServicePort{{
+				Name:       "http",
+				Protocol:   "TCP",
+				Port:       8080,
+				TargetPort: intstr.FromInt(8080),
+			}},
+		},
+	}
+	// s3 is like s1 but has a different port
+	s3 := &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "kuard",
+			Namespace: "default",
+		},
+		Spec: v1.ServiceSpec{
+			Ports: []v1.ServicePort{{
+				Name:       "http",
+				Protocol:   "TCP",
+				Port:       9999,
+				TargetPort: intstr.FromInt(8080),
+			}},
+		},
+	}
+	sec1 := &v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "secret",
+			Namespace: "default",
+		},
+		Data: secretdata("certificate", "key"),
+	}
 
 	tests := map[string]struct {
-		objs  []interface{}
-		roots []*VirtualHost
+		objs []interface{}
+		want []*VirtualHost
 	}{
-		"insert service then default vhost": {
+		"insert ingress w/ default backend": {
 			objs: []interface{}{
-				s1,
 				i1,
 			},
-			roots: []*VirtualHost{{
-				object: i1,
-				host:   "*",
-				children: []Vertex{
-					&Route{
-						path: "/",
-						children: []Vertex{
-							&Service{
+			want: []*VirtualHost{{
+				host: "*",
+				routes: map[string]*Route{
+					"/": &Route{
+						path:    "/",
+						object:  i1,
+						backend: i1.Spec.Backend,
+					},
+				},
+				secrets: make(map[meta]*Secret),
+			}},
+		},
+		"insert ingress w/ single unnamed backend": {
+			objs: []interface{}{
+				i2,
+			},
+			want: []*VirtualHost{{
+				host: "*",
+				routes: map[string]*Route{
+					"/": &Route{
+						path:    "/",
+						object:  i2,
+						backend: &i2.Spec.Rules[0].IngressRuleValue.HTTP.Paths[0].Backend,
+					},
+				},
+				secrets: make(map[meta]*Secret),
+			}},
+		},
+		"insert ingress w/ host name and single backend": {
+			objs: []interface{}{
+				i3,
+			},
+			want: []*VirtualHost{{
+				host: "kuard.example.com",
+				routes: map[string]*Route{
+					"/": &Route{
+						path:    "/",
+						object:  i3,
+						backend: &i3.Spec.Rules[0].IngressRuleValue.HTTP.Paths[0].Backend,
+					},
+				},
+				secrets: make(map[meta]*Secret),
+			}},
+		},
+		"insert ingress w/ default backend then matching service": {
+			objs: []interface{}{
+				i1,
+				s1,
+			},
+			want: []*VirtualHost{{
+				host: "*",
+				routes: map[string]*Route{
+					"/": &Route{
+						path:    "/",
+						object:  i1,
+						backend: i1.Spec.Backend,
+						services: map[meta]*Service{
+							meta{
+								name:      "kuard",
+								namespace: "default",
+							}: &Service{
 								object: s1,
 							},
 						},
 					},
 				},
+				secrets: make(map[meta]*Secret),
 			}},
 		},
-		"insert default vhost then service": {
+		"insert service then ingress w/ default backend": {
 			objs: []interface{}{
-				i1,
 				s1,
+				i1,
 			},
-			roots: []*VirtualHost{{
-				object: i1,
-				host:   "*",
-				children: []Vertex{
-					&Route{
-						path: "/",
-						children: []Vertex{
-							&Service{
+			want: []*VirtualHost{{
+				host: "*",
+				routes: map[string]*Route{
+					"/": &Route{
+						path:    "/",
+						object:  i1,
+						backend: i1.Spec.Backend,
+						services: map[meta]*Service{
+							meta{
+								name:      "kuard",
+								namespace: "default",
+							}: &Service{
 								object: s1,
 							},
 						},
+					},
+				},
+				secrets: make(map[meta]*Secret),
+			}},
+		},
+		"insert ingress w/ default backend then non-matching service": {
+			objs: []interface{}{
+				i1,
+				s2,
+			},
+			want: []*VirtualHost{{
+				host: "*",
+				routes: map[string]*Route{
+					"/": &Route{
+						path:    "/",
+						object:  i1,
+						backend: i1.Spec.Backend,
+					},
+				},
+				secrets: make(map[meta]*Secret),
+			}},
+		},
+		"insert non matching service then ingress w/ default backend": {
+			objs: []interface{}{
+				s2,
+				i1,
+			},
+			want: []*VirtualHost{{
+				host: "*",
+				routes: map[string]*Route{
+					"/": &Route{
+						path:    "/",
+						object:  i1,
+						backend: i1.Spec.Backend,
+					},
+				},
+				secrets: make(map[meta]*Secret),
+			}},
+		},
+		"insert ingress w/ default backend then matching service with wrong port": {
+			objs: []interface{}{
+				i1,
+				s3,
+			},
+			want: []*VirtualHost{{
+				host: "*",
+				routes: map[string]*Route{
+					"/": &Route{
+						path:    "/",
+						object:  i1,
+						backend: i1.Spec.Backend,
+					},
+				},
+				secrets: make(map[meta]*Secret),
+			}},
+		},
+		"insert service then matching ingress w/ default backend but wrong port": {
+			objs: []interface{}{
+				s3,
+				i1,
+			},
+			want: []*VirtualHost{{
+				host: "*",
+				routes: map[string]*Route{
+					"/": &Route{
+						path:    "/",
+						object:  i1,
+						backend: i1.Spec.Backend,
+					},
+				},
+				secrets: make(map[meta]*Secret),
+			}},
+		},
+		"insert unnamed ingress w/ single backend then matching service with wrong port": {
+			objs: []interface{}{
+				i2,
+				s3,
+			},
+			want: []*VirtualHost{{
+				host: "*",
+				routes: map[string]*Route{
+					"/": &Route{
+						path:    "/",
+						object:  i2,
+						backend: &i2.Spec.Rules[0].IngressRuleValue.HTTP.Paths[0].Backend,
+					},
+				},
+				secrets: make(map[meta]*Secret),
+			}},
+		},
+		"insert service then matching unnamed ingress w/ single backend but wrong port": {
+			objs: []interface{}{
+				s3,
+				i2,
+			},
+			want: []*VirtualHost{{
+				host: "*",
+				routes: map[string]*Route{
+					"/": &Route{
+						path:    "/",
+						object:  i2,
+						backend: &i2.Spec.Rules[0].IngressRuleValue.HTTP.Paths[0].Backend,
+					},
+				},
+				secrets: make(map[meta]*Secret),
+			}},
+		},
+		"insert ingress w/ default backend then matching service w/ named port": {
+			objs: []interface{}{
+				i4,
+				s1,
+			},
+			want: []*VirtualHost{{
+				host: "*",
+				routes: map[string]*Route{
+					"/": &Route{
+						path:    "/",
+						object:  i4,
+						backend: i4.Spec.Backend,
+						services: map[meta]*Service{
+							meta{
+								name:      "kuard",
+								namespace: "default",
+							}: &Service{
+								object: s1,
+							},
+						},
+					},
+				},
+				secrets: make(map[meta]*Secret),
+			}},
+		},
+		"insert service w/ named port then ingress w/ default backend": {
+			objs: []interface{}{
+				s1,
+				i4,
+			},
+			want: []*VirtualHost{{
+				host: "*",
+				routes: map[string]*Route{
+					"/": &Route{
+						path:    "/",
+						object:  i4,
+						backend: i4.Spec.Backend,
+						services: map[meta]*Service{
+							meta{
+								name:      "kuard",
+								namespace: "default",
+							}: &Service{
+								object: s1,
+							},
+						},
+					},
+				},
+				secrets: make(map[meta]*Secret),
+			}},
+		},
+		"insert ingress w/ single unnamed backend w/ named service port then service": {
+			objs: []interface{}{
+				i5,
+				s1,
+			},
+			want: []*VirtualHost{{
+				host: "*",
+				routes: map[string]*Route{
+					"/": &Route{
+						path:    "/",
+						object:  i5,
+						backend: &i5.Spec.Rules[0].IngressRuleValue.HTTP.Paths[0].Backend,
+						services: map[meta]*Service{
+							meta{
+								name:      "kuard",
+								namespace: "default",
+							}: &Service{
+								object: s1,
+							},
+						},
+					},
+				},
+				secrets: make(map[meta]*Secret),
+			}},
+		},
+		"insert service then ingress w/ single unnamed backend w/ named service port": {
+			objs: []interface{}{
+				s1,
+				i5,
+			},
+			want: []*VirtualHost{{
+				host: "*",
+				routes: map[string]*Route{
+					"/": &Route{
+						path:    "/",
+						object:  i5,
+						backend: &i5.Spec.Rules[0].IngressRuleValue.HTTP.Paths[0].Backend,
+						services: map[meta]*Service{
+							meta{
+								name:      "kuard",
+								namespace: "default",
+							}: &Service{
+								object: s1,
+							},
+						},
+					},
+				},
+				secrets: make(map[meta]*Secret),
+			}},
+		},
+		"insert secret": {
+			objs: []interface{}{
+				sec1,
+			},
+			want: []*VirtualHost{},
+		},
+		"insert secret then ingress w/o tls": {
+			objs: []interface{}{
+				sec1,
+				i1,
+			},
+			want: []*VirtualHost{{
+				host: "*",
+				routes: map[string]*Route{
+					"/": &Route{
+						path:    "/",
+						object:  i1,
+						backend: i1.Spec.Backend,
+					},
+				},
+				secrets: make(map[meta]*Secret),
+			}},
+		},
+		"insert secret then ingress w/ tls": {
+			objs: []interface{}{
+				sec1,
+				i3,
+			},
+			want: []*VirtualHost{{
+				host: "kuard.example.com",
+				routes: map[string]*Route{
+					"/": &Route{
+						path:    "/",
+						object:  i3,
+						backend: &i3.Spec.Rules[0].IngressRuleValue.HTTP.Paths[0].Backend,
+					},
+				},
+				secrets: map[meta]*Secret{
+					meta{
+						name:      "secret",
+						namespace: "default",
+					}: &Secret{
+						object: sec1,
+					},
+				},
+			}},
+		},
+		"insert ingress w/ tls then secret": {
+			objs: []interface{}{
+				i3,
+				sec1,
+			},
+			want: []*VirtualHost{{
+				host: "kuard.example.com",
+				routes: map[string]*Route{
+					"/": &Route{
+						path:    "/",
+						object:  i3,
+						backend: &i3.Spec.Rules[0].IngressRuleValue.HTTP.Paths[0].Backend,
+					},
+				},
+				secrets: map[meta]*Secret{
+					meta{
+						name:      "secret",
+						namespace: "default",
+					}: &Secret{
+						object: sec1,
 					},
 				},
 			}},
@@ -97,37 +523,40 @@ func TestDAG(t *testing.T) {
 				d.Insert(o)
 			}
 
-			got := make(map[string]Vertex)
+			got := make(map[string]*VirtualHost)
 			d.Visit(func(v Vertex) {
 				if v, ok := v.(*VirtualHost); ok {
 					got[v.FQDN()] = v
 				}
 			})
 
-			want := make(map[string]Vertex)
-			for _, r := range tc.roots {
-				want[r.FQDN()] = r
+			want := make(map[string]*VirtualHost)
+			for _, vh := range tc.want {
+				want[vh.FQDN()] = vh
 			}
 
 			if !reflect.DeepEqual(want, got) {
-				t.Fatalf("expected: %v, got: %v", want, got)
+				t.Fatal("expected:\n", want, "\ngot:\n", got)
 			}
 
 		})
-
 	}
 }
 
 func (v *VirtualHost) String() string {
-	return fmt.Sprintf("%T: %q %v", v, v.FQDN(), v.children)
+	return fmt.Sprintf("host: %v {routes: %v, secrets: %v}", v.FQDN(), v.routes, v.secrets)
 }
 
 func (r *Route) String() string {
-	return fmt.Sprintf("%T: %q %v", r, r.Prefix(), r.children)
+	return fmt.Sprintf("route: %q {services: %v}", r.Prefix(), r.services)
 }
 
 func (s *Service) String() string {
-	return fmt.Sprintf("%T: %q", s, s.Name())
+	return fmt.Sprintf("service: %s/%s {ports: %v}", s.object.Namespace, s.object.Name, s.object.Spec.Ports)
+}
+
+func (s *Secret) String() string {
+	return fmt.Sprintf("secret: %s/%s", s.object.Namespace, s.object.Name)
 }
 
 func backend(name string, port intstr.IntOrString) *v1beta1.IngressBackend {
@@ -137,14 +566,19 @@ func backend(name string, port intstr.IntOrString) *v1beta1.IngressBackend {
 	}
 }
 
-func service(ns, name string, ports ...v1.ServicePort) *v1.Service {
-	return &v1.Service{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: ns,
+func ingressrulevalue(backend *v1beta1.IngressBackend) v1beta1.IngressRuleValue {
+	return v1beta1.IngressRuleValue{
+		HTTP: &v1beta1.HTTPIngressRuleValue{
+			Paths: []v1beta1.HTTPIngressPath{{
+				Backend: *backend,
+			}},
 		},
-		Spec: v1.ServiceSpec{
-			Ports: ports,
-		},
+	}
+}
+
+func secretdata(cert, key string) map[string][]byte {
+	return map[string][]byte{
+		v1.TLSCertKey:       []byte(cert),
+		v1.TLSPrivateKeyKey: []byte(key),
 	}
 }

--- a/internal/dag/dag_test.go
+++ b/internal/dag/dag_test.go
@@ -1,0 +1,150 @@
+// Copyright © 2018 Heptio
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dag
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	"k8s.io/api/core/v1"
+	"k8s.io/api/extensions/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+// The DAG is senstive to ordering, adding an ingress, then a service,
+// should have the same result as adding a sevice, then an ingress, but
+// operationally triggers very different code paths. This Test case attemps
+// to cover all the permulations.
+func TestDAG(t *testing.T) {
+	i1 := &v1beta1.Ingress{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "kuard",
+			Namespace: "default",
+		},
+		Spec: v1beta1.IngressSpec{
+			Backend: backend("kuard", intstr.FromInt(8080))},
+	}
+	s1 := service("default", "kuard",
+		v1.ServicePort{
+			Protocol: "TCP",
+			Port:     8080,
+		},
+	)
+
+	tests := map[string]struct {
+		objs  []interface{}
+		roots []*VirtualHost
+	}{
+		"insert service then default vhost": {
+			objs: []interface{}{
+				s1,
+				i1,
+			},
+			roots: []*VirtualHost{{
+				object: i1,
+				host:   "*",
+				children: []Vertex{
+					&Route{
+						path: "/",
+						children: []Vertex{
+							&Service{
+								object: s1,
+							},
+						},
+					},
+				},
+			}},
+		},
+		"insert default vhost then service": {
+			objs: []interface{}{
+				i1,
+				s1,
+			},
+			roots: []*VirtualHost{{
+				object: i1,
+				host:   "*",
+				children: []Vertex{
+					&Route{
+						path: "/",
+						children: []Vertex{
+							&Service{
+								object: s1,
+							},
+						},
+					},
+				},
+			}},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			var d DAG
+			for _, o := range tc.objs {
+				d.Insert(o)
+			}
+
+			got := make(map[string]Vertex)
+			d.Visit(func(v Vertex) {
+				if v, ok := v.(*VirtualHost); ok {
+					got[v.FQDN()] = v
+				}
+			})
+
+			want := make(map[string]Vertex)
+			for _, r := range tc.roots {
+				want[r.FQDN()] = r
+			}
+
+			if !reflect.DeepEqual(want, got) {
+				t.Fatalf("expected: %v, got: %v", want, got)
+			}
+
+		})
+
+	}
+}
+
+func (v *VirtualHost) String() string {
+	return fmt.Sprintf("%T: %q %v", v, v.FQDN(), v.children)
+}
+
+func (r *Route) String() string {
+	return fmt.Sprintf("%T: %q %v", r, r.Prefix(), r.children)
+}
+
+func (s *Service) String() string {
+	return fmt.Sprintf("%T: %q", s, s.Name())
+}
+
+func backend(name string, port intstr.IntOrString) *v1beta1.IngressBackend {
+	return &v1beta1.IngressBackend{
+		ServiceName: name,
+		ServicePort: port,
+	}
+}
+
+func service(ns, name string, ports ...v1.ServicePort) *v1.Service {
+	return &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: ns,
+		},
+		Spec: v1.ServiceSpec{
+			Ports: ports,
+		},
+	}
+}

--- a/internal/dag/k8s.go
+++ b/internal/dag/k8s.go
@@ -19,10 +19,13 @@ type ResourceEventHandler struct {
 }
 
 func (r *ResourceEventHandler) OnAdd(obj interface{}) {
+	r.Insert(obj)
 }
 
 func (r *ResourceEventHandler) OnUpdate(oldObj, newObj interface{}) {
+	r.Insert(newObj)
 }
 
 func (r *ResourceEventHandler) OnDelete(obj interface{}) {
+	r.Remove(obj)
 }

--- a/internal/dag/k8s.go
+++ b/internal/dag/k8s.go
@@ -1,0 +1,28 @@
+// Copyright © 2018 Heptio
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dag
+
+// ResourceEventHandler converts its embedded DAG into a classic cache.ResourceEventHandler.
+type ResourceEventHandler struct {
+	DAG
+}
+
+func (r *ResourceEventHandler) OnAdd(obj interface{}) {
+}
+
+func (r *ResourceEventHandler) OnUpdate(oldObj, newObj interface{}) {
+}
+
+func (r *ResourceEventHandler) OnDelete(obj interface{}) {
+}

--- a/internal/debug/dot.go
+++ b/internal/debug/dot.go
@@ -50,7 +50,7 @@ func (dw *dotWriter) writeDot(w io.Writer) {
 			name = fmt.Sprintf("%s/path/%s", vhost, v.Prefix())
 			fmt.Fprintf(w, "%q [shape=record, label=\"{prefix|%s}\"]\n", name, v.Prefix())
 		}
-		v.ChildVertices(func(v dag.Vertex) {
+		v.Visit(func(v dag.Vertex) {
 			visit(v)
 			switch v := v.(type) {
 			case *dag.Secret:
@@ -65,7 +65,7 @@ func (dw *dotWriter) writeDot(w io.Writer) {
 		})
 	}
 
-	dw.DAG.Roots(visit)
+	dw.DAG.Visit(visit)
 
 	fmt.Fprintln(w, "}")
 }

--- a/internal/debug/dot.go
+++ b/internal/debug/dot.go
@@ -35,6 +35,7 @@ func (dw *dotWriter) writeDot(w io.Writer) {
 	var visit func(dag.Vertex)
 	visit = func(v dag.Vertex) {
 		var name string
+		var route *dag.Route
 		switch v := v.(type) {
 		case *dag.Secret:
 			name = fmt.Sprintf("secret/%s/%s", v.Namespace(), v.Name())
@@ -48,6 +49,7 @@ func (dw *dotWriter) writeDot(w io.Writer) {
 			fmt.Fprintf(w, "%q [shape=record, label=\"{host|%s}\"]\n", name, v.FQDN())
 		case *dag.Route:
 			name = fmt.Sprintf("%s/path/%s", vhost, v.Prefix())
+			route = v
 			fmt.Fprintf(w, "%q [shape=record, label=\"{prefix|%s}\"]\n", name, v.Prefix())
 		}
 		v.Visit(func(v dag.Vertex) {
@@ -56,7 +58,7 @@ func (dw *dotWriter) writeDot(w io.Writer) {
 			case *dag.Secret:
 				fmt.Fprintf(w, "%q -> \"secret/%s/%s\"\n", name, v.Namespace(), v.Name())
 			case *dag.Service:
-				fmt.Fprintf(w, "%q -> \"service/%s/%s\"\n", name, v.Namespace(), v.Name())
+				fmt.Fprintf(w, "%q -> \"service/%s/%s\" [label=\"port: %s\"]\n", name, v.Namespace(), v.Name(), route.ServicePort())
 			case *dag.VirtualHost:
 				fmt.Fprintf(w, "%q -> \"virtualhost/%s\"\n", name, v.FQDN())
 			case *dag.Route:

--- a/internal/debug/dot.go
+++ b/internal/debug/dot.go
@@ -1,0 +1,71 @@
+// Copyright © 2018 Heptio
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package debug
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/heptio/contour/internal/dag"
+	"github.com/sirupsen/logrus"
+)
+
+// quick and dirty dot debugging package
+
+type dotWriter struct {
+	*dag.DAG
+	logrus.FieldLogger
+}
+
+func (dw *dotWriter) writeDot(w io.Writer) {
+	fmt.Fprintln(w, "digraph DAG {\nrankdir=\"LR\"")
+
+	var vhost string
+	var visit func(dag.Vertex)
+	visit = func(v dag.Vertex) {
+		var name string
+		switch v := v.(type) {
+		case *dag.Secret:
+			name = fmt.Sprintf("secret/%s/%s", v.Namespace(), v.Name())
+			fmt.Fprintf(w, "%q [shape=record, label=\"{secret|%s}\"]\n", name, name[len("secret/"):])
+		case *dag.Service:
+			name = fmt.Sprintf("service/%s/%s", v.Namespace(), v.Name())
+			fmt.Fprintf(w, "%q [shape=record, label=\"{service|%s}\"]\n", name, name[len("service/"):])
+		case *dag.VirtualHost:
+			vhost = fmt.Sprintf("virtualhost/%s", v.FQDN())
+			name = vhost
+			fmt.Fprintf(w, "%q [shape=record, label=\"{host|%s}\"]\n", name, v.FQDN())
+		case *dag.Route:
+			name = fmt.Sprintf("%s/path/%s", vhost, v.Prefix())
+			fmt.Fprintf(w, "%q [shape=record, label=\"{prefix|%s}\"]\n", name, v.Prefix())
+		}
+		v.ChildVertices(func(v dag.Vertex) {
+			visit(v)
+			switch v := v.(type) {
+			case *dag.Secret:
+				fmt.Fprintf(w, "%q -> \"secret/%s/%s\"\n", name, v.Namespace(), v.Name())
+			case *dag.Service:
+				fmt.Fprintf(w, "%q -> \"service/%s/%s\"\n", name, v.Namespace(), v.Name())
+			case *dag.VirtualHost:
+				fmt.Fprintf(w, "%q -> \"virtualhost/%s\"\n", name, v.FQDN())
+			case *dag.Route:
+				fmt.Fprintf(w, "%q -> \"%s/path/%s\"\n", vhost, name, v.Prefix())
+			}
+		})
+	}
+
+	dw.DAG.Roots(visit)
+
+	fmt.Fprintln(w, "}")
+}


### PR DESCRIPTION
This PR introduces a new package, `internal/dag`, a data model to underpin the upcoming refactoring of the contour translator to work with Ingress and IngressRoute CRDs.

The DAG data model presents an abstract representation of the relationship between Ingress, ingressroutes, their constituent routes, the secrets used for ingress TLS, and the backend services that routes point too. The DAG is flexible enough to represent data that cannot be expressed today in Ingress, for example, a route with more than one backend object; that is, more than one service. In the DAG data model, this is simply a route with more than one Service object as a child.

Initially the dag is only plumbed into contour in a read only manner -- it is another watcher on certain object types only. You can view a representation of the DAG in memory via a debug endpoint available on contour's debug interface
```
curl http://127.0.0.1:8000/debug/dag | dot -Tpng -o contour.png
```
Which will generate something like this
![graph](https://user-images.githubusercontent.com/7171/41034055-c2818530-69cb-11e8-9967-e9d014f75cca.png)

The visualisation is an example of walking the DAG via it's `Visit()` interface and generating data from it. In this case it's a .dot file, but the intention is to do the same for the data we need to send to Envoy. For example

- To generate LDS data we would walk the DAG from its roots, collecting VirtualHosts (these are roots of the graph, and represent the abstract properties of a virtual host; its port, its TLS settings, its aliases, etc) and generating data for the LDS data stream.
- To generate RDS data we would walk the DAG from the roots, looking for Route objects (these represent a path prefixes of a VirtualHost) the path from VirtualHost to Route tells us the name of the vhost it belongs too, and the children of the Route tell us how to write our the Envoy RDS table. In the future we'll model IngressRoute delegations as a chain of Route objects.
- To generate CDS, we walk the DAG to its leaves, collecting a set of Service objects, they become the CDS table. k8s service objects that are not reachable from the DAG roots are not sent to Envoy, this should address #298.
- EDS data is not handled by the DAG, see #404 

Each DAG object holds a reference to the k8s, or part thereof, object that created it, giving us a way to handle long standing issues like updates to status objects, #21. We walk the graph of roots, collecting ingress objects (attached to Routes), then update their status as described in the k8s spec.

I envisage that Ingressroute status updates can be handled in the same way; walking from roots downwards, for each Route object we find, we know the path in which we found it, including all parents, and can update its status. Additionally, the DAG presents a `VisitAll` method which allows us to visit each of the objects registered with the dag, even if it is not reachable from a root, giving us a way to handle IngressRoute objects which have been inserted into the DAG, generating Route objects, but were not attached to any root.