### PR TITLE
internal/e2e: add missing e2e LDS tests

### DIFF
--- a/internal/e2e/e2e.go
+++ b/internal/e2e/e2e.go
@@ -49,13 +49,17 @@ func (t *testWriter) Write(buf []byte) (int, error) {
 	return len(buf), nil
 }
 
-func setup(t *testing.T) (cache.ResourceEventHandler, *grpc.ClientConn, func()) {
+func setup(t *testing.T, opts ...func(*contour.Translator)) (cache.ResourceEventHandler, *grpc.ClientConn, func()) {
 	log := logrus.New()
 	log.Out = &testWriter{t}
 
 	tr := &contour.Translator{
 		FieldLogger: log,
 	}
+	for _, opt := range opts {
+		opt(tr)
+	}
+
 	et := &contour.EndpointsTranslator{
 		FieldLogger: log,
 	}


### PR DESCRIPTION
Updates #454

Add e2e tests for tls-minimum-protocol and use-proxy-proto. These will
keep these scenarios covered when #460 lands.