### PR TITLE
Add example ingressroute objects

### DIFF
--- a/deployment/example-workload/ingressroute/00-common/00-namespaces.yaml
+++ b/deployment/example-workload/ingressroute/00-common/00-namespaces.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: marketing
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: default

--- a/deployment/example-workload/ingressroute/00-common/01-services.yaml
+++ b/deployment/example-workload/ingressroute/00-common/01-services.yaml
@@ -1,0 +1,154 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: s1
+  namespace: default
+spec:
+  selector:
+    app: kuard
+  ports:
+  - name: http
+    port: 80
+    protocol: TCP
+    targetPort: 8080
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: s2
+  namespace: default
+spec:
+  selector:
+    app: kuard
+  ports:
+  - name: http
+    port: 80
+    protocol: TCP
+    targetPort: 8080
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: s1-health
+  namespace: default
+spec:
+  selector:
+    app: kuard
+  ports:
+  - name: http
+    port: 80
+    protocol: TCP
+    targetPort: 8080
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: s2-health
+  namespace: default
+spec:
+  selector:
+    app: kuard
+  ports:
+  - name: http
+    port: 80
+    protocol: TCP
+    targetPort: 8080
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: s1-def-health
+  namespace: default
+spec:
+  selector:
+    app: kuard
+  ports:
+  - name: http
+    port: 80
+    protocol: TCP
+    targetPort: 8080
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: s2-def-health
+  namespace: default
+spec:
+  selector:
+    app: kuard
+  ports:
+  - name: http
+    port: 80
+    protocol: TCP
+    targetPort: 8080
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: s1-strategy
+  namespace: default
+spec:
+  selector:
+    app: kuard
+  ports:
+  - name: http
+    port: 80
+    protocol: TCP
+    targetPort: 8080
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: s2-strategy
+  namespace: default
+spec:
+  selector:
+    app: kuard
+  ports:
+  - name: http
+    port: 80
+    protocol: TCP
+    targetPort: 8080
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: s1-def-strategy
+  namespace: default
+spec:
+  selector:
+    app: kuard
+  ports:
+  - name: http
+    port: 80
+    protocol: TCP
+    targetPort: 8080
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: s2-def-strategy
+  namespace: default
+spec:
+  selector:
+    app: kuard
+  ports:
+  - name: http
+    port: 80
+    protocol: TCP
+    targetPort: 8080
+---
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: s2
+  namespace: marketing
+spec:
+  selector:
+    app: kuard
+  ports:
+  - name: http
+    port: 80
+    protocol: TCP
+    targetPort: 8080

--- a/deployment/example-workload/ingressroute/00-common/01-services.yaml
+++ b/deployment/example-workload/ingressroute/00-common/01-services.yaml
@@ -138,7 +138,6 @@ spec:
     protocol: TCP
     targetPort: 8080
 ---
----
 apiVersion: v1
 kind: Service
 metadata:

--- a/deployment/example-workload/ingressroute/00-common/02-deployments.yaml
+++ b/deployment/example-workload/ingressroute/00-common/02-deployments.yaml
@@ -1,0 +1,37 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: kuard
+  namespace: default
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: kuard
+  template:
+    metadata:
+      labels:
+        app: kuard
+    spec:
+      containers:
+      - image: gcr.io/kuar-demo/kuard-amd64:1
+        name: kuard
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: kuard
+  namespace: marketing
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: kuard
+  template:
+    metadata:
+      labels:
+        app: kuard
+    spec:
+      containers:
+      - image: gcr.io/kuar-demo/kuard-amd64:1
+        name: kuard

--- a/deployment/example-workload/ingressroute/01-ingress-to-ingressroute/basic.ingressroute.yaml
+++ b/deployment/example-workload/ingressroute/01-ingress-to-ingressroute/basic.ingressroute.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: contour.heptio.com/v1beta1
+kind: IngressRoute
+metadata: 
+  name: basic
+  namespace: default
+spec: 
+  virtualhost:
+    fqdn: foo-basic.bar.com
+  routes: 
+    - match: /
+      services: 
+        - name: s1
+          port: 80
+
+# apiVersion: extensions/v1beta1
+# kind: Ingress
+# metadata:
+#   name: basic
+# spec:
+#   rules:
+#   - host: foo-basic.bar.com
+#     http:
+#       paths:
+#       - backend:
+#           serviceName: s1
+#           servicePort: 80

