### PR TITLE
internal/dag: create separate roots for port 80 and port 443 vhosts

### DIFF
--- a/internal/dag/annotations.go
+++ b/internal/dag/annotations.go
@@ -1,0 +1,111 @@
+// Copyright © 2018 Heptio
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dag
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/gogo/protobuf/types"
+	"k8s.io/api/extensions/v1beta1"
+)
+
+const (
+	// set docs/annotations.md for details of how these annotations
+	// are applied by Contour.
+
+	annotationRequestTimeout   = "contour.heptio.com/request-timeout"
+	annotationWebsocketRoutes  = "contour.heptio.com/websocket-routes"
+	annotationUpstreamProtocol = "contour.heptio.com/upstream-protocol"
+
+	// By default envoy applies a 15 second timeout to all backend requests.
+	// The explicit value 0 turns off the timeout, implying "never time out"
+	// https://www.envoyproxy.io/docs/envoy/v1.5.0/api-v2/rds.proto#routeaction
+	infiniteTimeout = time.Duration(0)
+)
+
+// parseAnnotationTimeout parses the annotations map for a contour.heptio.com/request-timeout
+// value. If the value is not present, false is returned and the timeout value should be
+// ignored. If the value is present, but malformed, the timeout value is valid, and represents
+// infinite timeout.
+func parseAnnotationTimeout(annotations map[string]string, annotation string) (time.Duration, bool) {
+	timeoutStr := annotations[annotationRequestTimeout]
+	// Error or unspecified is interpreted as no timeout specified, use envoy defaults
+	if timeoutStr == "" {
+		return 0, false
+	}
+	// Interpret "infinity" explicitly as an infinite timeout, which envoy config
+	// expects as a timeout of 0. This could be specified with the duration string
+	// "0s" but want to give an explicit out for operators.
+	if timeoutStr == "infinity" {
+		return infiniteTimeout, true
+	}
+
+	timeoutParsed, err := time.ParseDuration(timeoutStr)
+	if err != nil {
+		// TODO(cmalonty) plumb a logger in here so we can log this error.
+		// Assuming infinite duration is going to surprise people less for
+		// a not-parseable duration than a implicit 15 second one.
+		return infiniteTimeout, true
+	}
+	return timeoutParsed, true
+}
+
+// parseAnnotationUint32 parsers the annotation map for the supplied annotation key.
+// If the value is not present, or malformed, then nil is returned.
+func parseAnnotationUInt32(annotations map[string]string, annotation string) *types.UInt32Value {
+	v, err := strconv.ParseUint(annotations[annotation], 10, 32)
+	if err != nil {
+		return nil
+	}
+	return &types.UInt32Value{Value: uint32(v)}
+}
+
+// parseUpstreamProtocols parses the annotations map for a contour.heptio.com/upstream-protocol.{protocol}
+// where 'protocol' identifies which protocol must be used in the upstream.
+// If the value is not present, or malformed, then an empty map is returned.
+func parseUpstreamProtocols(annotations map[string]string, annotation string, protocols ...string) map[string]string {
+	up := make(map[string]string)
+	for _, protocol := range protocols {
+		ports := annotations[fmt.Sprintf("%s.%s", annotation, protocol)]
+		for _, v := range strings.Split(ports, ",") {
+			port := strings.TrimSpace(v)
+			if port != "" {
+				up[port] = protocol
+			}
+		}
+	}
+	return up
+}
+
+// httpAllowed returns true unless the kubernetes.io/ingress.allow-http annotation is
+// present and set to false.
+func httpAllowed(i *v1beta1.Ingress) bool {
+	return !(i.Annotations["kubernetes.io/ingress.allow-http"] == "false")
+}
+
+// websocketRoutes returns a map of websocket routes. If the value is not present, or
+// malformed, then an empty map is returned.
+func websocketRoutes(i *v1beta1.Ingress) map[string]*types.BoolValue {
+	routes := make(map[string]*types.BoolValue)
+	for _, v := range strings.Split(i.Annotations[annotationWebsocketRoutes], ",") {
+		route := strings.TrimSpace(v)
+		if route != "" {
+			routes[route] = &types.BoolValue{Value: true}
+		}
+	}
+	return routes
+}

