### PR TITLE
IngressRoute CRD Validation

### DIFF
--- a/deployment/common/common.yaml
+++ b/deployment/common/common.yaml
@@ -69,7 +69,6 @@ spec:
             routes:
               type: array
               items:
-                type: object
                 required:
                   - match
                 properties:
@@ -88,7 +87,7 @@ spec:
                       namespace:
                         type: string
                         pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$ # DNS-1123
-                  service:
+                  services:
                     type: array
                     items:
                       type: object

--- a/deployment/common/common.yaml
+++ b/deployment/common/common.yaml
@@ -33,7 +33,7 @@ spec:
               properties:
                 fqdn:
                   type: string
-                  pattern: ^([a-z0-9]+(-[a-z0-9]+)*\.)+[a-z]{2,}$
+                  pattern: ^([a-zA-Z0-9]+(-[a-zA-Z0-9]+)*\.)+[a-z]{2,}$
                 aliases:
                   type: array
                   items:
@@ -77,11 +77,10 @@ spec:
                     type: string
                     pattern: ^\/.*$
                   delegate:
-                    type: string
+                    type: object
                     required:
                       - name
                       - namespace
-                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$ # DNS-1123
                     properties:
                       name:
                         type: string

--- a/deployment/common/common.yaml
+++ b/deployment/common/common.yaml
@@ -22,4 +22,108 @@ spec:
   names:
     plural: ingressroutes
     kind: IngressRoute
+  validation:
+    openAPIV3Schema:
+      properties:
+        spec:
+          required:
+            - routes
+          properties:
+            virtualhost:
+              properties:
+                fqdn:
+                  type: string
+                  pattern: ^([a-z0-9]+(-[a-z0-9]+)*\.)+[a-z]{2,}$
+                aliases:
+                  type: array
+                  items:
+                    type: string
+                    pattern: ^([a-z0-9]+(-[a-z0-9]+)*\.)+[a-z]{2,}$
+                tls:
+                  properties:
+                    secretName:
+                      type: string
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$ # DNS-1123
+            strategy:
+              type: string
+              enum:
+                - RoundRobin
+                - WeightedLeastRequest
+                - Random
+            lbHealthCheck:
+              type: object
+              required:
+                - path
+              properties:
+                path:
+                  type: string
+                  pattern: ^\/.*$
+                intervalSeconds:
+                  type: integer
+                timeoutSeconds: 
+                  type: integer
+                unhealthyThresholdCount:
+                  type: integer
+                healthyThresholdCount:
+                  type: integer
+            routes:
+              type: array
+              items:
+                type: object
+                required:
+                  - match
+                properties:
+                  match:
+                    type: string
+                    pattern: ^\/.*$
+                  delegate:
+                    type: string
+                    required:
+                      - name
+                      - namespace
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$ # DNS-1123
+                    properties:
+                      name:
+                        type: string
+                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$ # DNS-1123
+                      namespace:
+                        type: string
+                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$ # DNS-1123
+                  service:
+                    type: array
+                    items:
+                      type: object
+                      required:
+                        - name
+                        - port
+                      properties:
+                        name:
+                          type: string
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$ # DNS-1123
+                        port: 
+                          type: integer
+                        weight:
+                          type: integer
+                        strategy:
+                          type: string
+                          enum:
+                            - RoundRobin
+                            - WeightedLeastRequest
+                            - Random
+                        lbHealthCheck:
+                          type: object
+                          required:
+                            - path
+                          properties:
+                            path:
+                              type: string
+                              pattern: ^\/.*$
+                            intervalSeconds:
+                              type: integer
+                            timeoutSeconds: 
+                              type: integer
+                            unhealthyThresholdCount:
+                              type: integer
+                            healthyThresholdCount:
+                              type: integer
 ---

--- a/deployment/render/daemonset-norbac.yaml
+++ b/deployment/render/daemonset-norbac.yaml
@@ -25,6 +25,110 @@ spec:
   names:
     plural: ingressroutes
     kind: IngressRoute
