### PR TITLE
Fqdn validation

### DIFF
--- a/internal/dag/dag.go
+++ b/internal/dag/dag.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2/auth"
 	ingressroutev1 "github.com/heptio/contour/apis/contour/v1beta1"
+	"fmt"
 )
 
 // A DAG represents a directed acylic graph of objects representing the relationship
@@ -363,6 +364,12 @@ func (d *DAG) recompute() dag {
 		}
 
 		host := ir.Spec.VirtualHost.Fqdn
+
+		// Validate the fqdn is passed
+		if len(strings.TrimSpace(host)) == 0 {
+			fmt.Println("[ERROR] Spec.VirtualHost.Fqdn must be specified!")
+			continue
+		}
 
 		if tls := ir.Spec.VirtualHost.TLS; tls != nil {
 			// attach secrets to TLS enabled vhosts

--- a/internal/dag/dag_test.go
+++ b/internal/dag/dag_test.go
@@ -1950,6 +1950,77 @@ func TestDAGInsert(t *testing.T) {
 				},
 			},
 		},
+		"insert ingress with empty fqdn": {
+			objs: []interface{}{
+				&ingressroutev1.IngressRoute{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "kuard",
+						Namespace: "default",
+					},
+					Spec: ingressroutev1.IngressRouteSpec{
+						VirtualHost: &ingressroutev1.VirtualHost{
+							Fqdn: "",
+						},
+						Routes: []ingressroutev1.Route{{
+							Match:    "/",
+							Services: []ingressroutev1.Service{{Name: "kuard", Port: 8080}},
+						}},
+					},
+				},
+			},
+			want: []Vertex{},
+		},
+		"insert ingress with empty chars in fqdn": {
+			objs: []interface{}{
+				&ingressroutev1.IngressRoute{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "kuard",
+						Namespace: "default",
+					},
+					Spec: ingressroutev1.IngressRouteSpec{
+						VirtualHost: &ingressroutev1.VirtualHost{
+							Fqdn: "    ",
+						},
+						Routes: []ingressroutev1.Route{{
+							Match:    "/",
+							Services: []ingressroutev1.Service{{Name: "kuard", Port: 8080}},
+						}},
+					},
+				},
+			},
+			want: []Vertex{},
+		},
+		"insert valid ingressroute along with invalid fqdn": {
+			objs: []interface{}{
+				&ingressroutev1.IngressRoute{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "kuard",
+						Namespace: "default",
+					},
+					Spec: ingressroutev1.IngressRouteSpec{
+						VirtualHost: &ingressroutev1.VirtualHost{
+							Fqdn: "",
+						},
+						Routes: []ingressroutev1.Route{{
+							Match:    "/",
+							Services: []ingressroutev1.Service{{Name: "kuard", Port: 8080}},
+						}},
+					},
+				},
+				ir1,
+			},
+			want: []Vertex{
+				&VirtualHost{
+					Port: 80,
+					host: "example.com",
+					routes: map[string]*Route{
+						"/": &Route{
+							path:   "/",
+							object: ir1,
+						},
+					},
+				}},
+		},
 	}
 
 	for name, tc := range tests {


### PR DESCRIPTION
If any Root IngressRoute defined does not supply the `fqdn` value, then that object is invalid and should be skipped. Additionally, the status of the object is set to `invalid`. 

**(NOTE: This is currently blocked until #469 is merged.)**

Example:

```yaml
status:
  currentStatus: invalid
  description: Spec.VirtualHost.Fqdn must be specified!
```

// Fixes #447 