--- a/internal/dag/annotations_test.go
+++ b/internal/dag/annotations_test.go
@@ -1,0 +1,276 @@
+// Copyright © 2018 Heptio
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dag
+
+import (
+	"fmt"
+	"math"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/gogo/protobuf/types"
+	"k8s.io/api/extensions/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+func TestParseAnnotationTimeout(t *testing.T) {
+	tests := map[string]struct {
+		a    map[string]string
+		want time.Duration
+		ok   bool
+	}{
+		"nada": {
+			a:    nil,
+			want: 0,
+			ok:   false,
+		},
+		"empty": {
+			a:    map[string]string{annotationRequestTimeout: ""}, // not even sure this is possible via the API
+			want: 0,
+			ok:   false,
+		},
+		"infinity": {
+			a:    map[string]string{annotationRequestTimeout: "infinity"},
+			want: 0,
+			ok:   true,
+		},
+		"10 seconds": {
+			a:    map[string]string{annotationRequestTimeout: "10s"},
+			want: 10 * time.Second,
+			ok:   true,
+		},
+		"invalid": {
+			a:    map[string]string{annotationRequestTimeout: "10"}, // 10 what?
+			want: 0,
+			ok:   true,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			got, ok := parseAnnotationTimeout(tc.a, annotationRequestTimeout)
+			if got != tc.want || ok != tc.ok {
+				t.Fatalf("parseAnnotationTimeout(%q): want: %v, %v, got: %v, %v", tc.a, tc.want, tc.ok, got, ok)
+			}
+		})
+	}
+}
+
+func TestParseAnnotationUInt32(t *testing.T) {
+	tests := map[string]struct {
+		a     map[string]string
+		want  uint32
+		isNil bool
+	}{
+		"nada": {
+			a:     nil,
+			isNil: true,
+		},
+		"empty": {
+			a:     map[string]string{annotationRequestTimeout: ""}, // not even sure this is possible via the API
+			isNil: true,
+		},
+		"smallest": {
+			a:    map[string]string{annotationRequestTimeout: "0"},
+			want: 0,
+		},
+		"middle value": {
+			a:    map[string]string{annotationRequestTimeout: "20"},
+			want: 20,
+		},
+		"biggest": {
+			a:    map[string]string{annotationRequestTimeout: "4294967295"},
+			want: math.MaxUint32,
+		},
+		"invalid": {
+			a:     map[string]string{annotationRequestTimeout: "10seconds"}, // not a duration
+			isNil: true,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := parseAnnotationUInt32(tc.a, annotationRequestTimeout)
+			full := types.UInt32Value{Value: tc.want}
+
+			if ((got == nil) != tc.isNil) || (got != nil && *got != full) {
+				t.Fatalf("parseAnnotationUInt32(%q): want: %v, isNil: %v, got: %v", tc.a, tc.want, tc.isNil, got)
+			}
+		})
+	}
+}
+
+func TestParseUpstreamProtocols(t *testing.T) {
+	tests := map[string]struct {
+		a    map[string]string
+		want map[string]string
+	}{
+		"nada": {
+			a:    nil,
+			want: map[string]string{},
+		},
+		"empty": {
+			a:    map[string]string{fmt.Sprintf("%s.%s", annotationUpstreamProtocol, "h2"): ""},
+			want: map[string]string{},
+		},
+		"empty with spaces": {
+			a:    map[string]string{fmt.Sprintf("%s.%s", annotationUpstreamProtocol, "h2"): ", ,"},
+			want: map[string]string{},
+		},
+		"single value": {
+			a: map[string]string{fmt.Sprintf("%s.%s", annotationUpstreamProtocol, "h2"): "80"},
+			want: map[string]string{
+				"80": "h2",
+			},
+		},
+		"multiple value": {
+			a: map[string]string{fmt.Sprintf("%s.%s", annotationUpstreamProtocol, "h2"): "80,http,443,https"},
+			want: map[string]string{
+				"80":    "h2",
+				"http":  "h2",
+				"443":   "h2",
+				"https": "h2",
+			},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := parseUpstreamProtocols(tc.a, annotationUpstreamProtocol, "h2")
+			if !reflect.DeepEqual(tc.want, got) {
+				t.Fatalf("parseUpstreamProtocols(%q): want: %v, got: %v", tc.a, tc.want, got)
+			}
+		})
+	}
+}
+
+func TestWebsocketRoutes(t *testing.T) {
+	tests := map[string]struct {
+		a    *v1beta1.Ingress
+		want map[string]*types.BoolValue
+	}{
+		"empty": {
+			a: &v1beta1.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{annotationWebsocketRoutes: ""},
+				},
+			},
+			want: map[string]*types.BoolValue{},
+		},
+		"empty with spaces": {
+			a: &v1beta1.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{annotationWebsocketRoutes: ", ,"},
+				},
+			},
+			want: map[string]*types.BoolValue{},
+		},
+		"single value": {
+			a: &v1beta1.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{annotationWebsocketRoutes: "/ws1"},
+				},
+			},
+			want: map[string]*types.BoolValue{
+				"/ws1": &types.BoolValue{Value: true},
+			},
+		},
+		"multiple values": {
+			a: &v1beta1.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{annotationWebsocketRoutes: "/ws1,/ws2"},
+				},
+			},
+			want: map[string]*types.BoolValue{
+				"/ws1": &types.BoolValue{Value: true},
+				"/ws2": &types.BoolValue{Value: true},
+			},
+		},
+		"multiple values with spaces and invalid entries": {
+			a: &v1beta1.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{annotationWebsocketRoutes: " /ws1, , /ws2 "},
+				},
+			},
+			want: map[string]*types.BoolValue{
+				"/ws1": &types.BoolValue{Value: true},
+				"/ws2": &types.BoolValue{Value: true},
+			},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := websocketRoutes(tc.a)
+			if !reflect.DeepEqual(tc.want, got) {
+				t.Fatalf("websocketRoutes(%q): want: %v, got: %v", tc.a, tc.want, got)
+			}
+		})
+	}
+}
+
+func TestHttpAllowed(t *testing.T) {
+	tests := map[string]struct {
+		i     *v1beta1.Ingress
+		valid bool
+	}{
+		"basic ingress": {
+			i: &v1beta1.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "simple",
+					Namespace: "default",
+				},
+				Spec: v1beta1.IngressSpec{
+					TLS: []v1beta1.IngressTLS{{
+						Hosts:      []string{"whatever.example.com"},
+						SecretName: "secret",
+					}},
+					Backend: backend("backend", intstr.FromInt(80)),
+				},
+			},
+			valid: true,
+		},
+		"kubernetes.io/ingress.allow-http: \"false\"": {
+			i: &v1beta1.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "simple",
+					Namespace: "default",
+					Annotations: map[string]string{
+						"kubernetes.io/ingress.allow-http": "false",
+					},
+				},
+				Spec: v1beta1.IngressSpec{
+					TLS: []v1beta1.IngressTLS{{
+						Hosts:      []string{"whatever.example.com"},
+						SecretName: "secret",
+					}},
+					Backend: backend("backend", intstr.FromInt(80)),
+				},
+			},
+			valid: false,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := httpAllowed(tc.i)
+			want := tc.valid
+			if got != want {
+				t.Fatalf("got: %v, want: %v", got, want)
+			}
+		})
+	}
+}

