### PR TITLE
internal/dag: enforce root ingressroutes live in specific namespaces

### DIFF
--- a/cmd/contour/contour.go
+++ b/cmd/contour/contour.go
@@ -94,6 +94,7 @@ func main() {
 	serve.Flag("envoy-https-port", "Envoy HTTPS listener port").IntVar(&da.HTTPSPort)
 	serve.Flag("use-proxy-protocol", "Use PROXY protocol for all listeners").BoolVar(&da.UseProxyProto)
 	serve.Flag("ingress-class-name", "Contour IngressClass name").StringVar(&da.IngressClass)
+	serve.Flag("ingressroute-root-namespaces", "Restrict contour to searching these namespaces for root ingress routes").StringsVar(&da.IngressRouteRootNamespaces)
 
 	args := os.Args[1:]
 	switch kingpin.MustParse(app.Parse(args)) {


### PR DESCRIPTION
Implements enforcing mode, in which root ingress routes can only be defined in specific namespaces.

If contour encounters a root ingress route that is defined outside of the blessed namespaces, the ingress route is ignored.

If the list of blessed namespaces is empty, root ingress routes can be defined in any namespace.

Fixes #461 