--- a/deployment/example-workload/ingressroute/01-ingress-to-ingressroute/name-based.ingressroute.yaml
+++ b/deployment/example-workload/ingressroute/01-ingress-to-ingressroute/name-based.ingressroute.yaml
@@ -21,7 +21,7 @@ metadata:
   namespace: default
 spec: 
   virtualhost:
-    fqdn: bar1.bar.com
+    fqdn: bar1.foo.com
   routes: 
     - match: /
       services: 

--- a/deployment/example-workload/ingressroute/01-ingress-to-ingressroute/name-based.ingressroute.yaml
+++ b/deployment/example-workload/ingressroute/01-ingress-to-ingressroute/name-based.ingressroute.yaml
@@ -21,7 +21,7 @@ metadata:
   namespace: default
 spec: 
   virtualhost:
-    fqdn: bar1.foo.com
+    fqdn: bar1.bar.com
   routes: 
     - match: /
       services: 
@@ -40,7 +40,7 @@ spec:
 #       - backend:
 #           serviceName: s1
 #           servicePort: 80
-#   - host: bar1.foo.com
+#   - host: bar1.bar.com
 #     http:
 #       paths:
 #       - backend:

--- a/deployment/example-workload/ingressroute/01-ingress-to-ingressroute/name-based.ingressroute.yaml
+++ b/deployment/example-workload/ingressroute/01-ingress-to-ingressroute/name-based.ingressroute.yaml
@@ -1,0 +1,48 @@
+---
+apiVersion: contour.heptio.com/v1beta1
+kind: IngressRoute
+metadata: 
+  name: name-example-foo
+  namespace: default
+spec: 
+  virtualhost:
+    fqdn: foo1.bar.com
+  routes: 
+    - match: /
+      services: 
+        - name: s1
+          port: 80
+
+---
+apiVersion: contour.heptio.com/v1beta1
+kind: IngressRoute
+metadata: 
+  name: name-example-bar
+  namespace: default
+spec: 
+  virtualhost:
+    fqdn: bar1.bar.com
+  routes: 
+    - match: /
+      services: 
+        - name: s2
+          port: 80
+
+# apiVersion: extensions/v1beta1
+# kind: Ingress
+# metadata:
+#   name: name-example
+# spec:
+#   rules:
+#   - host: foo1.bar.com
+#     http:
+#       paths:
+#       - backend:
+#           serviceName: s1
+#           servicePort: 80
+#   - host: bar1.foo.com
+#     http:
+#       paths:
+#       - backend:
+#           serviceName: s2
+#           servicePort: 80

--- a/deployment/example-workload/ingressroute/01-ingress-to-ingressroute/tls.ingressroute.yaml
+++ b/deployment/example-workload/ingressroute/01-ingress-to-ingressroute/tls.ingressroute.yaml
@@ -1,0 +1,31 @@
+---
+apiVersion: contour.heptio.com/v1beta1
+kind: IngressRoute
+metadata: 
+  name: tls-example
+  namespace: default
+spec: 
+  virtualhost:
+    fqdn: foo2.bar.com
+    tls:
+      secretName: testsecret
+  routes: 
+    - match: /
+      services: 
+        - name: s1
+          port: 80
+
+# apiVersion: extensions/v1beta1
+# kind: Ingress
+# metadata:
+#   name: tls-example
+# spec:
+#   tls:
+#     - secretName: testsecret
+#   rules:
+#   - host: foo2.bar.com
+#     http:
+#       paths:
+#       - backend:
+#           serviceName: s1
+#           servicePort: 80

--- a/deployment/example-workload/ingressroute/02-basic/default-health-checks.ingressroute.yaml
+++ b/deployment/example-workload/ingressroute/02-basic/default-health-checks.ingressroute.yaml
@@ -4,9 +4,15 @@ kind: IngressRoute
 metadata: 
   name: health-check
   namespace: default
-spec: 
+spec:
   virtualhost:
     fqdn: health.bar.com