--- a/internal/dag/dag.go
+++ b/internal/dag/dag.go
@@ -186,6 +186,10 @@ func (d *DAG) recompute() *dag {
 
 	// deconstruct each ingress into routes and virtualhost entries
 	for _, ing := range d.ingresses {
+
+		// should we create port 80 routes for this ingress
+		httpAllowed := httpAllowed(ing)
+
 		if ing.Spec.Backend != nil {
 
 			// handle the annoying default ingress
@@ -205,7 +209,9 @@ func (d *DAG) recompute() *dag {
 					}
 				}
 			}
-			vhost("*", 80).routes[r.path] = r
+			if httpAllowed {
+				vhost("*", 80).routes[r.path] = r
+			}
 		}
 
 		// attach secrets from ingress to vhosts
@@ -247,7 +253,9 @@ func (d *DAG) recompute() *dag {
 						}
 					}
 				}
-				vhost(host, 80).routes[r.path] = r
+				if httpAllowed {
+					vhost(host, 80).routes[r.path] = r
+				}
 				if _, ok := _vhosts[hostport{host: host, port: 443}]; ok && host != "*" {
 					vhost(host, 443).routes[r.path] = r
 				}

--- a/internal/dag/dag.go
+++ b/internal/dag/dag.go
@@ -213,7 +213,7 @@ func (d *DAG) recompute() *dag {
 			m := meta{name: tls.SecretName, namespace: ing.Namespace}
 			if sec := secret(m); sec != nil {
 				for _, host := range tls.Hosts {
-					vhost(host, 80).addSecret(sec)
+					vhost(host, 443).addSecret(sec)
 				}
 			}
 		}
