### PR TITLE
internal/contour: only consult default ingress for vhost "*"

### DIFF
--- a/internal/contour/translatorcache_test.go
+++ b/internal/contour/translatorcache_test.go
@@ -271,6 +271,108 @@ func TestTranslatorCacheOnAddIngress(t *testing.T) {
 				},
 			},
 		},
+		"issue/404": {
+			i: v1beta1.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "hello",
+					Namespace: "default",
+				},
+				Spec: v1beta1.IngressSpec{
+					Backend: backend("kuard", intstr.FromInt(80)),
+					Rules: []v1beta1.IngressRule{{
+						Host: "test-gui",
+						IngressRuleValue: v1beta1.IngressRuleValue{
+							HTTP: &v1beta1.HTTPIngressRuleValue{
+								Paths: []v1beta1.HTTPIngressPath{{
+									Path: "/",
+									Backend: v1beta1.IngressBackend{
+										ServiceName: "test-gui",
+										ServicePort: intstr.FromInt(80),
+									},
+								}},
+							},
+						},
+					}},
+				},
+			},
+			wantIngresses: map[metadata]*v1beta1.Ingress{
+				metadata{name: "hello", namespace: "default"}: &v1beta1.Ingress{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "hello",
+						Namespace: "default",
+					},
+					Spec: v1beta1.IngressSpec{
+						Backend: backend("kuard", intstr.FromInt(80)),
+						Rules: []v1beta1.IngressRule{{
+							Host: "test-gui",
+							IngressRuleValue: v1beta1.IngressRuleValue{
+								HTTP: &v1beta1.HTTPIngressRuleValue{
+									Paths: []v1beta1.HTTPIngressPath{{
+										Path: "/",
+										Backend: v1beta1.IngressBackend{
+											ServiceName: "test-gui",
+											ServicePort: intstr.FromInt(80),
+										},
+									}},
+								},
+							},
+						}},
+					},
+				},
+			},
+			wantVhosts: map[string]map[metadata]*v1beta1.Ingress{
+				"*": map[metadata]*v1beta1.Ingress{
+					metadata{name: "hello", namespace: "default"}: &v1beta1.Ingress{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "hello",
+							Namespace: "default",
+						},
+						Spec: v1beta1.IngressSpec{
+							Backend: backend("kuard", intstr.FromInt(80)),
+							Rules: []v1beta1.IngressRule{{
+								Host: "test-gui",
+								IngressRuleValue: v1beta1.IngressRuleValue{
+									HTTP: &v1beta1.HTTPIngressRuleValue{
+										Paths: []v1beta1.HTTPIngressPath{{
+											Path: "/",
+											Backend: v1beta1.IngressBackend{
+												ServiceName: "test-gui",
+												ServicePort: intstr.FromInt(80),
+											},
+										}},
+									},
+								},
+							}},
+						},
+					},
+				},
+				"test-gui": map[metadata]*v1beta1.Ingress{
+					metadata{name: "hello", namespace: "default"}: &v1beta1.Ingress{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "hello",
+							Namespace: "default",
+						},
+						Spec: v1beta1.IngressSpec{
+							Backend: backend("kuard", intstr.FromInt(80)),
+							Rules: []v1beta1.IngressRule{{
+								Host: "test-gui",
+								IngressRuleValue: v1beta1.IngressRuleValue{
+									HTTP: &v1beta1.HTTPIngressRuleValue{
+										Paths: []v1beta1.HTTPIngressPath{{
+											Path: "/",
+											Backend: v1beta1.IngressBackend{
+												ServiceName: "test-gui",
+												ServicePort: intstr.FromInt(80),
+											},
+										}},
+									},
+								},
+							}},
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for name, tc := range tests {

--- a/internal/contour/virtualhost.go
+++ b/internal/contour/virtualhost.go
@@ -75,7 +75,7 @@ func (v *VirtualHostCache) recomputevhost(vhost string, ingresses map[metadata]*
 		}
 		wr := websocketRoutes(i)
 		requireTLS := tlsRequired(i)
-		if i.Spec.Backend != nil && len(ingresses) == 1 {
+		if i.Spec.Backend != nil && vhost == "*" {
 			r := route.Route{
 				Match:  prefixmatch("/"),
 				Action: action(i, i.Spec.Backend, wr["/"]),
@@ -130,7 +130,6 @@ func (v *VirtualHostCache) recomputevhostIngressRoute(vhost string, routes map[m
 	vv := virtualhost(vhost, "80")
 	for _, i := range routes {
 		for _, j := range i.Spec.Routes {
-
 			// TODO(sas): Handle case of no default path (e.g. "/")
 
 			vv.Routes = append(vv.Routes, route.Route{

--- a/internal/contour/virtualhost.go
+++ b/internal/contour/virtualhost.go
@@ -89,12 +89,18 @@ func (v *VirtualHostCache) recomputevhost(vhost string, ingresses map[metadata]*
 				}
 			}
 			vv.Routes = []route.Route{r}
-			continue
 		}
 		for _, rule := range i.Spec.Rules {
-			if rule.Host != "" && rule.Host != vhost {
+			host := rule.Host
+			if host == "" {
+				host = "*"
+			}
+
+			if host != vhost {
+				// not this vhost
 				continue
 			}
+
 			if rule.IngressRuleValue.HTTP == nil {
 				// TODO(dfc) plumb a logger in here so we can log this error.
 				continue

--- a/internal/contour/virtualhost_test.go
+++ b/internal/contour/virtualhost_test.go
@@ -682,6 +682,18 @@ func TestVirtualHostCacheRecomputevhost(t *testing.T) {
 								}},
 							},
 						},
+					}, {
+						IngressRuleValue: v1beta1.IngressRuleValue{
+							HTTP: &v1beta1.HTTPIngressRuleValue{
+								Paths: []v1beta1.HTTPIngressPath{{
+									Path: "/kuard",
+									Backend: v1beta1.IngressBackend{
+										ServiceName: "kuard",
+										ServicePort: intstr.FromInt(8080),
+									},
+								}},
+							},
+						},
 					}},
 				},
 			}}),
@@ -690,6 +702,9 @@ func TestVirtualHostCacheRecomputevhost(t *testing.T) {
 					Name:    "*",
 					Domains: []string{"*"},
 					Routes: []route.Route{{
+						Match:  prefixmatch("/kuard"),
+						Action: clusteraction("default/kuard/8080"),
+					}, {
 						Match:  prefixmatch("/"),
 						Action: clusteraction("default/kuard/80"),
 					}},
@@ -715,6 +730,18 @@ func TestVirtualHostCacheRecomputevhost(t *testing.T) {
 									Backend: v1beta1.IngressBackend{
 										ServiceName: "test-gui",
 										ServicePort: intstr.FromInt(80),
+									},
+								}},
+							},
+						},
+					}, {
+						IngressRuleValue: v1beta1.IngressRuleValue{
+							HTTP: &v1beta1.HTTPIngressRuleValue{
+								Paths: []v1beta1.HTTPIngressPath{{
+									Path: "/kuard",
+									Backend: v1beta1.IngressBackend{
+										ServiceName: "kuard",
+										ServicePort: intstr.FromInt(8080),
 									},
 								}},
 							},
@@ -748,7 +775,7 @@ func TestVirtualHostCacheRecomputevhost(t *testing.T) {
 			got := contents(&tr.VirtualHostCache.HTTP)
 			sort.Stable(virtualHostsByName(got))
 			if !reflect.DeepEqual(tc.ingress_http, got) {
-				t.Fatalf("recomputevhost(%v):\n (ingress_http) want:\n%+v\n got:\n%+v\n%+v", tc.vhost, tc.ingress_http, got, tc.ingresses)
+				t.Fatalf("recomputevhost(%v):\n (ingress_http) want:\n%+v\n got:\n%+v", tc.vhost, tc.ingress_http, got)
 			}
 
 			got = contents(&tr.VirtualHostCache.HTTPS)

--- a/internal/e2e/rds_test.go
+++ b/internal/e2e/rds_test.go
@@ -867,6 +867,18 @@ func TestDefaultBackendDoesNotOverwriteNamedHost(t *testing.T) {
 						}},
 					},
 				},
+			}, {
+				IngressRuleValue: v1beta1.IngressRuleValue{
+					HTTP: &v1beta1.HTTPIngressRuleValue{
+						Paths: []v1beta1.HTTPIngressPath{{
+							Path: "/kuard",
+							Backend: v1beta1.IngressBackend{
+								ServiceName: "kuard",
+								ServicePort: intstr.FromInt(8080),
+							},
+						}},
+					},
+				},
 			}},
 		},
 	})
@@ -880,6 +892,9 @@ func TestDefaultBackendDoesNotOverwriteNamedHost(t *testing.T) {
 					Name:    "*",
 					Domains: []string{"*"},
 					Routes: []route.Route{{
+						Match:  prefixmatch("/kuard"),
+						Action: routecluster("default/kuard/8080"),
+					}, {
 						Match:  prefixmatch("/"),
 						Action: routecluster("default/kuard/80"),
 					}},


### PR DESCRIPTION
Fixes #404

Only consule default ingress rules (that is, spec.host == "" or
spec.backend != nil) when recomputing the "*" vhost.

Signed-off-by: Dave Cheney <dave@cheney.net>