+  validation:
+    openAPIV3Schema:
+      properties:
+        spec:
+          required:
+            - routes
+          properties:
+            virtualhost:
+              properties:
+                fqdn:
+                  type: string
+                  pattern: ^([a-z0-9]+(-[a-z0-9]+)*\.)+[a-z]{2,}$
+                aliases:
+                  type: array
+                  items:
+                    type: string
+                    pattern: ^([a-z0-9]+(-[a-z0-9]+)*\.)+[a-z]{2,}$
+                tls:
+                  properties:
+                    secretName:
+                      type: string
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$ # DNS-1123
+            strategy:
+              type: string
+              enum:
+                - RoundRobin
+                - WeightedLeastRequest
+                - Random
+            lbHealthCheck:
+              type: object
+              required:
+                - path
+              properties:
+                path:
+                  type: string
+                  pattern: ^\/.*$
+                intervalSeconds:
+                  type: integer
+                timeoutSeconds: 
+                  type: integer
+                unhealthyThresholdCount:
+                  type: integer
+                healthyThresholdCount:
+                  type: integer
+            routes:
+              type: array
+              items:
+                type: object
+                required:
+                  - match
+                properties:
+                  match:
+                    type: string
+                    pattern: ^\/.*$
+                  delegate:
+                    type: string
+                    required:
+                      - name
+                      - namespace
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$ # DNS-1123
+                    properties:
+                      name:
+                        type: string
+                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$ # DNS-1123
+                      namespace:
+                        type: string
+                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$ # DNS-1123
+                  service:
+                    type: array
+                    items:
+                      type: object
+                      required:
+                        - name
+                        - port
+                      properties:
+                        name:
+                          type: string
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$ # DNS-1123
+                        port: 
+                          type: integer
+                        weight:
+                          type: integer
+                        strategy:
+                          type: string
+                          enum:
+                            - RoundRobin
+                            - WeightedLeastRequest
+                            - Random
+                        lbHealthCheck:
+                          type: object
+                          required:
+                            - path
+                          properties:
+                            path:
+                              type: string
+                              pattern: ^\/.*$
+                            intervalSeconds:
+                              type: integer
+                            timeoutSeconds: 
+                              type: integer
+                            unhealthyThresholdCount:
+                              type: integer
+                            healthyThresholdCount:
+                              type: integer
 ---
 apiVersion: extensions/v1beta1
 kind: DaemonSet

--- a/deployment/render/daemonset-norbac.yaml
+++ b/deployment/render/daemonset-norbac.yaml
@@ -36,7 +36,7 @@ spec:
               properties:
                 fqdn:
                   type: string
-                  pattern: ^([a-z0-9]+(-[a-z0-9]+)*\.)+[a-z]{2,}$
+                  pattern: ^([a-zA-Z0-9]+(-[a-zA-Z0-9]+)*\.)+[a-z]{2,}$
                 aliases:
                   type: array
                   items:
@@ -80,11 +80,10 @@ spec:
                     type: string
                     pattern: ^\/.*$
                   delegate:
-                    type: string
+                    type: object
                     required:
                       - name
                       - namespace
-                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$ # DNS-1123
                     properties:
                       name:
                         type: string

--- a/deployment/render/daemonset-rbac.yaml
+++ b/deployment/render/daemonset-rbac.yaml
@@ -25,6 +25,110 @@ spec:
   names:
     plural: ingressroutes
     kind: IngressRoute
+  validation:
+    openAPIV3Schema:
+      properties:
+        spec:
+          required:
+            - routes
+          properties:
+            virtualhost:
+              properties:
+                fqdn:
+                  type: string
+                  pattern: ^([a-z0-9]+(-[a-z0-9]+)*\.)+[a-z]{2,}$
+                aliases:
+                  type: array
+                  items:
+                    type: string
+                    pattern: ^([a-z0-9]+(-[a-z0-9]+)*\.)+[a-z]{2,}$
+                tls:
+                  properties:
+                    secretName:
+                      type: string
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$ # DNS-1123
+            strategy:
+              type: string
+              enum:
+                - RoundRobin
+                - WeightedLeastRequest
+                - Random
+            lbHealthCheck:
+              type: object
+              required:
+                - path
+              properties:
+                path:
+                  type: string
+                  pattern: ^\/.*$
+                intervalSeconds:
+                  type: integer
+                timeoutSeconds: 
+                  type: integer
+                unhealthyThresholdCount:
+                  type: integer
+                healthyThresholdCount:
+                  type: integer
+            routes:
+              type: array
+              items:
+                type: object
+                required:
+                  - match
+                properties:
+                  match:
+                    type: string
+                    pattern: ^\/.*$
+                  delegate:
+                    type: string
+                    required:
+                      - name
+                      - namespace
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$ # DNS-1123
+                    properties:
+                      name:
+                        type: string
+                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$ # DNS-1123
+                      namespace:
+                        type: string
+                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$ # DNS-1123
+                  service:
+                    type: array
+                    items:
+                      type: object
+                      required:
+                        - name
+                        - port
+                      properties:
+                        name:
+                          type: string
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$ # DNS-1123
+                        port: 
+                          type: integer
+                        weight:
+                          type: integer
+                        strategy:
+                          type: string
+                          enum:
+                            - RoundRobin
+                            - WeightedLeastRequest
+                            - Random
+                        lbHealthCheck:
+                          type: object
+                          required:
+                            - path
+                          properties:
+                            path:
+                              type: string
+                              pattern: ^\/.*$
+                            intervalSeconds:
+                              type: integer
+                            timeoutSeconds: 
+                              type: integer
+                            unhealthyThresholdCount:
+                              type: integer
+                            healthyThresholdCount:
+                              type: integer
 ---
 apiVersion: extensions/v1beta1
 kind: DaemonSet