@@ -248,6 +248,9 @@ func (d *DAG) recompute() *dag {
 					}
 				}
 				vhost(host, 80).routes[r.path] = r
+				if _, ok := _vhosts[hostport{host: host, port: 443}]; ok && host != "*" {
+					vhost(host, 443).routes[r.path] = r
+				}
 			}
 		}
 	}

--- a/internal/dag/dag_test.go
+++ b/internal/dag/dag_test.go
@@ -240,6 +240,7 @@ func TestDAGInsert(t *testing.T) {
 				i1,
 			},
 			want: []*VirtualHost{{
+				Port: 80,
 				host: "*",
 				routes: map[string]*Route{
 					"/": &Route{
@@ -255,6 +256,7 @@ func TestDAGInsert(t *testing.T) {
 				i2,
 			},
 			want: []*VirtualHost{{
+				Port: 80,
 				host: "*",
 				routes: map[string]*Route{
 					"/": &Route{
@@ -270,6 +272,7 @@ func TestDAGInsert(t *testing.T) {
 				i3,
 			},
 			want: []*VirtualHost{{
+				Port: 80,
 				host: "kuard.example.com",
 				routes: map[string]*Route{
 					"/": &Route{
@@ -286,6 +289,7 @@ func TestDAGInsert(t *testing.T) {
 				s1,
 			},
 			want: []*VirtualHost{{
+				Port: 80,
 				host: "*",
 				routes: map[string]*Route{
 					"/": &Route{
@@ -310,6 +314,7 @@ func TestDAGInsert(t *testing.T) {
 				i1,
 			},
 			want: []*VirtualHost{{
+				Port: 80,
 				host: "*",
 				routes: map[string]*Route{
 					"/": &Route{
@@ -334,6 +339,7 @@ func TestDAGInsert(t *testing.T) {
 				s2,
 			},
 			want: []*VirtualHost{{
+				Port: 80,
 				host: "*",
 				routes: map[string]*Route{
 					"/": &Route{
@@ -350,6 +356,7 @@ func TestDAGInsert(t *testing.T) {
 				i1,
 			},
 			want: []*VirtualHost{{
+				Port: 80,
 				host: "*",
 				routes: map[string]*Route{
 					"/": &Route{
@@ -366,6 +373,7 @@ func TestDAGInsert(t *testing.T) {
 				s3,
 			},
 			want: []*VirtualHost{{
+				Port: 80,
 				host: "*",
 				routes: map[string]*Route{
 					"/": &Route{
@@ -382,6 +390,7 @@ func TestDAGInsert(t *testing.T) {
 				i1,
 			},
 			want: []*VirtualHost{{
+				Port: 80,
 				host: "*",
 				routes: map[string]*Route{
 					"/": &Route{
@@ -398,6 +407,7 @@ func TestDAGInsert(t *testing.T) {
 				s3,
 			},
 			want: []*VirtualHost{{
+				Port: 80,
 				host: "*",
 				routes: map[string]*Route{
 					"/": &Route{
@@ -414,6 +424,7 @@ func TestDAGInsert(t *testing.T) {
 				i2,
 			},
 			want: []*VirtualHost{{
+				Port: 80,
 				host: "*",
 				routes: map[string]*Route{
 					"/": &Route{
@@ -430,6 +441,7 @@ func TestDAGInsert(t *testing.T) {
 				s1,
 			},
 			want: []*VirtualHost{{
+				Port: 80,
 				host: "*",
 				routes: map[string]*Route{
 					"/": &Route{
@@ -454,6 +466,7 @@ func TestDAGInsert(t *testing.T) {
 				i4,
 			},
 			want: []*VirtualHost{{
+				Port: 80,
 				host: "*",
 				routes: map[string]*Route{
 					"/": &Route{
@@ -478,6 +491,7 @@ func TestDAGInsert(t *testing.T) {
 				s1,
 			},
 			want: []*VirtualHost{{
+				Port: 80,
 				host: "*",
 				routes: map[string]*Route{
 					"/": &Route{
@@ -502,6 +516,7 @@ func TestDAGInsert(t *testing.T) {
 				i5,
 			},
 			want: []*VirtualHost{{
+				Port: 80,
 				host: "*",
 				routes: map[string]*Route{
 					"/": &Route{
@@ -532,6 +547,7 @@ func TestDAGInsert(t *testing.T) {
 				i1,
 			},
 			want: []*VirtualHost{{
+				Port: 80,
 				host: "*",
 				routes: map[string]*Route{
 					"/": &Route{
@@ -548,6 +564,7 @@ func TestDAGInsert(t *testing.T) {
 				i3,
 			},
 			want: []*VirtualHost{{
+				Port: 80,
 				host: "kuard.example.com",
 				routes: map[string]*Route{
 					"/": &Route{
@@ -572,6 +589,7 @@ func TestDAGInsert(t *testing.T) {
 				sec1,
 			},
 			want: []*VirtualHost{{
+				Port: 80,
 				host: "kuard.example.com",
 				routes: map[string]*Route{
 					"/": &Route{
@@ -595,6 +613,7 @@ func TestDAGInsert(t *testing.T) {
 				i6,
 			},
 			want: []*VirtualHost{{
+				Port: 80,
 				host: "a.example.com",
 				routes: map[string]*Route{
 					"/": &Route{
@@ -604,6 +623,7 @@ func TestDAGInsert(t *testing.T) {
 					},
 				},
 			}, {
+				Port: 80,
 				host: "b.example.com",
 				routes: map[string]*Route{
 					"/": &Route{
@@ -620,6 +640,7 @@ func TestDAGInsert(t *testing.T) {
 				s1,
 			},
 			want: []*VirtualHost{{
+				Port: 80,
 				host: "a.example.com",
 				routes: map[string]*Route{
 					"/": &Route{
@@ -637,6 +658,7 @@ func TestDAGInsert(t *testing.T) {
 					},
 				},
 			}, {
+				Port: 80,
 				host: "b.example.com",
 				routes: map[string]*Route{
 					"/": &Route{
@@ -661,6 +683,7 @@ func TestDAGInsert(t *testing.T) {
 				i6,
 			},
 			want: []*VirtualHost{{
+				Port: 80,
 				host: "a.example.com",
 				routes: map[string]*Route{
 					"/": &Route{
@@ -678,6 +701,7 @@ func TestDAGInsert(t *testing.T) {
 					},
 				},
 			}, {
+				Port: 80,
 				host: "b.example.com",
 				routes: map[string]*Route{
 					"/": &Route{
@@ -703,6 +727,7 @@ func TestDAGInsert(t *testing.T) {
 				sec1,
 			},
 			want: []*VirtualHost{{
+				Port: 80,
 				host: "a.example.com",
 				routes: map[string]*Route{
 					"/": &Route{
@@ -720,6 +745,7 @@ func TestDAGInsert(t *testing.T) {
 					},
 				},
 			}, {
+				Port: 80,
 				host: "b.example.com",
 				routes: map[string]*Route{
 					"/": &Route{
@@ -753,6 +779,7 @@ func TestDAGInsert(t *testing.T) {
 				i6,
 			},
 			want: []*VirtualHost{{
+				Port: 80,
 				host: "a.example.com",
 				routes: map[string]*Route{
 					"/": &Route{
@@ -770,6 +797,7 @@ func TestDAGInsert(t *testing.T) {
 					},
 				},
 			}, {
+				Port: 80,
 				host: "b.example.com",
 				routes: map[string]*Route{
 					"/": &Route{
@@ -801,6 +829,7 @@ func TestDAGInsert(t *testing.T) {
 				i7,
 			},
 			want: []*VirtualHost{{
+				Port: 80,
 				host: "b.example.com",
 				routes: map[string]*Route{
 					"/": &Route{
@@ -823,6 +852,7 @@ func TestDAGInsert(t *testing.T) {
 				s1,
 			},
 			want: []*VirtualHost{{
+				Port: 80,
 				host: "b.example.com",
 				routes: map[string]*Route{
 					"/": &Route{
@@ -859,6 +889,7 @@ func TestDAGInsert(t *testing.T) {
 				s1, s2, i8,
 			},
 			want: []*VirtualHost{{
+				Port: 80,
 				host: "b.example.com",
 				routes: map[string]*Route{
 					"/": &Route{
@@ -1092,6 +1123,7 @@ func TestDAGRemove(t *testing.T) {
 				i3,
 			},
 			want: []*VirtualHost{{
+				Port: 80,
 				host: "kuard.example.com",
 				routes: map[string]*Route{
 					"/": &Route{
@@ -1121,6 +1153,7 @@ func TestDAGRemove(t *testing.T) {
 				s1,
 			},
 			want: []*VirtualHost{{
+				Port: 80,
 				host: "*",
 				routes: map[string]*Route{
 					"/": &Route{
@@ -1140,6 +1173,7 @@ func TestDAGRemove(t *testing.T) {
 				s2,
 			},
 			want: []*VirtualHost{{
+				Port: 80,
 				host: "*",
 				routes: map[string]*Route{
 					"/": &Route{
@@ -1169,6 +1203,7 @@ func TestDAGRemove(t *testing.T) {
 				s1,
 			},
 			want: []*VirtualHost{{
+				Port: 80,
 				host: "*",
 				routes: map[string]*Route{
 					"/": &Route{
@@ -1188,6 +1223,7 @@ func TestDAGRemove(t *testing.T) {
 				sec1,
 			},
 			want: []*VirtualHost{{
+				Port: 80,
 				host: "kuard.example.com",
 				routes: map[string]*Route{
 					"/": &Route{
@@ -1216,6 +1252,7 @@ func TestDAGRemove(t *testing.T) {
 				s1,
 			},
 			want: []*VirtualHost{{
+				Port: 80,
 				host: "a.example.com",
 				routes: map[string]*Route{
 					"/": &Route{
@@ -1225,6 +1262,7 @@ func TestDAGRemove(t *testing.T) {
 					},
 				},
 			}, {
+				Port: 80,
 				host: "b.example.com",
 				routes: map[string]*Route{
 					"/": &Route{
@@ -1245,6 +1283,7 @@ func TestDAGRemove(t *testing.T) {
 				sec1,
 			},
 			want: []*VirtualHost{{
+				Port: 80,
 				host: "a.example.com",
 				routes: map[string]*Route{
 					"/": &Route{
@@ -1262,6 +1301,7 @@ func TestDAGRemove(t *testing.T) {
 					},
 				},
 			}, {
+				Port: 80,
 				host: "b.example.com",
 				routes: map[string]*Route{
 					"/": &Route{
@@ -1290,6 +1330,7 @@ func TestDAGRemove(t *testing.T) {
 				s1,
 			},
 			want: []*VirtualHost{{
+				Port: 80,
 				host: "a.example.com",
 				routes: map[string]*Route{
 					"/": &Route{
@@ -1299,6 +1340,7 @@ func TestDAGRemove(t *testing.T) {
 					},
 				},
 			}, {
+				Port: 80,
 				host: "b.example.com",
 				routes: map[string]*Route{
 					"/": &Route{
@@ -1327,6 +1369,7 @@ func TestDAGRemove(t *testing.T) {
 				s2,
 			},
 			want: []*VirtualHost{{
+				Port: 80,
 				host: "b.example.com",
 				routes: map[string]*Route{
 					"/": &Route{

--- a/internal/debug/dot.go
+++ b/internal/debug/dot.go
@@ -40,7 +40,7 @@ func (dw *dotWriter) writeDot(w io.Writer) {
 		case *dag.Service:
 			fmt.Fprintf(w, `"%p" [shape=record, label="{service|%s/%s}"]`+"\n", parent, parent.Namespace(), parent.Name())
 		case *dag.VirtualHost:
-			fmt.Fprintf(w, `"%p" [shape=record, label="{host|%s}"]`+"\n", parent, parent.FQDN())
+			fmt.Fprintf(w, `"%p" [shape=record, label="{host|%s:%d}"]`+"\n", parent, parent.FQDN(), parent.Port)
 		case *dag.Route:
 			route = parent
 			fmt.Fprintf(w, `"%p" [shape=record, label="{prefix|%s}"]`+"\n", parent, parent.Prefix())


### PR DESCRIPTION
Updates #429

This PR alters the DAG generation to create unique roots for each host/port combination. This embeds more information into the dag, for example, the port number of a vhost is no longer determined by the presence of a child secret object. Now the port a vhost listens on and if it uses TLS is independent -- although a vhost _must_ have a child secret to be TLS enabled.

With this in place we can now start to generate different route graphs for the port 80 and port 443 listeners. This PR includes an example of this by adding support for the `kubernetes.io/ingress.allow-http: "false"` annotation. 

It should be noted that TLS objects will never be attached to virtualhosts that do not have hostnames. See #410 for details.

![graph](https://user-images.githubusercontent.com/7171/41155711-633039b2-6b62-11e8-95c3-3779b84c194e.png)