+  lbHealthCheck:
+    path: /healthy
+    intervalSeconds: 5
+    timeoutSeconds: 2
+    unhealthyThresholdCount: 3
+    healthyThresholdCount: 5
   routes: 
     - match: /
       services: 

--- a/deployment/example-workload/ingressroute/02-basic/default-health-checks.ingressroute.yaml
+++ b/deployment/example-workload/ingressroute/02-basic/default-health-checks.ingressroute.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: contour.heptio.com/v1beta1
+kind: IngressRoute
+metadata: 
+  name: health-check
+  namespace: default
+spec: 
+  virtualhost:
+    fqdn: health.bar.com
+  routes: 
+    - match: /
+      services: 
+        - name: s1-def-health
+          port: 80
+        - name: s2-def-health
+          port: 80

--- a/deployment/example-workload/ingressroute/02-basic/default-lb-strategy.ingressroute.yaml
+++ b/deployment/example-workload/ingressroute/02-basic/default-lb-strategy.ingressroute.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: contour.heptio.com/v1beta1
+kind: IngressRoute
+metadata: 
+  name: default-lb-strategy
+  namespace: default
+spec: 
+  virtualhost:
+    fqdn: default-strategy.bar.com
+  strategy: RoundRobin # Default LB Algorithm to be applied to services
+  routes: 
+    - match: /
+      services: 
+        - name: s1-def-strategy
+          port: 80
+        - name: s2-def-strategy
+          port: 80

--- a/deployment/example-workload/ingressroute/02-basic/domain-aliases.ingressroute.yaml
+++ b/deployment/example-workload/ingressroute/02-basic/domain-aliases.ingressroute.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: contour.heptio.com/v1beta1
+kind: IngressRoute
+metadata: 
+  name: domain-aliases
+  namespace: default
+spec: 
+  virtualhost:
+    fqdn: bar.com
+    aliases:
+      - www.bar.com
+  routes: 
+    - match: /
+      services: 
+        - name: s1
+          port: 80

--- a/deployment/example-workload/ingressroute/02-basic/health-checks.ingressroute.yaml
+++ b/deployment/example-workload/ingressroute/02-basic/health-checks.ingressroute.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: contour.heptio.com/v1beta1
+kind: IngressRoute
+metadata: 
+  name: health-check
+  namespace: default
+spec: 
+  virtualhost:
+    fqdn: health.bar.com
+  routes: 
+    - match: /
+      services: 
+        - name: s1-health
+          port: 80
+          lbHealthCheck:
+            path: /healthy
+            intervalSeconds: 5
+            timeoutSeconds: 2
+            unhealthyThresholdCount: 3
+            healthyThresholdCount: 5
+        - name: s2-health # no health-check defined for this service
+          port: 80

--- a/deployment/example-workload/ingressroute/02-basic/lb-strategy.ingressroute.yaml
+++ b/deployment/example-workload/ingressroute/02-basic/lb-strategy.ingressroute.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: contour.heptio.com/v1beta1
+kind: IngressRoute
+metadata: 
+  name: lb-strategy
+  namespace: default
+spec: 
+  virtualhost:
+    fqdn: strategy.bar.com
+  routes: 
+    - match: /
+      services: 
+        - name: s1-strategy
+          port: 80
+        - name: s2-strategy
+          port: 80
+          strategy: WeightedLeastRequest # Default LB Algoritm for this Service is overridden

--- a/deployment/example-workload/ingressroute/02-basic/multiple-upstreams.ingressroute.yaml
+++ b/deployment/example-workload/ingressroute/02-basic/multiple-upstreams.ingressroute.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: contour.heptio.com/v1beta1
+kind: IngressRoute
+metadata: 
+  name: multiple-upstreams
+  namespace: default
+spec: 
+  virtualhost:
+    fqdn: multi.bar.com
+  routes: 
+    - match: /
+      services: 
+        - name: s1
+          port: 80
+        - name: s2
+          port: 80

--- a/deployment/example-workload/ingressroute/02-basic/weight-shifting.ingressroute.yaml
+++ b/deployment/example-workload/ingressroute/02-basic/weight-shifting.ingressroute.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: contour.heptio.com/v1beta1
+kind: IngressRoute
+metadata: 
+  name: weight-shifting
+  namespace: default
+spec: 
+  virtualhost:
+    fqdn: weights.bar.com
+  routes: 
+    - match: /
+      services: 
+        - name: s1
+          port: 80
+          weight: 10
+        - name: s2
+          port: 80
+          weight: 90

