### PR TITLE
internal/dag: rewrite DAG to be immutable

### DIFF
--- a/internal/dag/dag.go
+++ b/internal/dag/dag.go
@@ -26,14 +26,20 @@ import (
 // A DAG represents a directed acylic graph of objects representing the relationship
 // between Kubernetes Ingress objects, the backend Services, and Secret objects.
 // The DAG models these relationships as Roots and Vertices.
-//
-// A DAG is mutable and not thread safe.
 type DAG struct {
-	rwm sync.RWMutex
+	mu sync.Mutex
 
-	roots    map[string]*VirtualHost
-	secrets  map[meta]*Secret
-	services map[meta]*Service
+	ingresses map[meta]*v1beta1.Ingress
+	secrets   map[meta]*v1.Secret
+	services  map[meta]*v1.Service
+
+	dag *dag
+}
+
+// dag represents
+type dag struct {
+	// roots are the roots of this dag
+	roots []Vertex
 }
 
 // meta holds the name and namespace of a Kubernetes object.
@@ -43,194 +49,146 @@ type meta struct {
 
 // Visit calls f for every root of this DAG.
 func (d *DAG) Visit(f func(Vertex)) {
-	d.rwm.RLock()
-	defer d.rwm.RUnlock()
-	d.visit(f)
-}
-
-func (d *DAG) visit(f func(Vertex)) {
-	for _, r := range d.roots {
+	d.mu.Lock()
+	dag := d.dag
+	d.mu.Unlock()
+	for _, r := range dag.roots {
 		f(r)
-	}
-}
-
-// VisitAll calls the function f for each Vertex registered with this DAG.
-// This includes Vertices which are not reachable from a Root, ie, those that
-// are orphaned.
-func (d *DAG) VisitAll(f func(Vertex)) {
-	d.rwm.RLock()
-	defer d.rwm.RUnlock()
-	for _, v := range d.roots {
-		f(v)
-	}
-	for _, v := range d.secrets {
-		f(v)
-	}
-	for _, v := range d.services {
-		f(v)
 	}
 }
 
 // Insert inserts obj into the DAG. If an object with a matching type, name, and
 // namespace exists, it will be overwritten.
 func (d *DAG) Insert(obj interface{}) {
-	d.rwm.Lock()
-	defer d.rwm.Unlock()
+	d.mu.Lock()
+	defer d.mu.Unlock()
 	switch obj := obj.(type) {
 	case *v1.Secret:
-		d.insertSecret(obj)
+		m := meta{name: obj.Name, namespace: obj.Namespace}
+		if d.secrets == nil {
+			d.secrets = make(map[meta]*v1.Secret)
+		}
+		d.secrets[m] = obj
 	case *v1.Service:
-		d.insertService(obj)
+		m := meta{name: obj.Name, namespace: obj.Namespace}
+		if d.services == nil {
+			d.services = make(map[meta]*v1.Service)
+		}
+		d.services[m] = obj
 	case *v1beta1.Ingress:
-		d.insertIngress(obj)
+		m := meta{name: obj.Name, namespace: obj.Namespace}
+		if d.ingresses == nil {
+			d.ingresses = make(map[meta]*v1beta1.Ingress)
+		}
+		d.ingresses[m] = obj
+	default:
+		// not an interesting object
 	}
 }
 
 // Remove removes obj from the DAG. If no object with a matching type, name, and
 // namespace exists in the DAG, no action is taken.
 func (d *DAG) Remove(obj interface{}) {
-	d.rwm.Lock()
-	defer d.rwm.Unlock()
 	switch obj := obj.(type) {
+	default:
+		d.remove(obj)
 	case cache.DeletedFinalStateUnknown:
 		d.Remove(obj.Obj) // recurse into ourselves with the tombstoned value
 	}
 }
 
-// insertSecret inserts a Secret into the DAG. If there is an existing Service with
-// the same name and namespace, it will be replaced.
-func (d *DAG) insertSecret(s *v1.Secret) {
-
-	m := meta{name: s.Name, namespace: s.Namespace}
-
-	// lookup vertex in secrets map
-	v, ok := d.secrets[m]
-	if !ok {
-		v = new(Secret)
-		if d.secrets == nil {
-			d.secrets = make(map[meta]*Secret)
+func (d *DAG) remove(obj interface{}) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	switch obj := obj.(type) {
+	case *v1.Secret:
+		m := meta{name: obj.Name, namespace: obj.Namespace}
+		delete(d.secrets, m)
+		if len(d.secrets) == 0 {
+			d.secrets = nil
 		}
-		d.secrets[m] = v
-	}
-	v.object = s
-
-	// now visit each root and if there is an ingress object matching this secret,
-	// add this secret as a child of that root.
-	d.visit(func(v Vertex) {
-		vh := v.(*VirtualHost)
-		vh.Visit(func(v Vertex) {
-			r, ok := v.(*Route)
-			if !ok {
-				// not a route, skip it
-				return
-			}
-			if r.object.Namespace != s.Namespace {
-				// this secret does not match the namespace the ingress
-				// that geneated this route belogs to, skip it.
-				return
-			}
-			for _, tls := range r.object.Spec.TLS {
-				d.addSecret(&tls, vh, tls.SecretName, s.Namespace)
-			}
-		})
-	})
-}
-
-// addSecret looks up the named secret and if it exists
-// adds it to vh.
-func (d *DAG) addSecret(tls *v1beta1.IngressTLS, vh *VirtualHost, name, namespace string) {
-	m := meta{name: name, namespace: namespace}
-	if s, ok := d.secrets[m]; ok {
-		for _, host := range tls.Hosts {
-			if host == vh.FQDN() {
-				vh.addSecret(s)
-			}
+	case *v1.Service:
+		m := meta{name: obj.Name, namespace: obj.Namespace}
+		delete(d.services, m)
+		if len(d.services) == 0 {
+			d.services = nil
 		}
+	case *v1beta1.Ingress:
+		m := meta{name: obj.Name, namespace: obj.Namespace}
+		delete(d.ingresses, m)
+		if len(d.ingresses) == 0 {
+			d.ingresses = nil
+		}
+	default:
+		// not interesting
 	}
 }
 
-// insertService inserts a Servce into the DAG. If there is an existing Service with
-// the same name and namespace, it will be replaced.
-func (d *DAG) insertService(svc *v1.Service) {
-	s := d.service(svc)
-
-	// foreach root, foreach route, attach this vertex as a child if the
-	// name and namespace match.
-	d.visit(func(virtualhost Vertex) {
-		virtualhost.Visit(func(v Vertex) {
-			r, ok := v.(*Route)
-			if !ok {
-				// not a route, skip it
-				return
-			}
-			if r.object.Namespace != s.object.Namespace {
-				// route's ingress object doesn't match service
-				return
-			}
-			if r.backend.ServiceName != s.object.Name {
-				// services's name doesn't match ingress's backend
-				return
-			}
-			// iterate through the ports on the service object, if we
-			// find a match against the port's name or number, we add
-			// the service as a child of the route.
-			for _, p := range s.object.Spec.Ports {
-				if r.backend.ServicePort.IntValue() == int(p.Port) || r.backend.ServicePort.String() == p.Name {
-					r.addService(s)
-				}
-			}
-		})
-	})
+// Recompute recomputes the DAG.
+func (d *DAG) Recompute() {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.dag = d.recompute()
 }
 
-func (d *DAG) insertIngress(i *v1beta1.Ingress) {
-	if i.Spec.Backend != nil {
-		vh := d.virtualhost("*")
-		r := &Route{
-			path:    "/",
-			object:  i,
-			backend: i.Spec.Backend,
+// recompute builds a new *dag.dag.
+func (d *DAG) recompute() *dag {
+	_services := make(map[meta]*Service)
+	service := func(m meta) *Service {
+		if s, ok := _services[m]; ok {
+			return s
 		}
-		vh.routes[r.path] = r
-
-		m := meta{name: r.backend.ServiceName, namespace: r.object.Namespace}
-		if s, ok := d.services[m]; ok {
-			// iterate through the ports on the service object, if we
-			// find a match against the backends port's name or number, we add
-			// the service as a child of the route.
-			for _, p := range s.object.Spec.Ports {
-				if r.backend.ServicePort.IntValue() == int(p.Port) || r.backend.ServicePort.String() == p.Name {
-					r.addService(s)
-				}
-			}
+		svc, ok := d.services[m]
+		if !ok {
+			return nil
 		}
+		s := &Service{
+			object: svc,
+		}
+		_services[s.toMeta()] = s
+		return s
 	}
 
-	for _, rule := range i.Spec.Rules {
-		host := rule.Host
-		if host == "" {
-			host = "*"
+	_secrets := make(map[meta]*Secret)
+	secret := func(m meta) *Secret {
+		if s, ok := _secrets[m]; ok {
+			return s
 		}
-		vh := d.virtualhost(host)
-
-		for _, tls := range i.Spec.TLS {
-			d.addSecret(&tls, vh, tls.SecretName, i.Namespace)
+		sec, ok := d.secrets[m]
+		if !ok {
+			return nil
 		}
+		s := &Secret{
+			object: sec,
+		}
+		_secrets[s.toMeta()] = s
+		return s
+	}
 
-		for n := range rule.IngressRuleValue.HTTP.Paths {
-			path := rule.IngressRuleValue.HTTP.Paths[n].Path
-			if path == "" {
-				path = "/"
+	_vhosts := make(map[string]*VirtualHost)
+	vhost := func(host string) *VirtualHost {
+		vh, ok := _vhosts[host]
+		if !ok {
+			vh = &VirtualHost{
+				host:   host,
+				routes: make(map[string]*Route),
 			}
+			_vhosts[host] = vh
+		}
+		return vh
+	}
+
+	// step 3. deconstruct each ingress into routes and virtualhost entries
+	// routes := make(map[hostpath]*Route)
+	for _, ing := range d.ingresses {
+		if ing.Spec.Backend != nil {
 			r := &Route{
-				path:    path,
-				object:  i,
-				backend: &rule.IngressRuleValue.HTTP.Paths[n].Backend,
+				path:    "/",
+				object:  ing,
+				backend: ing.Spec.Backend,
 			}
-			vh.routes[r.path] = r
-
 			m := meta{name: r.backend.ServiceName, namespace: r.object.Namespace}
-			if s, ok := d.services[m]; ok {
+			if s := service(m); s != nil {
 				// iterate through the ports on the service object, if we
 				// find a match against the backends port's name or number, we add
 				// the service as a child of the route.
@@ -240,42 +198,54 @@ func (d *DAG) insertIngress(i *v1beta1.Ingress) {
 					}
 				}
 			}
+			vhost("*").routes[r.path] = r
+		}
+
+		for _, tls := range ing.Spec.TLS {
+			m := meta{name: tls.SecretName, namespace: ing.Namespace}
+			if sec := secret(m); sec != nil {
+				for _, host := range tls.Hosts {
+					vhost(host).addSecret(sec)
+				}
+			}
+		}
+
+		for _, rule := range ing.Spec.Rules {
+			host := rule.Host
+			if host == "" {
+				host = "*"
+			}
+			for n := range rule.IngressRuleValue.HTTP.Paths {
+				path := rule.IngressRuleValue.HTTP.Paths[n].Path
+				if path == "" {
+					path = "/"
+				}
+				r := &Route{
+					path:    path,
+					object:  ing,
+					backend: &rule.IngressRuleValue.HTTP.Paths[n].Backend,
+				}
+
+				m := meta{name: r.backend.ServiceName, namespace: r.object.Namespace}
+				if s := service(m); s != nil {
+					// iterate through the ports on the service object, if we
+					// find a match against the backends port's name or number, we add
+					// the service as a child of the route.
+					for _, p := range s.object.Spec.Ports {
+						if r.backend.ServicePort.IntValue() == int(p.Port) || r.backend.ServicePort.String() == p.Name {
+							r.addService(s)
+						}
+					}
+				}
+				vhost(host).routes[r.path] = r
+			}
 		}
 	}
-}
-
-// virtualhost returns the *VirtualHost record
-// for this host. If none exists, it is created.
-func (d *DAG) virtualhost(host string) *VirtualHost {
-	vh, ok := d.roots[host]
-	if ok {
-		return vh
+	_d := new(dag)
+	for _, vh := range _vhosts {
+		_d.roots = append(_d.roots, vh)
 	}
-	vh = &VirtualHost{
-		host:   host,
-		routes: make(map[string]*Route),
-	}
-	if d.roots == nil {
-		d.roots = make(map[string]*VirtualHost)
-	}
-	d.roots[vh.host] = vh
-	return vh
-}
-
-// service returns the *Service record for the *v1.Service.
-// If none exists, it is created.
-func (d *DAG) service(svc *v1.Service) *Service {
-	m := meta{name: svc.Name, namespace: svc.Namespace}
-	s, ok := d.services[m]
-	if !ok {
-		s = new(Service)
-		if d.services == nil {
-			d.services = make(map[meta]*Service)
-		}
-		d.services[m] = s
-	}
-	s.object = svc
-	return s
+	return _d
 }
 
 type Root interface {

--- a/internal/dag/dag_test.go
+++ b/internal/dag/dag_test.go
@@ -899,6 +899,7 @@ func TestInsert(t *testing.T) {
 			for _, o := range tc.objs {
 				d.Insert(o)
 			}
+			d.Recompute()
 
 			got := make(map[string]*VirtualHost)
 			d.Visit(func(v Vertex) {

--- a/internal/dag/dag_test.go
+++ b/internal/dag/dag_test.go
@@ -24,10 +24,9 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
-func TestInsert(t *testing.T) {
+func TestDAGInsert(t *testing.T) {
 	// The DAG is senstive to ordering, adding an ingress, then a service,
-	// should have the same result as adding a sevice, then an ingress, but
-	// operationally triggers very different code paths.
+	// should have the same result as adding a sevice, then an ingress.
 
 	i1 := &v1beta1.Ingress{
 		ObjectMeta: metav1.ObjectMeta{
@@ -898,6 +897,470 @@ func TestInsert(t *testing.T) {
 			var d DAG
 			for _, o := range tc.objs {
 				d.Insert(o)
+			}
+			d.Recompute()
+
+			got := make(map[string]*VirtualHost)
+			d.Visit(func(v Vertex) {
+				if v, ok := v.(*VirtualHost); ok {
+					got[v.FQDN()] = v
+				}
+			})
+
+			want := make(map[string]*VirtualHost)
+			for _, vh := range tc.want {
+				want[vh.FQDN()] = vh
+			}
+
+			if !reflect.DeepEqual(want, got) {
+				t.Fatal("expected:\n", want, "\ngot:\n", got)
+			}
+
+		})
+	}
+}
+
+func TestDAGRemove(t *testing.T) {
+	// The DAG is senstive to ordering, removing an ingress, then a service,
+	// has a different effect than removing a sevice, then an ingress.
+
+	i1 := &v1beta1.Ingress{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "kuard",
+			Namespace: "default",
+		},
+		Spec: v1beta1.IngressSpec{
+			Backend: backend("kuard", intstr.FromInt(8080))},
+	}
+	// i2 is functionally identical to i1
+	i2 := &v1beta1.Ingress{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "kuard",
+			Namespace: "default",
+		},
+		Spec: v1beta1.IngressSpec{
+			Rules: []v1beta1.IngressRule{{
+				IngressRuleValue: ingressrulevalue(backend("kuard", intstr.FromInt(8080))),
+			}},
+		},
+	}
+	// i3 is similar to i2 but includes a hostname on the ingress rule
+	i3 := &v1beta1.Ingress{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "kuard",
+			Namespace: "default",
+		},
+		Spec: v1beta1.IngressSpec{
+			TLS: []v1beta1.IngressTLS{{
+				Hosts:      []string{"kuard.example.com"},
+				SecretName: "secret",
+			}},
+			Rules: []v1beta1.IngressRule{{
+				Host:             "kuard.example.com",
+				IngressRuleValue: ingressrulevalue(backend("kuard", intstr.FromInt(8080))),
+			}},
+		},
+	}
+	// i5 is functionally identical to i2
+	i5 := &v1beta1.Ingress{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "kuard",
+			Namespace: "default",
+		},
+		Spec: v1beta1.IngressSpec{
+			Rules: []v1beta1.IngressRule{{
+				IngressRuleValue: ingressrulevalue(backend("kuard", intstr.FromString("http"))),
+			}},
+		},
+	}
+	// i6 contains two named vhosts which point to the same sevice
+	// one of those has TLS
+	i6 := &v1beta1.Ingress{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "two-vhosts",
+			Namespace: "default",
+		},
+		Spec: v1beta1.IngressSpec{
+			TLS: []v1beta1.IngressTLS{{
+				Hosts:      []string{"b.example.com"},
+				SecretName: "secret",
+			}},
+			Rules: []v1beta1.IngressRule{{
+				Host:             "a.example.com",
+				IngressRuleValue: ingressrulevalue(backend("kuard", intstr.FromInt(8080))),
+			}, {
+				Host:             "b.example.com",
+				IngressRuleValue: ingressrulevalue(backend("kuard", intstr.FromString("http"))),
+			}},
+		},
+	}
+	// i7 contains a single vhost with two paths
+	i7 := &v1beta1.Ingress{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "two-paths",
+			Namespace: "default",
+		},
+		Spec: v1beta1.IngressSpec{
+			TLS: []v1beta1.IngressTLS{{
+				Hosts:      []string{"b.example.com"},
+				SecretName: "secret",
+			}},
+			Rules: []v1beta1.IngressRule{{
+				Host: "b.example.com",
+				IngressRuleValue: v1beta1.IngressRuleValue{
+					HTTP: &v1beta1.HTTPIngressRuleValue{
+						Paths: []v1beta1.HTTPIngressPath{{
+							Backend: v1beta1.IngressBackend{
+								ServiceName: "kuard",
+								ServicePort: intstr.FromString("http"),
+							},
+						}, {
+							Path: "/kuarder",
+							Backend: v1beta1.IngressBackend{
+								ServiceName: "kuarder",
+								ServicePort: intstr.FromInt(8080),
+							},
+						}},
+					},
+				},
+			}},
+		},
+	}
+
+	s1 := &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "kuard",
+			Namespace: "default",
+		},
+		Spec: v1.ServiceSpec{
+			Ports: []v1.ServicePort{{
+				Name:       "http",
+				Protocol:   "TCP",
+				Port:       8080,
+				TargetPort: intstr.FromInt(8080),
+			}},
+		},
+	}
+	// s2 is like s1 but with a different name
+	s2 := &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "kuarder",
+			Namespace: "default",
+		},
+		Spec: v1.ServiceSpec{
+			Ports: []v1.ServicePort{{
+				Name:       "http",
+				Protocol:   "TCP",
+				Port:       8080,
+				TargetPort: intstr.FromInt(8080),
+			}},
+		},
+	}
+	sec1 := &v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "secret",
+			Namespace: "default",
+		},
+		Data: secretdata("certificate", "key"),
+	}
+
+	tests := map[string]struct {
+		insert []interface{}
+		remove []interface{}
+		want   []*VirtualHost
+	}{
+		"remove ingress w/ default backend": {
+			insert: []interface{}{
+				i1,
+			},
+			remove: []interface{}{
+				i1,
+			},
+			want: []*VirtualHost{},
+		},
+		"remove ingress w/ single unnamed backend": {
+			insert: []interface{}{
+				i2,
+			},
+			remove: []interface{}{
+				i2,
+			},
+			want: []*VirtualHost{},
+		},
+		"insert ingress w/ host name and single backend": {
+			insert: []interface{}{
+				i3,
+			},
+			want: []*VirtualHost{{
+				host: "kuard.example.com",
+				routes: map[string]*Route{
+					"/": &Route{
+						path:    "/",
+						object:  i3,
+						backend: &i3.Spec.Rules[0].IngressRuleValue.HTTP.Paths[0].Backend,
+					},
+				},
+			}},
+		},
+		"remove ingress w/ default backend leaving matching service": {
+			insert: []interface{}{
+				i1,
+				s1,
+			},
+			remove: []interface{}{
+				i1,
+			},
+			want: []*VirtualHost{},
+		},
+		"remove service leaving ingress w/ default backend": {
+			insert: []interface{}{
+				s1,
+				i1,
+			},
+			remove: []interface{}{
+				s1,
+			},
+			want: []*VirtualHost{{
+				host: "*",
+				routes: map[string]*Route{
+					"/": &Route{
+						path:    "/",
+						object:  i1,
+						backend: i1.Spec.Backend,
+					},
+				},
+			}},
+		},
+		"remove non matching service leaving ingress w/ default backend": {
+			insert: []interface{}{
+				i1,
+				s2,
+			},
+			remove: []interface{}{
+				s2,
+			},
+			want: []*VirtualHost{{
+				host: "*",
+				routes: map[string]*Route{
+					"/": &Route{
+						path:    "/",
+						object:  i1,
+						backend: i1.Spec.Backend,
+					},
+				},
+			}},
+		},
+		"remove ingress w/ default backend leaving non matching service": {
+			insert: []interface{}{
+				s2,
+				i1,
+			},
+			remove: []interface{}{
+				i1,
+			},
+			want: []*VirtualHost{},
+		},
+		"remove service w/ named service port leaving ingress w/ single unnamed backend": {
+			insert: []interface{}{
+				i5,
+				s1,
+			},
+			remove: []interface{}{
+				s1,
+			},
+			want: []*VirtualHost{{
+				host: "*",
+				routes: map[string]*Route{
+					"/": &Route{
+						path:    "/",
+						object:  i5,
+						backend: &i5.Spec.Rules[0].IngressRuleValue.HTTP.Paths[0].Backend,
+					},
+				},
+			}},
+		},
+		"remove secret leaving ingress w/ tls": {
+			insert: []interface{}{
+				sec1,
+				i3,
+			},
+			remove: []interface{}{
+				sec1,
+			},
+			want: []*VirtualHost{{
+				host: "kuard.example.com",
+				routes: map[string]*Route{
+					"/": &Route{
+						path:    "/",
+						object:  i3,
+						backend: &i3.Spec.Rules[0].IngressRuleValue.HTTP.Paths[0].Backend,
+					},
+				},
+			}},
+		},
+		"remove ingress w/ two vhosts": {
+			insert: []interface{}{
+				i6,
+			},
+			remove: []interface{}{
+				i6,
+			},
+			want: []*VirtualHost{},
+		},
+		"remove service leaving ingress w/ two vhosts": {
+			insert: []interface{}{
+				i6,
+				s1,
+			},
+			remove: []interface{}{
+				s1,
+			},
+			want: []*VirtualHost{{
+				host: "a.example.com",
+				routes: map[string]*Route{
+					"/": &Route{
+						path:    "/",
+						object:  i6,
+						backend: &i6.Spec.Rules[0].IngressRuleValue.HTTP.Paths[0].Backend,
+					},
+				},
+			}, {
+				host: "b.example.com",
+				routes: map[string]*Route{
+					"/": &Route{
+						path:    "/",
+						object:  i6,
+						backend: &i6.Spec.Rules[1].IngressRuleValue.HTTP.Paths[0].Backend,
+					},
+				},
+			}},
+		},
+		"remove secret from ingress w/ two vhosts and service": {
+			insert: []interface{}{
+				i6,
+				s1,
+				sec1,
+			},
+			remove: []interface{}{
+				sec1,
+			},
+			want: []*VirtualHost{{
+				host: "a.example.com",
+				routes: map[string]*Route{
+					"/": &Route{
+						path:    "/",
+						object:  i6,
+						backend: &i6.Spec.Rules[0].IngressRuleValue.HTTP.Paths[0].Backend,
+						services: map[meta]*Service{
+							meta{
+								name:      "kuard",
+								namespace: "default",
+							}: &Service{
+								object: s1,
+							},
+						},
+					},
+				},
+			}, {
+				host: "b.example.com",
+				routes: map[string]*Route{
+					"/": &Route{
+						path:    "/",
+						object:  i6,
+						backend: &i6.Spec.Rules[1].IngressRuleValue.HTTP.Paths[0].Backend,
+						services: map[meta]*Service{
+							meta{
+								name:      "kuard",
+								namespace: "default",
+							}: &Service{
+								object: s1,
+							},
+						},
+					},
+				},
+			}},
+		},
+		"remove service from ingress w/ two vhosts and secret": {
+			insert: []interface{}{
+				s1,
+				sec1,
+				i6,
+			},
+			remove: []interface{}{
+				s1,
+			},
+			want: []*VirtualHost{{
+				host: "a.example.com",
+				routes: map[string]*Route{
+					"/": &Route{
+						path:    "/",
+						object:  i6,
+						backend: &i6.Spec.Rules[0].IngressRuleValue.HTTP.Paths[0].Backend,
+					},
+				},
+			}, {
+				host: "b.example.com",
+				routes: map[string]*Route{
+					"/": &Route{
+						path:    "/",
+						object:  i6,
+						backend: &i6.Spec.Rules[1].IngressRuleValue.HTTP.Paths[0].Backend,
+					},
+				},
+				secrets: map[meta]*Secret{
+					meta{
+						name:      "secret",
+						namespace: "default",
+					}: &Secret{
+						object: sec1,
+					},
+				},
+			}},
+		},
+		"remove service from  ingress w/ two paths": {
+			insert: []interface{}{
+				i7,
+				s2,
+				s1,
+			},
+			remove: []interface{}{
+				s2,
+			},
+			want: []*VirtualHost{{
+				host: "b.example.com",
+				routes: map[string]*Route{
+					"/": &Route{
+						path:    "/",
+						object:  i7,
+						backend: &i7.Spec.Rules[0].IngressRuleValue.HTTP.Paths[0].Backend,
+						services: map[meta]*Service{
+							meta{
+								name:      "kuard",
+								namespace: "default",
+							}: &Service{
+								object: s1,
+							},
+						},
+					},
+					"/kuarder": &Route{
+						path:    "/kuarder",
+						object:  i7,
+						backend: &i7.Spec.Rules[0].IngressRuleValue.HTTP.Paths[1].Backend,
+					},
+				},
+			}},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			var d DAG
+			for _, o := range tc.insert {
+				d.Insert(o)
+			}
+			d.Recompute()
+			for _, o := range tc.remove {
+				d.Remove(o)
 			}
 			d.Recompute()
 

--- a/internal/dag/k8s.go
+++ b/internal/dag/k8s.go
@@ -20,12 +20,16 @@ type ResourceEventHandler struct {
 
 func (r *ResourceEventHandler) OnAdd(obj interface{}) {
 	r.Insert(obj)
+	r.Recompute()
 }
 
 func (r *ResourceEventHandler) OnUpdate(oldObj, newObj interface{}) {
+	r.Remove(oldObj)
 	r.Insert(newObj)
+	r.Recompute()
 }
 
 func (r *ResourceEventHandler) OnDelete(obj interface{}) {
 	r.Remove(obj)
+	r.Recompute()
 }


### PR DESCRIPTION
Updates #428

This PR replaces the previously mutable DAG implementation with an immutable version. The rational for this is laid out in #428, and this PR accomplishes the replacement of the data structure. The holdoff behaviour described in #428 is not implemented, and will be assessed during load testing.

This new DAG is simpler and more reliable to build, but comes at the cost of high rates of allocation during high load, expected during startup. For the moment we're just going to live with that and accept that reliable rebuilds of the dag under steady state running will be the target. This will let us build unit tests as we add features to the DAG production. If we need to optimise the DAG later on, those unit tests will keep us honest.

Signed-off-by: Dave Cheney <dave@cheney.net>