### PR TITLE
internal/dag: perform path prefix match instead of string prefix match

### DIFF
--- a/internal/dag/dag.go
+++ b/internal/dag/dag.go
@@ -388,7 +388,11 @@ func (d *DAG) processIngressRoute(ir *ingressroutev1.IngressRoute, prefixMatch s
 
 	for _, route := range ir.Spec.Routes {
 		// base case: The route points to services, so we add them to the vhost
-		if len(route.Services) > 0 && strings.HasPrefix(route.Match, prefixMatch) {
+		if len(route.Services) > 0 {
+			if !matchesPathPrefix(route.Match, prefixMatch) {
+				// TODO: set status
+				return
+			}
 			r := &Route{
 				path:   route.Match,
 				object: ir,
@@ -418,6 +422,24 @@ func (d *DAG) processIngressRoute(ir *ingressroutev1.IngressRoute, prefixMatch s
 			}
 		}
 	}
+}
+
+// matchesPathPrefix checks whether the given path matches the given prefix
+func matchesPathPrefix(path, prefix string) bool {
+	if len(prefix) == 0 {
+		return true
+	}
+	// an empty string cannot have a prefix
+	if len(path) == 0 {
+		return false
+	}
+	if prefix[len(prefix)-1] != '/' {
+		prefix = prefix + "/"
+	}
+	if path[len(path)-1] != '/' {
+		path = path + "/"
+	}
+	return strings.HasPrefix(strings.ToLower(path), strings.ToLower(prefix))
 }
 
 type Root interface {

--- a/internal/dag/dag.go
+++ b/internal/dag/dag.go
@@ -439,7 +439,7 @@ func matchesPathPrefix(path, prefix string) bool {
 	if path[len(path)-1] != '/' {
 		path = path + "/"
 	}
-	return strings.HasPrefix(strings.ToLower(path), strings.ToLower(prefix))
+	return strings.HasPrefix(path, prefix)
 }
 
 type Root interface {

--- a/internal/dag/dag_test.go
+++ b/internal/dag/dag_test.go
@@ -3158,11 +3158,6 @@ func TestMatchesPathPrefix(t *testing.T) {
 			path:    "/foo",
 			matches: true,
 		},
-		"no case sensitivity": {
-			prefix:  "/foo",
-			path:    "/FOO",
-			matches: true,
-		},
 		"strict match with / at the end": {
 			prefix:  "/foo/",
 			path:    "/foo/",


### PR DESCRIPTION
Fixes #488 

Instead of performing a string prefix match, make sure that the child ingressroute matches the parent's path prefix. 

In the case that any of the routes of the child ingressroute does not match the parent's path prefix, the entire child ingressroute is considered invalid and not considered in the DAG.