--- a/deployment/example-workload/ingressroute/03-delegation-within-namespace/root.ingressroute.yaml
+++ b/deployment/example-workload/ingressroute/03-delegation-within-namespace/root.ingressroute.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: contour.heptio.com/v1beta1
+kind: IngressRoute
+metadata: 
+  name: delegation-root
+  namespace: default
+spec: 
+  virtualhost:
+    fqdn: root.bar.com
+  routes: 
+    - match: /
+      services: 
+        - name: s1
+          port: 80
+# delegate the subpath, `/service2` to the IngressRoute object in this namespace with the name `service2`
+    - match: /service2 
+      delegate:
+        name: service2
+

--- a/deployment/example-workload/ingressroute/03-delegation-within-namespace/service2.ingressroute.yaml
+++ b/deployment/example-workload/ingressroute/03-delegation-within-namespace/service2.ingressroute.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: contour.heptio.com/v1beta1
+kind: IngressRoute
+metadata: 
+  name: service2
+  namespace: default
+spec: 
+  routes: 
+    - match: /service2
+      services: 
+        - name: s2
+          port: 80

--- a/deployment/example-workload/ingressroute/04-blue-green-delegation/blue.ingressroute.yaml
+++ b/deployment/example-workload/ingressroute/04-blue-green-delegation/blue.ingressroute.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: contour.heptio.com/v1beta1
+kind: IngressRoute
+metadata: 
+  name: blue
+  namespace: default
+spec: 
+  routes: 
+    - match: /
+      services: 
+        - name: s2
+          port: 80

--- a/deployment/example-workload/ingressroute/04-blue-green-delegation/green.ingressroute.yaml
+++ b/deployment/example-workload/ingressroute/04-blue-green-delegation/green.ingressroute.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: contour.heptio.com/v1beta1
+kind: IngressRoute
+metadata: 
+  name: green
+  namespace: default
+spec: 
+  routes: 
+    - match: /
+      services: 
+        - name: s1
+          port: 80

--- a/deployment/example-workload/ingressroute/04-blue-green-delegation/root.ingressroute.yaml
+++ b/deployment/example-workload/ingressroute/04-blue-green-delegation/root.ingressroute.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: contour.heptio.com/v1beta1
+kind: IngressRoute
+metadata: 
+  name: blue-green-root
+  namespace: default
+spec: 
+  virtualhost:
+    fqdn: blue-green.bar.com
+  routes: 
+    - match: / 
+      delegate:
+        name: blue # Changing this to `green` will immediately switch to the other ingressroute object
+                   # This can be helpful for testing different ingressroute configs
+                   # or for improved UX doing blue/green application deployments
+

--- a/deployment/example-workload/ingressroute/05-delegation-across-namespaces/blog.ingressroute.yaml
+++ b/deployment/example-workload/ingressroute/05-delegation-across-namespaces/blog.ingressroute.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: contour.heptio.com/v1beta1
+kind: IngressRoute
+metadata: 
+  name: blog
+  namespace: marketing
+spec: 
+  routes: 
+    - match: /blog
+      services: 
+        - name: s2
+          port: 80

--- a/deployment/example-workload/ingressroute/05-delegation-across-namespaces/root.ingressroute.yaml
+++ b/deployment/example-workload/ingressroute/05-delegation-across-namespaces/root.ingressroute.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: contour.heptio.com/v1beta1
+kind: IngressRoute
+metadata: 
+  name: namespace-delegation-root
+  namespace: default
+spec: 
+  virtualhost:
+    fqdn: ns-root.bar.com
+  routes: 
+    - match: /
+      services: 
+        - name: s1
+          port: 80
+# delegate the subpath, `/blog` to the IngressRoute object in the marketing namespace with the name `blog`
+    - match: /blog 
+      delegate:
+        name: blog
+        namespace: marketing


### PR DESCRIPTION
As part of #450, I wanted to create put together a suite of IngressRoute objects and corresponding services.

This should hopefully be helpful for the development team working on the IngressRoute DAG implementations.