### PR TITLE
internal/dag: canonicalise service port during Recompute

### DIFF
--- a/internal/dag/dag_test.go
+++ b/internal/dag/dag_test.go
@@ -365,9 +365,8 @@ func TestDAGInsert(t *testing.T) {
 				host: "*",
 				routes: map[string]*Route{
 					"/": &Route{
-						path:    "/",
-						object:  i1,
-						backend: i1.Spec.Backend,
+						path:   "/",
+						object: i1,
 					},
 				},
 			}},
@@ -381,9 +380,8 @@ func TestDAGInsert(t *testing.T) {
 				host: "*",
 				routes: map[string]*Route{
 					"/": &Route{
-						path:    "/",
-						object:  i2,
-						backend: &i2.Spec.Rules[0].IngressRuleValue.HTTP.Paths[0].Backend,
+						path:   "/",
+						object: i2,
 					},
 				},
 			}},
@@ -397,9 +395,8 @@ func TestDAGInsert(t *testing.T) {
 				host: "kuard.example.com",
 				routes: map[string]*Route{
 					"/": &Route{
-						path:    "/",
-						object:  i3,
-						backend: &i3.Spec.Rules[0].IngressRuleValue.HTTP.Paths[0].Backend,
+						path:   "/",
+						object: i3,
 					},
 				},
 			}},