--- a/deployment/render/daemonset-rbac.yaml
+++ b/deployment/render/daemonset-rbac.yaml
@@ -36,7 +36,7 @@ spec:
               properties:
                 fqdn:
                   type: string
-                  pattern: ^([a-z0-9]+(-[a-z0-9]+)*\.)+[a-z]{2,}$
+                  pattern: ^([a-zA-Z0-9]+(-[a-zA-Z0-9]+)*\.)+[a-z]{2,}$
                 aliases:
                   type: array
                   items:
@@ -80,11 +80,10 @@ spec:
                     type: string
                     pattern: ^\/.*$
                   delegate:
-                    type: string
+                    type: object
                     required:
                       - name
                       - namespace
-                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$ # DNS-1123
                     properties:
                       name:
                         type: string

--- a/deployment/render/deployment-norbac.yaml
+++ b/deployment/render/deployment-norbac.yaml
@@ -25,6 +25,110 @@ spec:
   names:
     plural: ingressroutes
     kind: IngressRoute
+  validation:
+    openAPIV3Schema:
+      properties:
+        spec:
+          required:
+            - routes
+          properties:
+            virtualhost:
+              properties:
+                fqdn:
+                  type: string
+                  pattern: ^([a-z0-9]+(-[a-z0-9]+)*\.)+[a-z]{2,}$
+                aliases:
+                  type: array
+                  items:
+                    type: string
+                    pattern: ^([a-z0-9]+(-[a-z0-9]+)*\.)+[a-z]{2,}$
+                tls:
+                  properties:
+                    secretName:
+                      type: string
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$ # DNS-1123
+            strategy:
+              type: string
+              enum:
+                - RoundRobin
+                - WeightedLeastRequest
+                - Random
+            lbHealthCheck:
+              type: object
+              required:
+                - path
+              properties:
+                path:
+                  type: string
+                  pattern: ^\/.*$
+                intervalSeconds:
+                  type: integer
+                timeoutSeconds: 
+                  type: integer
+                unhealthyThresholdCount:
+                  type: integer
+                healthyThresholdCount:
+                  type: integer
+            routes:
+              type: array
+              items:
+                type: object
+                required:
+                  - match
+                properties:
+                  match:
+                    type: string
+                    pattern: ^\/.*$
+                  delegate:
+                    type: string
+                    required:
+                      - name
+                      - namespace
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$ # DNS-1123
+                    properties:
+                      name:
+                        type: string
+                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$ # DNS-1123
+                      namespace:
+                        type: string
+                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$ # DNS-1123
+                  service:
+                    type: array
+                    items:
+                      type: object
+                      required:
+                        - name
+                        - port
+                      properties:
+                        name:
+                          type: string
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$ # DNS-1123
+                        port: 
+                          type: integer
+                        weight:
+                          type: integer
+                        strategy:
+                          type: string
+                          enum:
+                            - RoundRobin
+                            - WeightedLeastRequest
+                            - Random
+                        lbHealthCheck:
+                          type: object
+                          required:
+                            - path
+                          properties:
+                            path:
+                              type: string
+                              pattern: ^\/.*$
+                            intervalSeconds:
+                              type: integer
+                            timeoutSeconds: 
+                              type: integer
+                            unhealthyThresholdCount:
+                              type: integer
+                            healthyThresholdCount:
+                              type: integer
 ---
 apiVersion: extensions/v1beta1
 kind: Deployment

