### PR TITLE
internal/dag: process ingressroute documents     

### DIFF
--- a/internal/dag/dag.go
+++ b/internal/dag/dag.go
@@ -339,7 +339,7 @@ func (r *Route) ServicePort() string {
 	case *v1beta1.IngressBackend:
 		return b.ServicePort.String()
 	default:
-		panic(b)
+		return "unknown"
 	}
 }
 

--- a/internal/dag/dag.go
+++ b/internal/dag/dag.go
@@ -208,7 +208,7 @@ func (d *DAG) recompute() *dag {
 				object:  ing,
 				backend: ing.Spec.Backend,
 			}
-			m := meta{name: r.backend.ServiceName, namespace: r.object.Namespace}
+			m := meta{name: r.backend.ServiceName, namespace: ing.Namespace}
 			if s := service(m); s != nil {
 				// iterate through the ports on the service object, if we
 				// find a match against the backends port's name or number, we add
@@ -251,7 +251,7 @@ func (d *DAG) recompute() *dag {
 					backend: &rule.IngressRuleValue.HTTP.Paths[n].Backend,
 				}
 
-				m := meta{name: r.backend.ServiceName, namespace: r.object.Namespace}
+				m := meta{name: r.backend.ServiceName, namespace: ing.Namespace}
 				if s := service(m); s != nil {
 					// iterate through the ports on the service object, if we
 					// find a match against the backends port's name or number, we add
@@ -288,7 +288,7 @@ type Root interface {
 
 type Route struct {
 	path     string
-	object   *v1beta1.Ingress // the ingress which mentioned this route
+	object   interface{} // one of Ingress or IngressRoute
 	services map[meta]*Service
 	backend  *v1beta1.IngressBackend
 }


### PR DESCRIPTION
Initial support for processing ingress route documents.

 - :443 support is missing
 - no tests for remove

![graph](https://user-images.githubusercontent.com/7171/41832479-97549884-788f-11e8-9ffe-611ceaebea26.png)
_note:_ kuard.davecheney.com points to both default/httpbin _and_ default/kuard

Signed-off-by: Dave Cheney <dave@cheney.net>