@@ -414,15 +411,16 @@ func TestDAGInsert(t *testing.T) {
 				host: "*",
 				routes: map[string]*Route{
 					"/": &Route{
-						path:    "/",
-						object:  i1,
-						backend: i1.Spec.Backend,
-						services: map[meta]*Service{
-							meta{
+						path:   "/",
+						object: i1,
+						services: map[portmeta]*Service{
+							portmeta{
 								name:      "kuard",
 								namespace: "default",
+								port:      8080,
 							}: &Service{
 								object: s1,
+								Port:   8080,
 							},
 						},
 					},
@@ -439,15 +437,16 @@ func TestDAGInsert(t *testing.T) {
 				host: "*",
 				routes: map[string]*Route{
 					"/": &Route{
-						path:    "/",
-						object:  i1,
-						backend: i1.Spec.Backend,
-						services: map[meta]*Service{
-							meta{
+						path:   "/",
+						object: i1,
+						services: map[portmeta]*Service{
+							portmeta{
 								name:      "kuard",
 								namespace: "default",
+								port:      8080,
 							}: &Service{
 								object: s1,
+								Port:   8080,
 							},
 						},
 					},
@@ -464,9 +463,8 @@ func TestDAGInsert(t *testing.T) {
 				host: "*",
 				routes: map[string]*Route{
 					"/": &Route{
-						path:    "/",
-						object:  i1,
-						backend: i1.Spec.Backend,
+						path:   "/",
+						object: i1,
 					},
 				},
 			}},
@@ -481,9 +479,8 @@ func TestDAGInsert(t *testing.T) {
 				host: "*",
 				routes: map[string]*Route{
 					"/": &Route{
-						path:    "/",
-						object:  i1,
-						backend: i1.Spec.Backend,
+						path:   "/",
+						object: i1,
 					},
 				},
 			}},
@@ -498,9 +495,8 @@ func TestDAGInsert(t *testing.T) {
 				host: "*",
 				routes: map[string]*Route{
 					"/": &Route{
-						path:    "/",
-						object:  i1,
-						backend: i1.Spec.Backend,
+						path:   "/",
+						object: i1,
 					},
 				},
 			}},
@@ -515,9 +511,8 @@ func TestDAGInsert(t *testing.T) {
 				host: "*",
 				routes: map[string]*Route{
 					"/": &Route{
-						path:    "/",
-						object:  i1,
-						backend: i1.Spec.Backend,
+						path:   "/",
+						object: i1,
 					},
 				},
 			}},
@@ -532,9 +527,8 @@ func TestDAGInsert(t *testing.T) {
 				host: "*",
 				routes: map[string]*Route{
 					"/": &Route{
-						path:    "/",
-						object:  i2,
-						backend: &i2.Spec.Rules[0].IngressRuleValue.HTTP.Paths[0].Backend,
+						path:   "/",
+						object: i2,
 					},
 				},
 			}},
@@ -549,9 +543,8 @@ func TestDAGInsert(t *testing.T) {
 				host: "*",
 				routes: map[string]*Route{
 					"/": &Route{
-						path:    "/",
-						object:  i2,
-						backend: &i2.Spec.Rules[0].IngressRuleValue.HTTP.Paths[0].Backend,
+						path:   "/",
+						object: i2,
 					},
 				},
 			}},
@@ -566,15 +559,16 @@ func TestDAGInsert(t *testing.T) {
 				host: "*",
 				routes: map[string]*Route{
 					"/": &Route{
-						path:    "/",
-						object:  i4,
-						backend: i4.Spec.Backend,
-						services: map[meta]*Service{
-							meta{
+						path:   "/",
+						object: i4,
+						services: map[portmeta]*Service{
+							portmeta{
 								name:      "kuard",
 								namespace: "default",
+								port:      8080,
 							}: &Service{
 								object: s1,
+								Port:   8080,
 							},
 						},
 					},
@@ -591,15 +585,16 @@ func TestDAGInsert(t *testing.T) {
 				host: "*",
 				routes: map[string]*Route{
 					"/": &Route{
-						path:    "/",
-						object:  i4,
-						backend: i4.Spec.Backend,
-						services: map[meta]*Service{
-							meta{
+						path:   "/",
+						object: i4,
+						services: map[portmeta]*Service{
+							portmeta{
 								name:      "kuard",
 								namespace: "default",
+								port:      8080,
 							}: &Service{
 								object: s1,
+								Port:   8080,
 							},
 						},
 					},
@@ -616,15 +611,16 @@ func TestDAGInsert(t *testing.T) {
 				host: "*",
 				routes: map[string]*Route{
 					"/": &Route{
-						path:    "/",
-						object:  i5,
-						backend: &i5.Spec.Rules[0].IngressRuleValue.HTTP.Paths[0].Backend,
-						services: map[meta]*Service{
-							meta{
+						path:   "/",
+						object: i5,
+						services: map[portmeta]*Service{
+							portmeta{
 								name:      "kuard",
 								namespace: "default",
+								port:      8080,
 							}: &Service{
 								object: s1,
+								Port:   8080,
 							},
 						},
 					},
@@ -641,15 +637,16 @@ func TestDAGInsert(t *testing.T) {
 				host: "*",
 				routes: map[string]*Route{
 					"/": &Route{
-						path:    "/",
-						object:  i5,
-						backend: &i5.Spec.Rules[0].IngressRuleValue.HTTP.Paths[0].Backend,
-						services: map[meta]*Service{
-							meta{
+						path:   "/",
+						object: i5,
+						services: map[portmeta]*Service{
+							portmeta{
 								name:      "kuard",
 								namespace: "default",
+								port:      8080,
 							}: &Service{
 								object: s1,
+								Port:   8080,
 							},
 						},
 					},
@@ -672,9 +669,8 @@ func TestDAGInsert(t *testing.T) {
 				host: "*",
 				routes: map[string]*Route{
 					"/": &Route{
-						path:    "/",
-						object:  i1,
-						backend: i1.Spec.Backend,
+						path:   "/",
+						object: i1,
 					},
 				},
 			}},
@@ -689,9 +685,8 @@ func TestDAGInsert(t *testing.T) {
 				host: "kuard.example.com",
 				routes: map[string]*Route{
 					"/": &Route{
-						path:    "/",
-						object:  i3,
-						backend: &i3.Spec.Rules[0].IngressRuleValue.HTTP.Paths[0].Backend,
+						path:   "/",
+						object: i3,
 					},
 				},
 			}, {
@@ -699,9 +694,8 @@ func TestDAGInsert(t *testing.T) {
 				host: "kuard.example.com",
 				routes: map[string]*Route{
 					"/": &Route{
-						path:    "/",
-						object:  i3,
-						backend: &i3.Spec.Rules[0].IngressRuleValue.HTTP.Paths[0].Backend,
+						path:   "/",
+						object: i3,
 					},
 				},
 				secrets: map[meta]*Secret{
@@ -724,9 +718,8 @@ func TestDAGInsert(t *testing.T) {
 				host: "kuard.example.com",
 				routes: map[string]*Route{
 					"/": &Route{
-						path:    "/",
-						object:  i3,
-						backend: &i3.Spec.Rules[0].IngressRuleValue.HTTP.Paths[0].Backend,
+						path:   "/",
+						object: i3,
 					},
 				},
 			}, {
@@ -734,9 +727,8 @@ func TestDAGInsert(t *testing.T) {
 				host: "kuard.example.com",
 				routes: map[string]*Route{
 					"/": &Route{
-						path:    "/",
-						object:  i3,
-						backend: &i3.Spec.Rules[0].IngressRuleValue.HTTP.Paths[0].Backend,
+						path:   "/",
+						object: i3,
 					},
 				},
 				secrets: map[meta]*Secret{
@@ -758,9 +750,8 @@ func TestDAGInsert(t *testing.T) {
 				host: "a.example.com",
 				routes: map[string]*Route{
 					"/": &Route{
-						path:    "/",
-						object:  i6,
-						backend: &i6.Spec.Rules[0].IngressRuleValue.HTTP.Paths[0].Backend,
+						path:   "/",
+						object: i6,
 					},
 				},
 			}, {
@@ -768,9 +759,8 @@ func TestDAGInsert(t *testing.T) {
 				host: "b.example.com",
 				routes: map[string]*Route{
 					"/": &Route{
-						path:    "/",
-						object:  i6,
-						backend: &i6.Spec.Rules[1].IngressRuleValue.HTTP.Paths[0].Backend,
+						path:   "/",
+						object: i6,
 					},
 				},
 			}},
@@ -785,15 +775,16 @@ func TestDAGInsert(t *testing.T) {
 				host: "a.example.com",
 				routes: map[string]*Route{
 					"/": &Route{
-						path:    "/",
-						object:  i6,
-						backend: &i6.Spec.Rules[0].IngressRuleValue.HTTP.Paths[0].Backend,
-						services: map[meta]*Service{
-							meta{
+						path:   "/",
+						object: i6,
+						services: map[portmeta]*Service{
+							portmeta{
 								name:      "kuard",
 								namespace: "default",
+								port:      8080,
 							}: &Service{
 								object: s1,
+								Port:   8080,
 							},
 						},
 					},
@@ -803,15 +794,16 @@ func TestDAGInsert(t *testing.T) {
 				host: "b.example.com",
 				routes: map[string]*Route{
 					"/": &Route{
-						path:    "/",
-						object:  i6,
-						backend: &i6.Spec.Rules[1].IngressRuleValue.HTTP.Paths[0].Backend,
-						services: map[meta]*Service{
-							meta{
+						path:   "/",
+						object: i6,
+						services: map[portmeta]*Service{
+							portmeta{
 								name:      "kuard",
 								namespace: "default",
+								port:      8080,
 							}: &Service{
 								object: s1,
+								Port:   8080,
 							},
 						},
 					},
@@ -828,15 +820,16 @@ func TestDAGInsert(t *testing.T) {
 				host: "a.example.com",
 				routes: map[string]*Route{
 					"/": &Route{
-						path:    "/",
-						object:  i6,
-						backend: &i6.Spec.Rules[0].IngressRuleValue.HTTP.Paths[0].Backend,
-						services: map[meta]*Service{
-							meta{
+						path:   "/",
+						object: i6,
+						services: map[portmeta]*Service{
+							portmeta{
 								name:      "kuard",
 								namespace: "default",
+								port:      8080,
 							}: &Service{
 								object: s1,
+								Port:   8080,
 							},
 						},
 					},
@@ -846,15 +839,16 @@ func TestDAGInsert(t *testing.T) {
 				host: "b.example.com",
 				routes: map[string]*Route{
 					"/": &Route{
-						path:    "/",
-						object:  i6,
-						backend: &i6.Spec.Rules[1].IngressRuleValue.HTTP.Paths[0].Backend,
-						services: map[meta]*Service{
-							meta{
+						path:   "/",
+						object: i6,
+						services: map[portmeta]*Service{
+							portmeta{
 								name:      "kuard",
 								namespace: "default",
+								port:      8080,
 							}: &Service{
 								object: s1,
+								Port:   8080,
 							},
 						},
 					},
@@ -872,15 +866,16 @@ func TestDAGInsert(t *testing.T) {
 				host: "a.example.com",
 				routes: map[string]*Route{
 					"/": &Route{
-						path:    "/",
-						object:  i6,
-						backend: &i6.Spec.Rules[0].IngressRuleValue.HTTP.Paths[0].Backend,
-						services: map[meta]*Service{
-							meta{
+						path:   "/",
+						object: i6,
+						services: map[portmeta]*Service{
+							portmeta{
 								name:      "kuard",
 								namespace: "default",
+								port:      8080,
 							}: &Service{
 								object: s1,
+								Port:   8080,
 							},
 						},
 					},
@@ -890,15 +885,16 @@ func TestDAGInsert(t *testing.T) {
 				host: "b.example.com",
 				routes: map[string]*Route{
 					"/": &Route{
-						path:    "/",
-						object:  i6,
-						backend: &i6.Spec.Rules[1].IngressRuleValue.HTTP.Paths[0].Backend,
-						services: map[meta]*Service{
-							meta{
+						path:   "/",
+						object: i6,
+						services: map[portmeta]*Service{
+							portmeta{
 								name:      "kuard",
 								namespace: "default",
+								port:      8080,
 							}: &Service{
 								object: s1,
+								Port:   8080,
 							},
 						},
 					},
@@ -908,15 +904,16 @@ func TestDAGInsert(t *testing.T) {
 				host: "b.example.com",
 				routes: map[string]*Route{
 					"/": &Route{
-						path:    "/",
-						object:  i6,
-						backend: &i6.Spec.Rules[1].IngressRuleValue.HTTP.Paths[0].Backend,
-						services: map[meta]*Service{
-							meta{
+						path:   "/",
+						object: i6,
+						services: map[portmeta]*Service{
+							portmeta{
 								name:      "kuard",
 								namespace: "default",
+								port:      8080,
 							}: &Service{
 								object: s1,
+								Port:   8080,
 							},
 						},
 					},
@@ -942,15 +939,16 @@ func TestDAGInsert(t *testing.T) {
 				host: "a.example.com",
 				routes: map[string]*Route{
 					"/": &Route{
-						path:    "/",
-						object:  i6,
-						backend: &i6.Spec.Rules[0].IngressRuleValue.HTTP.Paths[0].Backend,
-						services: map[meta]*Service{
-							meta{
+						path:   "/",
+						object: i6,
+						services: map[portmeta]*Service{
+							portmeta{
 								name:      "kuard",
 								namespace: "default",
+								port:      8080,
 							}: &Service{
 								object: s1,
+								Port:   8080,
 							},
 						},
 					},
@@ -960,15 +958,16 @@ func TestDAGInsert(t *testing.T) {
 				host: "b.example.com",
 				routes: map[string]*Route{
 					"/": &Route{
-						path:    "/",
-						object:  i6,
-						backend: &i6.Spec.Rules[1].IngressRuleValue.HTTP.Paths[0].Backend,
-						services: map[meta]*Service{
-							meta{
+						path:   "/",
+						object: i6,
+						services: map[portmeta]*Service{
+							portmeta{
 								name:      "kuard",
 								namespace: "default",
+								port:      8080,
 							}: &Service{
 								object: s1,
+								Port:   8080,
 							},
 						},
 					},
@@ -978,15 +977,16 @@ func TestDAGInsert(t *testing.T) {
 				host: "b.example.com",
 				routes: map[string]*Route{
 					"/": &Route{
-						path:    "/",
-						object:  i6,
-						backend: &i6.Spec.Rules[1].IngressRuleValue.HTTP.Paths[0].Backend,
-						services: map[meta]*Service{
-							meta{
+						path:   "/",
+						object: i6,
+						services: map[portmeta]*Service{
+							portmeta{
 								name:      "kuard",
 								namespace: "default",
+								port:      8080,
 							}: &Service{
 								object: s1,
+								Port:   8080,
 							},
 						},
 					},
@@ -1010,14 +1010,12 @@ func TestDAGInsert(t *testing.T) {
 				host: "b.example.com",
 				routes: map[string]*Route{
 					"/": &Route{
-						path:    "/",
-						object:  i7,
-						backend: &i7.Spec.Rules[0].IngressRuleValue.HTTP.Paths[0].Backend,
+						path:   "/",
+						object: i7,
 					},
 					"/kuarder": &Route{
-						path:    "/kuarder",
-						object:  i7,
-						backend: &i7.Spec.Rules[0].IngressRuleValue.HTTP.Paths[1].Backend,
+						path:   "/kuarder",
+						object: i7,
 					},
 				},
 			}},
@@ -1033,28 +1031,30 @@ func TestDAGInsert(t *testing.T) {
 				host: "b.example.com",
 				routes: map[string]*Route{
 					"/": &Route{
-						path:    "/",
-						object:  i7,
-						backend: &i7.Spec.Rules[0].IngressRuleValue.HTTP.Paths[0].Backend,
-						services: map[meta]*Service{
-							meta{
+						path:   "/",
+						object: i7,
+						services: map[portmeta]*Service{
+							portmeta{
 								name:      "kuard",
 								namespace: "default",
+								port:      8080,
 							}: &Service{
 								object: s1,
+								Port:   8080,
 							},
 						},
 					},
 					"/kuarder": &Route{
-						path:    "/kuarder",
-						object:  i7,
-						backend: &i7.Spec.Rules[0].IngressRuleValue.HTTP.Paths[1].Backend,
-						services: map[meta]*Service{
-							meta{
+						path:   "/kuarder",
+						object: i7,
+						services: map[portmeta]*Service{
+							portmeta{
 								name:      "kuarder",
 								namespace: "default",
+								port:      8080,
 							}: &Service{
 								object: s2,
+								Port:   8080,
 							},
 						},
 					},
@@ -1070,28 +1070,30 @@ func TestDAGInsert(t *testing.T) {
 				host: "b.example.com",
 				routes: map[string]*Route{
 					"/": &Route{
-						path:    "/",
-						object:  i8,
-						backend: &i8.Spec.Rules[0].IngressRuleValue.HTTP.Paths[0].Backend,
-						services: map[meta]*Service{
-							meta{
+						path:   "/",
+						object: i8,
+						services: map[portmeta]*Service{
+							portmeta{
 								name:      "kuard",
 								namespace: "default",
+								port:      8080,
 							}: &Service{
 								object: s1,
+								Port:   8080,
 							},
 						},
 					},
 					"/kuarder": &Route{
-						path:    "/kuarder",
-						object:  i8,
-						backend: &i8.Spec.Rules[1].IngressRuleValue.HTTP.Paths[0].Backend,
-						services: map[meta]*Service{
-							meta{
+						path:   "/kuarder",
+						object: i8,
+						services: map[portmeta]*Service{
+							portmeta{
 								name:      "kuarder",
 								namespace: "default",
+								port:      8080,
 							}: &Service{
 								object: s2,
+								Port:   8080,
 							},
 						},
 					},
@@ -1115,28 +1117,30 @@ func TestDAGInsert(t *testing.T) {
 				host: "b.example.com",
 				routes: map[string]*Route{
 					"/": &Route{
-						path:    "/",
-						object:  i9,
-						backend: &i9.Spec.Rules[0].IngressRuleValue.HTTP.Paths[0].Backend,
-						services: map[meta]*Service{
-							meta{
+						path:   "/",
+						object: i9,
+						services: map[portmeta]*Service{
+							portmeta{
 								name:      "kuard",
 								namespace: "default",
+								port:      8080,
 							}: &Service{
 								object: s1,
+								Port:   8080,
 							},
 						},
 					},
 					"/kuarder": &Route{
-						path:    "/kuarder",
-						object:  i9,
-						backend: &i9.Spec.Rules[1].IngressRuleValue.HTTP.Paths[0].Backend,
-						services: map[meta]*Service{
-							meta{
+						path:   "/kuarder",
+						object: i9,
+						services: map[portmeta]*Service{
+							portmeta{
 								name:      "kuarder",
 								namespace: "default",
+								port:      8080,
 							}: &Service{
 								object: s2,
+								Port:   8080,
 							},
 						},
 					},
@@ -1178,15 +1182,16 @@ func TestDAGInsert(t *testing.T) {
 				host: "b.example.com",
 				routes: map[string]*Route{
 					"/": &Route{
-						path:    "/",
-						object:  i6a,
-						backend: &i6a.Spec.Rules[1].IngressRuleValue.HTTP.Paths[0].Backend,
-						services: map[meta]*Service{
-							meta{
+						path:   "/",
+						object: i6a,
+						services: map[portmeta]*Service{
+							portmeta{
 								name:      "kuard",
 								namespace: "default",
+								port:      8080,
 							}: &Service{
 								object: s1,
+								Port:   8080,
 							},
 						},
 					},
@@ -1227,12 +1232,14 @@ func TestDAGInsert(t *testing.T) {
 					"/": &Route{
 						path:   "/",
 						object: ir1,
-						services: map[meta]*Service{
-							meta{
+						services: map[portmeta]*Service{
+							portmeta{
 								name:      "kuard",
 								namespace: "default",
+								port:      8080,
 							}: &Service{
 								object: s1,
+								Port:   8080,
 							},
 						},
 					},
@@ -1250,12 +1257,14 @@ func TestDAGInsert(t *testing.T) {
 					"/": &Route{
 						path:   "/",
 						object: ir2,
-						services: map[meta]*Service{
-							meta{
+						services: map[portmeta]*Service{
+							portmeta{
 								name:      "kuarder",
 								namespace: "default",
+								port:      8080,
 							}: &Service{
 								object: s2,
+								Port:   8080,
 							},
 						},
 					},
@@ -1273,18 +1282,22 @@ func TestDAGInsert(t *testing.T) {
 					"/": &Route{
 						path:   "/",
 						object: ir2,
-						services: map[meta]*Service{
-							meta{
+						services: map[portmeta]*Service{
+							portmeta{
 								name:      "kuard",
 								namespace: "default",
+								port:      8080,
 							}: &Service{
 								object: s1,
+								Port:   8080,
 							},
-							meta{
+							portmeta{
 								name:      "kuarder",
 								namespace: "default",
+								port:      8080,
 							}: &Service{
 								object: s2,
+								Port:   8080,
 							},
 						},
 					},
@@ -1502,9 +1515,8 @@ func TestDAGRemove(t *testing.T) {
 				host: "kuard.example.com",
 				routes: map[string]*Route{
 					"/": &Route{
-						path:    "/",
-						object:  i3,
-						backend: &i3.Spec.Rules[0].IngressRuleValue.HTTP.Paths[0].Backend,
+						path:   "/",
+						object: i3,
 					},
 				},
 			}},
@@ -1532,9 +1544,8 @@ func TestDAGRemove(t *testing.T) {
 				host: "*",
 				routes: map[string]*Route{
 					"/": &Route{
-						path:    "/",
-						object:  i1,
-						backend: i1.Spec.Backend,
+						path:   "/",
+						object: i1,
 					},
 				},
 			}},
@@ -1552,9 +1563,8 @@ func TestDAGRemove(t *testing.T) {
 				host: "*",
 				routes: map[string]*Route{
 					"/": &Route{
-						path:    "/",
-						object:  i1,
-						backend: i1.Spec.Backend,
+						path:   "/",
+						object: i1,
 					},
 				},
 			}},
@@ -1582,9 +1592,8 @@ func TestDAGRemove(t *testing.T) {
 				host: "*",
 				routes: map[string]*Route{
 					"/": &Route{
-						path:    "/",
-						object:  i5,
-						backend: &i5.Spec.Rules[0].IngressRuleValue.HTTP.Paths[0].Backend,
+						path:   "/",
+						object: i5,
 					},
 				},
 			}},
@@ -1602,9 +1611,8 @@ func TestDAGRemove(t *testing.T) {
 				host: "kuard.example.com",
 				routes: map[string]*Route{
 					"/": &Route{
-						path:    "/",
-						object:  i3,
-						backend: &i3.Spec.Rules[0].IngressRuleValue.HTTP.Paths[0].Backend,
+						path:   "/",
+						object: i3,
 					},
 				},
 			}},
@@ -1631,9 +1639,8 @@ func TestDAGRemove(t *testing.T) {
 				host: "a.example.com",
 				routes: map[string]*Route{
 					"/": &Route{
-						path:    "/",
-						object:  i6,
-						backend: &i6.Spec.Rules[0].IngressRuleValue.HTTP.Paths[0].Backend,
+						path:   "/",
+						object: i6,
 					},
 				},
 			}, {
@@ -1641,9 +1648,8 @@ func TestDAGRemove(t *testing.T) {
 				host: "b.example.com",
 				routes: map[string]*Route{
 					"/": &Route{
-						path:    "/",
-						object:  i6,
-						backend: &i6.Spec.Rules[1].IngressRuleValue.HTTP.Paths[0].Backend,
+						path:   "/",
+						object: i6,
 					},
 				},
 			}},
@@ -1662,15 +1668,16 @@ func TestDAGRemove(t *testing.T) {
 				host: "a.example.com",
 				routes: map[string]*Route{
 					"/": &Route{
-						path:    "/",
-						object:  i6,
-						backend: &i6.Spec.Rules[0].IngressRuleValue.HTTP.Paths[0].Backend,
-						services: map[meta]*Service{
-							meta{
+						path:   "/",
+						object: i6,
+						services: map[portmeta]*Service{
+							portmeta{
 								name:      "kuard",
 								namespace: "default",
+								port:      8080,
 							}: &Service{
 								object: s1,
+								Port:   8080,
 							},
 						},
 					},
@@ -1680,15 +1687,16 @@ func TestDAGRemove(t *testing.T) {
 				host: "b.example.com",
 				routes: map[string]*Route{
 					"/": &Route{
-						path:    "/",
-						object:  i6,
-						backend: &i6.Spec.Rules[1].IngressRuleValue.HTTP.Paths[0].Backend,
-						services: map[meta]*Service{
-							meta{
+						path:   "/",
+						object: i6,
+						services: map[portmeta]*Service{
+							portmeta{
 								name:      "kuard",
 								namespace: "default",
+								port:      8080,
 							}: &Service{
 								object: s1,
+								Port:   8080,
 							},
 						},
 					},
@@ -1709,9 +1717,8 @@ func TestDAGRemove(t *testing.T) {
 				host: "a.example.com",
 				routes: map[string]*Route{
 					"/": &Route{
-						path:    "/",
-						object:  i6,
-						backend: &i6.Spec.Rules[0].IngressRuleValue.HTTP.Paths[0].Backend,
+						path:   "/",
+						object: i6,
 					},
 				},
 			}, {
@@ -1719,9 +1726,8 @@ func TestDAGRemove(t *testing.T) {
 				host: "b.example.com",
 				routes: map[string]*Route{
 					"/": &Route{
-						path:    "/",
-						object:  i6,
-						backend: &i6.Spec.Rules[1].IngressRuleValue.HTTP.Paths[0].Backend,
+						path:   "/",
+						object: i6,
 					},
 				},
 			}, {
@@ -1729,9 +1735,8 @@ func TestDAGRemove(t *testing.T) {
 				host: "b.example.com",
 				routes: map[string]*Route{
 					"/": &Route{
-						path:    "/",
-						object:  i6,
-						backend: &i6.Spec.Rules[1].IngressRuleValue.HTTP.Paths[0].Backend,
+						path:   "/",
+						object: i6,
 					},
 				},
 				secrets: map[meta]*Secret{
@@ -1758,22 +1763,22 @@ func TestDAGRemove(t *testing.T) {
 				host: "b.example.com",
 				routes: map[string]*Route{
 					"/": &Route{
-						path:    "/",
-						object:  i7,
-						backend: &i7.Spec.Rules[0].IngressRuleValue.HTTP.Paths[0].Backend,
-						services: map[meta]*Service{
-							meta{
+						path:   "/",
+						object: i7,
+						services: map[portmeta]*Service{
+							portmeta{
 								name:      "kuard",
 								namespace: "default",
+								port:      8080,
 							}: &Service{
 								object: s1,
+								Port:   8080,
 							},
 						},
 					},
 					"/kuarder": &Route{
-						path:    "/kuarder",
-						object:  i7,
-						backend: &i7.Spec.Rules[0].IngressRuleValue.HTTP.Paths[1].Backend,
+						path:   "/kuarder",
+						object: i7,
 					},
 				},
 			}},
@@ -1817,7 +1822,7 @@ func (v *VirtualHost) String() string {
 }
 
 func (r *Route) String() string {
-	return fmt.Sprintf("route: %q {services: %v, object: %p, backend: %+v}", r.Prefix(), r.services, r.object, r.backend)
+	return fmt.Sprintf("route: %q {services: %v, object: %p}", r.Prefix(), r.services, r.object)
 }
 
 func (s *Service) String() string {

--- a/internal/debug/dot.go
+++ b/internal/debug/dot.go
@@ -47,7 +47,7 @@ func (c *ctx) writeVertex(v dag.Vertex) {
 	case *dag.Secret:
 		fmt.Fprintf(c.w, `"%p" [shape=record, label="{secret|%s/%s}"]`+"\n", v, v.Namespace(), v.Name())
 	case *dag.Service:
-		fmt.Fprintf(c.w, `"%p" [shape=record, label="{service|%s/%s}"]`+"\n", v, v.Namespace(), v.Name())
+		fmt.Fprintf(c.w, `"%p" [shape=record, label="{service|%s/%s:%d}"]`+"\n", v, v.Namespace(), v.Name(), v.Port)
 	case *dag.VirtualHost:
 		fmt.Fprintf(c.w, `"%p" [shape=record, label="{host|%s:%d}"]`+"\n", v, v.FQDN(), v.Port)
 	case *dag.Route:
@@ -63,8 +63,6 @@ func (c *ctx) writeEdge(parent, child dag.Vertex) {
 	switch child := child.(type) {
 	default:
 		fmt.Fprintf(c.w, `"%p" -> "%p"`+"\n", parent, child)
-	case *dag.Service:
-		fmt.Fprintf(c.w, `"%p" -> "%p" [label="port: %d"]`+"\n", parent, child, child.Port)
 	}
 
 }

--- a/internal/debug/dot.go
+++ b/internal/debug/dot.go
@@ -36,13 +36,9 @@ type ctx struct {
 	w     io.Writer
 	nodes map[interface{}]bool
 	edges map[pair]bool
-	route *dag.Route
 }
 
 func (c *ctx) writeVertex(v dag.Vertex) {
-	if r, ok := v.(*dag.Route); ok {
-		c.route = r
-	}
 	if c.nodes[v] {
 		return
 	}
@@ -68,7 +64,7 @@ func (c *ctx) writeEdge(parent, child dag.Vertex) {
 	default:
 		fmt.Fprintf(c.w, `"%p" -> "%p"`+"\n", parent, child)
 	case *dag.Service:
-		fmt.Fprintf(c.w, `"%p" -> "%p" [label="port: %s"]`+"\n", parent, child, c.route.ServicePort())
+		fmt.Fprintf(c.w, `"%p" -> "%p" [label="port: %d"]`+"\n", parent, child, child.Port)
 	}
 
 }


### PR DESCRIPTION
Updates #211
Fixes #462

Handling the IntStr nature of Ingress's Backend.SevicePort field has
been a thorn in Contour's side for a long time (see #211). This PR
addesses both #211 and #462 by resolving the port number during DAG
recomputation if a named port is in use.

We store the selected port number on dag.Service and construct a tupple
of namespace/name/port to treat each service separately, ie. a service
with port 9000 is different to the port 9001 on the same service object.

In doing so we remove the requirement to store the particular
v1beta1.ServiceBackend on the Route object, which resolves the issue of
an ingressroutev1 object lacking that object. The route object doesn't
need to hold this information anyway, it's already present on the
Service object as described above.

![graph](https://user-images.githubusercontent.com/7171/41892120-5f7b1ef8-795a-11e8-88dd-4f61f4ad1822.png)

Signed-off-by: Dave Cheney <dave@cheney.net>