--- a/deployment/render/deployment-norbac.yaml
+++ b/deployment/render/deployment-norbac.yaml
@@ -36,7 +36,7 @@ spec:
               properties:
                 fqdn:
                   type: string
-                  pattern: ^([a-z0-9]+(-[a-z0-9]+)*\.)+[a-z]{2,}$
+                  pattern: ^([a-zA-Z0-9]+(-[a-zA-Z0-9]+)*\.)+[a-z]{2,}$
                 aliases:
                   type: array
                   items:
@@ -80,11 +80,10 @@ spec:
                     type: string
                     pattern: ^\/.*$
                   delegate:
-                    type: string
+                    type: object
                     required:
                       - name
                       - namespace
-                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$ # DNS-1123
                     properties:
                       name:
                         type: string

--- a/deployment/render/deployment-rbac.yaml
+++ b/deployment/render/deployment-rbac.yaml
@@ -25,6 +25,110 @@ spec:
   names:
     plural: ingressroutes
     kind: IngressRoute
+  validation:
+    openAPIV3Schema:
+      properties:
+        spec:
+          required:
+            - routes
+          properties:
+            virtualhost:
+              properties:
+                fqdn:
+                  type: string
+                  pattern: ^([a-z0-9]+(-[a-z0-9]+)*\.)+[a-z]{2,}$
+                aliases:
+                  type: array
+                  items:
+                    type: string
+                    pattern: ^([a-z0-9]+(-[a-z0-9]+)*\.)+[a-z]{2,}$
+                tls:
+                  properties:
+                    secretName:
+                      type: string
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$ # DNS-1123
+            strategy:
+              type: string
+              enum:
+                - RoundRobin
+                - WeightedLeastRequest
+                - Random
+            lbHealthCheck:
+              type: object
+              required:
+                - path
+              properties:
+                path:
+                  type: string
+                  pattern: ^\/.*$
+                intervalSeconds:
+                  type: integer
+                timeoutSeconds: 
+                  type: integer
+                unhealthyThresholdCount:
+                  type: integer
+                healthyThresholdCount:
+                  type: integer
+            routes:
+              type: array
+              items:
+                type: object
+                required:
+                  - match
+                properties:
+                  match:
+                    type: string
+                    pattern: ^\/.*$
+                  delegate:
+                    type: string
+                    required:
+                      - name
+                      - namespace
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$ # DNS-1123
+                    properties:
+                      name:
+                        type: string
+                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$ # DNS-1123
+                      namespace:
+                        type: string
+                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$ # DNS-1123
+                  service:
+                    type: array
+                    items:
+                      type: object
+                      required:
+                        - name
+                        - port
+                      properties:
+                        name:
+                          type: string
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$ # DNS-1123
+                        port: 
+                          type: integer
+                        weight:
+                          type: integer
+                        strategy:
+                          type: string
+                          enum:
+                            - RoundRobin
+                            - WeightedLeastRequest
+                            - Random
+                        lbHealthCheck:
+                          type: object
+                          required:
+                            - path
+                          properties:
+                            path:
+                              type: string
+                              pattern: ^\/.*$
+                            intervalSeconds:
+                              type: integer
+                            timeoutSeconds: 
+                              type: integer
+                            unhealthyThresholdCount:
+                              type: integer
+                            healthyThresholdCount:
+                              type: integer
 ---
 apiVersion: extensions/v1beta1
 kind: Deployment

--- a/deployment/render/deployment-rbac.yaml
+++ b/deployment/render/deployment-rbac.yaml
@@ -36,7 +36,7 @@ spec:
               properties:
                 fqdn:
                   type: string
-                  pattern: ^([a-z0-9]+(-[a-z0-9]+)*\.)+[a-z]{2,}$
+                  pattern: ^([a-zA-Z0-9]+(-[a-zA-Z0-9]+)*\.)+[a-z]{2,}$
                 aliases:
                   type: array
                   items:
@@ -80,11 +80,10 @@ spec:
                     type: string
                     pattern: ^\/.*$
                   delegate:
-                    type: string
+                    type: object
                     required:
                       - name
                       - namespace
-                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$ # DNS-1123
                     properties:
                       name:
                         type: string


### PR DESCRIPTION
This adds CRD Validation to the IngressRoute spec. One thing to note is it defines an Enum of values allowed for the `strategy` field which is not yet implemented. We may need to return to this validation once that feature lands.

// Fixes #416 

Signed-off-by: Steve Sloka <steves@heptio.com>