### PR TITLE
internal/dag: record service port object on dag.Service

### DIFF
--- a/internal/dag/dag.go
+++ b/internal/dag/dag.go
@@ -166,24 +166,26 @@ func (sm *serviceMap) lookup(m meta, port intstr.IntOrString) *Service {
 	if !ok {
 		return nil
 	}
-	for _, p := range svc.Spec.Ports {
+	for i := range svc.Spec.Ports {
+		p := &svc.Spec.Ports[i]
 		if int(p.Port) == port.IntValue() {
-			return sm.insert(svc, int(p.Port))
+			return sm.insert(svc, p)
 		}
 		if port.String() == p.Name {
-			return sm.insert(svc, int(p.Port))
+			return sm.insert(svc, p)
 		}
 	}
 	return nil
 }
 
-func (sm *serviceMap) insert(svc *v1.Service, port int) *Service {
+func (sm *serviceMap) insert(svc *v1.Service, port *v1.ServicePort) *Service {
 	if sm._services == nil {
 		sm._services = make(map[portmeta]*Service)
 	}
 	s := &Service{
-		object: svc,
-		Port:   port,
+		object:      svc,
+		Port:        int(port.Port),
+		ServicePort: port,
 	}
 	sm._services[s.toMeta()] = s
 	return s
@@ -511,6 +513,8 @@ type Service struct {
 
 	// Port is the port of this service
 	Port int
+
+	*v1.ServicePort
 }
 
 func (s *Service) Name() string       { return s.object.Name }

--- a/internal/dag/dag.go
+++ b/internal/dag/dag.go
@@ -158,7 +158,7 @@ type serviceMap struct {
 // If no matching Service is found lookup returns nil.
 func (sm *serviceMap) lookup(m meta, port intstr.IntOrString) *Service {
 	if port.Type == intstr.Int {
-		if s, ok := sm._services[portmeta{name: m.name, namespace: m.namespace, port: int(port.IntValue())}]; ok {
+		if s, ok := sm._services[portmeta{name: m.name, namespace: m.namespace, port: int32(port.IntValue())}]; ok {
 			return s
 		}
 	}
@@ -184,7 +184,6 @@ func (sm *serviceMap) insert(svc *v1.Service, port *v1.ServicePort) *Service {
 	}
 	s := &Service{
 		object:      svc,
-		Port:        int(port.Port),
 		ServicePort: port,
 	}
 	sm._services[s.toMeta()] = s
@@ -511,9 +510,6 @@ type Vertex interface {
 type Service struct {
 	object *v1.Service
 
-	// Port is the port of this service
-	Port int
-
 	*v1.ServicePort
 }
 
@@ -524,7 +520,7 @@ func (s *Service) Visit(func(Vertex)) {}
 type portmeta struct {
 	name      string
 	namespace string
-	port      int
+	port      int32
 }
 
 func (s *Service) toMeta() portmeta {

--- a/internal/dag/dag_test.go
+++ b/internal/dag/dag_test.go
@@ -759,8 +759,9 @@ func TestDAGInsert(t *testing.T) {
 							object: i1,
 							services: servicemap(
 								&Service{
-									object: s1,
-									Port:   8080,
+									object:      s1,
+									Port:        8080,
+									ServicePort: &s1.Spec.Ports[0],
 								},
 							),
 						},
@@ -783,8 +784,9 @@ func TestDAGInsert(t *testing.T) {
 							object: i1,
 							services: servicemap(
 								&Service{
-									object: s1,
-									Port:   8080,
+									object:      s1,
+									Port:        8080,
+									ServicePort: &s1.Spec.Ports[0],
 								},
 							),
 						},
@@ -897,8 +899,9 @@ func TestDAGInsert(t *testing.T) {
 							object: i4,
 							services: servicemap(
 								&Service{
-									object: s1,
-									Port:   8080,
+									object:      s1,
+									Port:        8080,
+									ServicePort: &s1.Spec.Ports[0],
 								},
 							),
 						},
@@ -921,8 +924,9 @@ func TestDAGInsert(t *testing.T) {
 							object: i4,
 							services: servicemap(
 								&Service{
-									object: s1,
-									Port:   8080,
+									object:      s1,
+									Port:        8080,
+									ServicePort: &s1.Spec.Ports[0],
 								},
 							),
 						},
@@ -945,8 +949,9 @@ func TestDAGInsert(t *testing.T) {
 							object: i5,
 							services: servicemap(
 								&Service{
-									object: s1,
-									Port:   8080,
+									object:      s1,
+									Port:        8080,
+									ServicePort: &s1.Spec.Ports[0],
 								},
 							),
 						},
@@ -969,8 +974,9 @@ func TestDAGInsert(t *testing.T) {
 							object: i5,
 							services: servicemap(
 								&Service{
-									object: s1,
-									Port:   8080,
+									object:      s1,
+									Port:        8080,
+									ServicePort: &s1.Spec.Ports[0],
 								},
 							),
 						},
@@ -1107,8 +1113,9 @@ func TestDAGInsert(t *testing.T) {
 							object: i6,
 							services: servicemap(
 								&Service{
-									object: s1,
-									Port:   8080,
+									object:      s1,
+									Port:        8080,
+									ServicePort: &s1.Spec.Ports[0],
 								},
 							),
 						},
@@ -1123,8 +1130,9 @@ func TestDAGInsert(t *testing.T) {
 							object: i6,
 							services: servicemap(
 								&Service{
-									object: s1,
-									Port:   8080,
+									object:      s1,
+									Port:        8080,
+									ServicePort: &s1.Spec.Ports[0],
 								},
 							),
 						},
@@ -1147,8 +1155,9 @@ func TestDAGInsert(t *testing.T) {
 							object: i6,
 							services: servicemap(
 								&Service{
-									object: s1,
-									Port:   8080,
+									object:      s1,
+									Port:        8080,
+									ServicePort: &s1.Spec.Ports[0],
 								},
 							),
 						},
@@ -1163,8 +1172,9 @@ func TestDAGInsert(t *testing.T) {
 							object: i6,
 							services: servicemap(
 								&Service{
-									object: s1,
-									Port:   8080,
+									object:      s1,
+									Port:        8080,
+									ServicePort: &s1.Spec.Ports[0],
 								},
 							),
 						},
@@ -1188,8 +1198,9 @@ func TestDAGInsert(t *testing.T) {
 							object: i6,
 							services: servicemap(
 								&Service{
-									object: s1,
-									Port:   8080,
+									object:      s1,
+									Port:        8080,
+									ServicePort: &s1.Spec.Ports[0],
 								},
 							),
 						},
@@ -1204,8 +1215,9 @@ func TestDAGInsert(t *testing.T) {
 							object: i6,
 							services: servicemap(
 								&Service{
-									object: s1,
-									Port:   8080,
+									object:      s1,
+									Port:        8080,
+									ServicePort: &s1.Spec.Ports[0],
 								},
 							),
 						},
@@ -1220,8 +1232,9 @@ func TestDAGInsert(t *testing.T) {
 							object: i6,
 							services: servicemap(
 								&Service{
-									object: s1,
-									Port:   8080,
+									object:      s1,
+									Port:        8080,
+									ServicePort: &s1.Spec.Ports[0],
 								},
 							),
 						},
@@ -1248,8 +1261,9 @@ func TestDAGInsert(t *testing.T) {
 							object: i6,
 							services: servicemap(
 								&Service{
-									object: s1,
-									Port:   8080,
+									object:      s1,
+									Port:        8080,
+									ServicePort: &s1.Spec.Ports[0],
 								},
 							),
 						},
@@ -1263,8 +1277,9 @@ func TestDAGInsert(t *testing.T) {
 							object: i6,
 							services: servicemap(
 								&Service{
-									object: s1,
-									Port:   8080,
+									object:      s1,
+									Port:        8080,
+									ServicePort: &s1.Spec.Ports[0],
 								},
 							),
 						},
@@ -1279,8 +1294,9 @@ func TestDAGInsert(t *testing.T) {
 							object: i6,
 							services: servicemap(
 								&Service{
-									object: s1,
-									Port:   8080,
+									object:      s1,
+									Port:        8080,
+									ServicePort: &s1.Spec.Ports[0],
 								},
 							),
 						},
@@ -1327,8 +1343,9 @@ func TestDAGInsert(t *testing.T) {
 							object: i7,
 							services: servicemap(
 								&Service{
-									object: s1,
-									Port:   8080,
+									object:      s1,
+									Port:        8080,
+									ServicePort: &s1.Spec.Ports[0],
 								},
 							),
 						},
@@ -1337,8 +1354,9 @@ func TestDAGInsert(t *testing.T) {
 							object: i7,
 							services: servicemap(
 								&Service{
-									object: s2,
-									Port:   8080,
+									object:      s2,
+									Port:        8080,
+									ServicePort: &s1.Spec.Ports[0],
 								},
 							),
 						},
@@ -1360,8 +1378,9 @@ func TestDAGInsert(t *testing.T) {
 							object: i8,
 							services: servicemap(
 								&Service{
-									object: s1,
-									Port:   8080,
+									object:      s1,
+									Port:        8080,
+									ServicePort: &s1.Spec.Ports[0],
 								},
 							),
 						},
@@ -1370,8 +1389,9 @@ func TestDAGInsert(t *testing.T) {
 							object: i8,
 							services: servicemap(
 								&Service{
-									object: s2,
-									Port:   8080,
+									object:      s2,
+									Port:        8080,
+									ServicePort: &s2.Spec.Ports[0],
 								},
 							),
 						},
@@ -1402,8 +1422,9 @@ func TestDAGInsert(t *testing.T) {
 							object: i9,
 							services: servicemap(
 								&Service{
-									object: s1,
-									Port:   8080,
+									object:      s1,
+									Port:        8080,
+									ServicePort: &s1.Spec.Ports[0],
 								},
 							),
 						},
@@ -1412,8 +1433,9 @@ func TestDAGInsert(t *testing.T) {
 							object: i9,
 							services: servicemap(
 								&Service{
-									object: s2,
-									Port:   8080,
+									object:      s2,
+									Port:        8080,
+									ServicePort: &s2.Spec.Ports[0],
 								},
 							),
 						},
@@ -1457,8 +1479,9 @@ func TestDAGInsert(t *testing.T) {
 							object: i6a,
 							services: servicemap(
 								&Service{
-									object: s1,
-									Port:   8080,
+									object:      s1,
+									Port:        8080,
+									ServicePort: &s1.Spec.Ports[0],
 								},
 							),
 						},
@@ -1483,8 +1506,9 @@ func TestDAGInsert(t *testing.T) {
 							object: i6b,
 							services: servicemap(
 								&Service{
-									object: s1,
-									Port:   8080,
+									object:      s1,
+									Port:        8080,
+									ServicePort: &s1.Spec.Ports[0],
 								},
 							),
 							HTTPSUpgrade: true,
@@ -1501,8 +1525,9 @@ func TestDAGInsert(t *testing.T) {
 							object: i6b,
 							services: servicemap(
 								&Service{
-									object: s1,
-									Port:   8080,
+									object:      s1,
+									Port:        8080,
+									ServicePort: &s1.Spec.Ports[0],
 								},
 							),
 							HTTPSUpgrade: true,
@@ -1544,8 +1569,9 @@ func TestDAGInsert(t *testing.T) {
 							object: ir1,
 							services: servicemap(
 								&Service{
-									object: s1,
-									Port:   8080,
+									object:      s1,
+									Port:        8080,
+									ServicePort: &s1.Spec.Ports[0],
 								},
 							),
 						},
@@ -1566,8 +1592,9 @@ func TestDAGInsert(t *testing.T) {
 							object: ir2,
 							services: servicemap(
 								&Service{
-									object: s2,
-									Port:   8080,
+									object:      s2,
+									Port:        8080,
+									ServicePort: &s2.Spec.Ports[0],
 								},
 							),
 						},
@@ -1588,12 +1615,14 @@ func TestDAGInsert(t *testing.T) {
 							object: ir2,
 							services: servicemap(
 								&Service{
-									object: s1,
-									Port:   8080,
+									object:      s1,
+									Port:        8080,
+									ServicePort: &s1.Spec.Ports[0],
 								},
 								&Service{
-									object: s2,
-									Port:   8080,
+									object:      s2,
+									Port:        8080,
+									ServicePort: &s2.Spec.Ports[0],
 								},
 							),
 						},
@@ -1616,8 +1645,9 @@ func TestDAGInsert(t *testing.T) {
 							object: i10,
 							services: servicemap(
 								&Service{
-									object: s1,
-									Port:   8080,
+									object:      s1,
+									Port:        8080,
+									ServicePort: &s1.Spec.Ports[0],
 								},
 							),
 						},
@@ -1633,8 +1663,9 @@ func TestDAGInsert(t *testing.T) {
 							object: i10,
 							services: servicemap(
 								&Service{
-									object: s1,
-									Port:   8080,
+									object:      s1,
+									Port:        8080,
+									ServicePort: &s1.Spec.Ports[0],
 								},
 							),
 						},
@@ -1660,8 +1691,9 @@ func TestDAGInsert(t *testing.T) {
 							object: i11,
 							services: servicemap(
 								&Service{
-									object: s1,
-									Port:   8080,
+									object:      s1,
+									Port:        8080,
+									ServicePort: &s1.Spec.Ports[0],
 								},
 							),
 						},
@@ -1670,8 +1702,9 @@ func TestDAGInsert(t *testing.T) {
 							object: i11,
 							services: servicemap(
 								&Service{
-									object: s1,
-									Port:   8080,
+									object:      s1,
+									Port:        8080,
+									ServicePort: &s1.Spec.Ports[0],
 								},
 							),
 							Websocket: true,
@@ -1695,8 +1728,9 @@ func TestDAGInsert(t *testing.T) {
 							object: i12a,
 							services: servicemap(
 								&Service{
-									object: s1,
-									Port:   8080,
+									object:      s1,
+									Port:        8080,
+									ServicePort: &s1.Spec.Ports[0],
 								},
 							),
 							Timeout: -1, // invalid timeout equals infinity ¯\_(ツ)_/¯.
@@ -1720,8 +1754,9 @@ func TestDAGInsert(t *testing.T) {
 							object: i12b,
 							services: servicemap(
 								&Service{
-									object: s1,
-									Port:   8080,
+									object:      s1,
+									Port:        8080,
+									ServicePort: &s1.Spec.Ports[0],
 								},
 							),
 							Timeout: 90 * time.Second,
@@ -1745,8 +1780,9 @@ func TestDAGInsert(t *testing.T) {
 							object: i12c,
 							services: servicemap(
 								&Service{
-									object: s1,
-									Port:   8080,
+									object:      s1,
+									Port:        8080,
+									ServicePort: &s1.Spec.Ports[0],
 								},
 							),
 							Timeout: -1,
@@ -1769,8 +1805,9 @@ func TestDAGInsert(t *testing.T) {
 							object: ir4,
 							services: servicemap(
 								&Service{
-									object: s4,
-									Port:   8080,
+									object:      s4,
+									Port:        8080,
+									ServicePort: &s4.Spec.Ports[0],
 								},
 							),
 						},
@@ -1779,8 +1816,9 @@ func TestDAGInsert(t *testing.T) {
 							object: ir5,
 							services: servicemap(
 								&Service{
-									object: s5,
-									Port:   8080,
+									object:      s5,
+									Port:        8080,
+									ServicePort: &s5.Spec.Ports[0],
 								},
 							),
 						},
@@ -1802,8 +1840,9 @@ func TestDAGInsert(t *testing.T) {
 							object: i13a,
 							services: servicemap(
 								&Service{
-									object: s13a,
-									Port:   8080,
+									object:      s13a,
+									Port:        8080,
+									ServicePort: &s13a.Spec.Ports[0],
 								},
 							),
 							HTTPSUpgrade: true,
@@ -1813,8 +1852,9 @@ func TestDAGInsert(t *testing.T) {
 							object: i13b,
 							services: servicemap(
 								&Service{
-									object: s13b,
-									Port:   8009,
+									object:      s13b,
+									Port:        8009,
+									ServicePort: &s13b.Spec.Ports[0],
 								},
 							),
 						},
@@ -1830,8 +1870,9 @@ func TestDAGInsert(t *testing.T) {
 							object: i13a,
 							services: servicemap(
 								&Service{
-									object: s13a,
-									Port:   8080,
+									object:      s13a,
+									Port:        8080,
+									ServicePort: &s13a.Spec.Ports[0],
 								},
 							),
 							HTTPSUpgrade: true,
@@ -1841,8 +1882,9 @@ func TestDAGInsert(t *testing.T) {
 							object: i13b,
 							services: servicemap(
 								&Service{
-									object: s13b,
-									Port:   8009,
+									object:      s13b,
+									Port:        8009,
+									ServicePort: &s13b.Spec.Ports[0],
 								},
 							),
 						},
@@ -2358,8 +2400,9 @@ func TestDAGRemove(t *testing.T) {
 							object: i6,
 							services: servicemap(
 								&Service{
-									object: s1,
-									Port:   8080,
+									object:      s1,
+									Port:        8080,
+									ServicePort: &s1.Spec.Ports[0],
 								},
 							),
 						},
@@ -2373,8 +2416,9 @@ func TestDAGRemove(t *testing.T) {
 							object: i6,
 							services: servicemap(
 								&Service{
-									object: s1,
-									Port:   8080,
+									object:      s1,
+									Port:        8080,
+									ServicePort: &s1.Spec.Ports[0],
 								},
 							),
 						},
@@ -2445,8 +2489,9 @@ func TestDAGRemove(t *testing.T) {
 							object: i7,
 							services: servicemap(
 								&Service{
-									object: s1,
-									Port:   8080,
+									object:      s1,
+									Port:        8080,
+									ServicePort: &s1.Spec.Ports[0],
 								},
 							),
 						},
@@ -2583,8 +2628,9 @@ func TestDAGRemove(t *testing.T) {
 							object: ir5,
 							services: servicemap(
 								&Service{
-									object: s1,
-									Port:   8080,
+									object:      s1,
+									Port:        8080,
+									ServicePort: &s1.Spec.Ports[0],
 								},
 							),
 						},
@@ -2688,7 +2734,7 @@ func (r *Route) String() string {
 }
 
 func (s *Service) String() string {
-	return fmt.Sprintf("service: %s/%s {ports: %v}", s.object.Namespace, s.object.Name, s.object.Spec.Ports)
+	return fmt.Sprintf("service: %s/%s {serviceport: %v}", s.object.Namespace, s.object.Name, s.ServicePort)
 }
 
 func (s *Secret) String() string {
@@ -2747,32 +2793,36 @@ func TestServiceMapLookup(t *testing.T) {
 			meta: meta{name: "service1", namespace: "default"},
 			port: intstr.FromInt(8080),
 			want: &Service{
-				object: s1,
-				Port:   8080,
+				object:      s1,
+				Port:        8080,
+				ServicePort: &s1.Spec.Ports[0],
 			},
 		},
 		"lookup service by port name": {
 			meta: meta{name: "service1", namespace: "default"},
 			port: intstr.FromString("http"),
 			want: &Service{
-				object: s1,
-				Port:   8080,
+				object:      s1,
+				Port:        8080,
+				ServicePort: &s1.Spec.Ports[0],
 			},
 		},
 		"lookup service by port number (as string)": {
 			meta: meta{name: "service1", namespace: "default"},
 			port: intstr.Parse("8080"),
 			want: &Service{
-				object: s1,
-				Port:   8080,
+				object:      s1,
+				Port:        8080,
+				ServicePort: &s1.Spec.Ports[0],
 			},
 		},
 		"lookup service by port number (from string)": {
 			meta: meta{name: "service1", namespace: "default"},
 			port: intstr.FromString("8080"),
 			want: &Service{
-				object: s1,
-				Port:   8080,
+				object:      s1,
+				Port:        8080,
+				ServicePort: &s1.Spec.Ports[0],
 			},
 		},
 	}

--- a/internal/dag/dag_test.go
+++ b/internal/dag/dag_test.go
@@ -760,7 +760,6 @@ func TestDAGInsert(t *testing.T) {
 							services: servicemap(
 								&Service{
 									object:      s1,
-									Port:        8080,
 									ServicePort: &s1.Spec.Ports[0],
 								},
 							),
@@ -785,7 +784,6 @@ func TestDAGInsert(t *testing.T) {
 							services: servicemap(
 								&Service{
 									object:      s1,
-									Port:        8080,
 									ServicePort: &s1.Spec.Ports[0],
 								},
 							),
@@ -900,7 +898,6 @@ func TestDAGInsert(t *testing.T) {
 							services: servicemap(
 								&Service{
 									object:      s1,
-									Port:        8080,
 									ServicePort: &s1.Spec.Ports[0],
 								},
 							),
@@ -925,7 +922,6 @@ func TestDAGInsert(t *testing.T) {
 							services: servicemap(
 								&Service{
 									object:      s1,
-									Port:        8080,
 									ServicePort: &s1.Spec.Ports[0],
 								},
 							),
@@ -950,7 +946,6 @@ func TestDAGInsert(t *testing.T) {
 							services: servicemap(
 								&Service{
 									object:      s1,
-									Port:        8080,
 									ServicePort: &s1.Spec.Ports[0],
 								},
 							),
@@ -975,7 +970,6 @@ func TestDAGInsert(t *testing.T) {
 							services: servicemap(
 								&Service{
 									object:      s1,
-									Port:        8080,
 									ServicePort: &s1.Spec.Ports[0],
 								},
 							),
@@ -1114,7 +1108,6 @@ func TestDAGInsert(t *testing.T) {
 							services: servicemap(
 								&Service{
 									object:      s1,
-									Port:        8080,
 									ServicePort: &s1.Spec.Ports[0],
 								},
 							),
@@ -1131,7 +1124,6 @@ func TestDAGInsert(t *testing.T) {
 							services: servicemap(
 								&Service{
 									object:      s1,
-									Port:        8080,
 									ServicePort: &s1.Spec.Ports[0],
 								},
 							),
@@ -1156,7 +1148,6 @@ func TestDAGInsert(t *testing.T) {
 							services: servicemap(
 								&Service{
 									object:      s1,
-									Port:        8080,
 									ServicePort: &s1.Spec.Ports[0],
 								},
 							),
@@ -1173,7 +1164,6 @@ func TestDAGInsert(t *testing.T) {
 							services: servicemap(
 								&Service{
 									object:      s1,
-									Port:        8080,
 									ServicePort: &s1.Spec.Ports[0],
 								},
 							),
@@ -1199,7 +1189,6 @@ func TestDAGInsert(t *testing.T) {
 							services: servicemap(
 								&Service{
 									object:      s1,
-									Port:        8080,
 									ServicePort: &s1.Spec.Ports[0],
 								},
 							),
@@ -1216,7 +1205,6 @@ func TestDAGInsert(t *testing.T) {
 							services: servicemap(
 								&Service{
 									object:      s1,
-									Port:        8080,
 									ServicePort: &s1.Spec.Ports[0],
 								},
 							),
@@ -1233,7 +1221,6 @@ func TestDAGInsert(t *testing.T) {
 							services: servicemap(
 								&Service{
 									object:      s1,
-									Port:        8080,
 									ServicePort: &s1.Spec.Ports[0],
 								},
 							),
@@ -1262,7 +1249,6 @@ func TestDAGInsert(t *testing.T) {
 							services: servicemap(
 								&Service{
 									object:      s1,
-									Port:        8080,
 									ServicePort: &s1.Spec.Ports[0],
 								},
 							),
@@ -1278,7 +1264,6 @@ func TestDAGInsert(t *testing.T) {
 							services: servicemap(
 								&Service{
 									object:      s1,
-									Port:        8080,
 									ServicePort: &s1.Spec.Ports[0],
 								},
 							),
@@ -1295,7 +1280,6 @@ func TestDAGInsert(t *testing.T) {
 							services: servicemap(
 								&Service{
 									object:      s1,
-									Port:        8080,
 									ServicePort: &s1.Spec.Ports[0],
 								},
 							),
@@ -1344,7 +1328,6 @@ func TestDAGInsert(t *testing.T) {
 							services: servicemap(
 								&Service{
 									object:      s1,
-									Port:        8080,
 									ServicePort: &s1.Spec.Ports[0],
 								},
 							),
@@ -1355,7 +1338,6 @@ func TestDAGInsert(t *testing.T) {
 							services: servicemap(
 								&Service{
 									object:      s2,
-									Port:        8080,
 									ServicePort: &s1.Spec.Ports[0],
 								},
 							),
@@ -1379,7 +1361,6 @@ func TestDAGInsert(t *testing.T) {
 							services: servicemap(
 								&Service{
 									object:      s1,
-									Port:        8080,
 									ServicePort: &s1.Spec.Ports[0],
 								},
 							),
@@ -1390,7 +1371,6 @@ func TestDAGInsert(t *testing.T) {
 							services: servicemap(
 								&Service{
 									object:      s2,
-									Port:        8080,
 									ServicePort: &s2.Spec.Ports[0],
 								},
 							),
@@ -1423,7 +1403,6 @@ func TestDAGInsert(t *testing.T) {
 							services: servicemap(
 								&Service{
 									object:      s1,
-									Port:        8080,
 									ServicePort: &s1.Spec.Ports[0],
 								},
 							),
@@ -1434,7 +1413,6 @@ func TestDAGInsert(t *testing.T) {
 							services: servicemap(
 								&Service{
 									object:      s2,
-									Port:        8080,
 									ServicePort: &s2.Spec.Ports[0],
 								},
 							),
@@ -1480,7 +1458,6 @@ func TestDAGInsert(t *testing.T) {
 							services: servicemap(
 								&Service{
 									object:      s1,
-									Port:        8080,
 									ServicePort: &s1.Spec.Ports[0],
 								},
 							),
@@ -1507,7 +1484,6 @@ func TestDAGInsert(t *testing.T) {
 							services: servicemap(
 								&Service{
 									object:      s1,
-									Port:        8080,
 									ServicePort: &s1.Spec.Ports[0],
 								},
 							),
@@ -1526,7 +1502,6 @@ func TestDAGInsert(t *testing.T) {
 							services: servicemap(
 								&Service{
 									object:      s1,
-									Port:        8080,
 									ServicePort: &s1.Spec.Ports[0],
 								},
 							),
@@ -1570,7 +1545,6 @@ func TestDAGInsert(t *testing.T) {
 							services: servicemap(
 								&Service{
 									object:      s1,
-									Port:        8080,
 									ServicePort: &s1.Spec.Ports[0],
 								},
 							),
@@ -1593,7 +1567,6 @@ func TestDAGInsert(t *testing.T) {
 							services: servicemap(
 								&Service{
 									object:      s2,
-									Port:        8080,
 									ServicePort: &s2.Spec.Ports[0],
 								},
 							),
@@ -1616,12 +1589,10 @@ func TestDAGInsert(t *testing.T) {
 							services: servicemap(
 								&Service{
 									object:      s1,
-									Port:        8080,
 									ServicePort: &s1.Spec.Ports[0],
 								},
 								&Service{
 									object:      s2,
-									Port:        8080,
 									ServicePort: &s2.Spec.Ports[0],
 								},
 							),
@@ -1646,7 +1617,6 @@ func TestDAGInsert(t *testing.T) {
 							services: servicemap(
 								&Service{
 									object:      s1,
-									Port:        8080,
 									ServicePort: &s1.Spec.Ports[0],
 								},
 							),
@@ -1664,7 +1634,6 @@ func TestDAGInsert(t *testing.T) {
 							services: servicemap(
 								&Service{
 									object:      s1,
-									Port:        8080,
 									ServicePort: &s1.Spec.Ports[0],
 								},
 							),
@@ -1692,7 +1661,6 @@ func TestDAGInsert(t *testing.T) {
 							services: servicemap(
 								&Service{
 									object:      s1,
-									Port:        8080,
 									ServicePort: &s1.Spec.Ports[0],
 								},
 							),
@@ -1703,7 +1671,6 @@ func TestDAGInsert(t *testing.T) {
 							services: servicemap(
 								&Service{
 									object:      s1,
-									Port:        8080,
 									ServicePort: &s1.Spec.Ports[0],
 								},
 							),
@@ -1729,7 +1696,6 @@ func TestDAGInsert(t *testing.T) {
 							services: servicemap(
 								&Service{
 									object:      s1,
-									Port:        8080,
 									ServicePort: &s1.Spec.Ports[0],
 								},
 							),
@@ -1755,7 +1721,6 @@ func TestDAGInsert(t *testing.T) {
 							services: servicemap(
 								&Service{
 									object:      s1,
-									Port:        8080,
 									ServicePort: &s1.Spec.Ports[0],
 								},
 							),
@@ -1781,7 +1746,6 @@ func TestDAGInsert(t *testing.T) {
 							services: servicemap(
 								&Service{
 									object:      s1,
-									Port:        8080,
 									ServicePort: &s1.Spec.Ports[0],
 								},
 							),
@@ -1806,7 +1770,6 @@ func TestDAGInsert(t *testing.T) {
 							services: servicemap(
 								&Service{
 									object:      s4,
-									Port:        8080,
 									ServicePort: &s4.Spec.Ports[0],
 								},
 							),
@@ -1817,7 +1780,6 @@ func TestDAGInsert(t *testing.T) {
 							services: servicemap(
 								&Service{
 									object:      s5,
-									Port:        8080,
 									ServicePort: &s5.Spec.Ports[0],
 								},
 							),
@@ -1841,7 +1803,6 @@ func TestDAGInsert(t *testing.T) {
 							services: servicemap(
 								&Service{
 									object:      s13a,
-									Port:        8080,
 									ServicePort: &s13a.Spec.Ports[0],
 								},
 							),
@@ -1853,7 +1814,6 @@ func TestDAGInsert(t *testing.T) {
 							services: servicemap(
 								&Service{
 									object:      s13b,
-									Port:        8009,
 									ServicePort: &s13b.Spec.Ports[0],
 								},
 							),
@@ -1871,7 +1831,6 @@ func TestDAGInsert(t *testing.T) {
 							services: servicemap(
 								&Service{
 									object:      s13a,
-									Port:        8080,
 									ServicePort: &s13a.Spec.Ports[0],
 								},
 							),
@@ -1883,7 +1842,6 @@ func TestDAGInsert(t *testing.T) {
 							services: servicemap(
 								&Service{
 									object:      s13b,
-									Port:        8009,
 									ServicePort: &s13b.Spec.Ports[0],
 								},
 							),
@@ -2401,7 +2359,6 @@ func TestDAGRemove(t *testing.T) {
 							services: servicemap(
 								&Service{
 									object:      s1,
-									Port:        8080,
 									ServicePort: &s1.Spec.Ports[0],
 								},
 							),
@@ -2417,7 +2374,6 @@ func TestDAGRemove(t *testing.T) {
 							services: servicemap(
 								&Service{
 									object:      s1,
-									Port:        8080,
 									ServicePort: &s1.Spec.Ports[0],
 								},
 							),
@@ -2490,7 +2446,6 @@ func TestDAGRemove(t *testing.T) {
 							services: servicemap(
 								&Service{
 									object:      s1,
-									Port:        8080,
 									ServicePort: &s1.Spec.Ports[0],
 								},
 							),
@@ -2629,7 +2584,6 @@ func TestDAGRemove(t *testing.T) {
 							services: servicemap(
 								&Service{
 									object:      s1,
-									Port:        8080,
 									ServicePort: &s1.Spec.Ports[0],
 								},
 							),
@@ -2794,7 +2748,6 @@ func TestServiceMapLookup(t *testing.T) {
 			port: intstr.FromInt(8080),
 			want: &Service{
 				object:      s1,
-				Port:        8080,
 				ServicePort: &s1.Spec.Ports[0],
 			},
 		},
@@ -2803,7 +2756,6 @@ func TestServiceMapLookup(t *testing.T) {
 			port: intstr.FromString("http"),
 			want: &Service{
 				object:      s1,
-				Port:        8080,
 				ServicePort: &s1.Spec.Ports[0],
 			},
 		},
@@ -2812,7 +2764,6 @@ func TestServiceMapLookup(t *testing.T) {
 			port: intstr.Parse("8080"),
 			want: &Service{
 				object:      s1,
-				Port:        8080,
 				ServicePort: &s1.Spec.Ports[0],
 			},
 		},
@@ -2821,7 +2772,6 @@ func TestServiceMapLookup(t *testing.T) {
 			port: intstr.FromString("8080"),
 			want: &Service{
 				object:      s1,
-				Port:        8080,
 				ServicePort: &s1.Spec.Ports[0],
 			},
 		},

--- a/internal/route/visitor.go
+++ b/internal/route/visitor.go
@@ -73,7 +73,7 @@ func (v *Visitor) Visit() map[string]*v2.RouteConfiguration {
 						Action: actionroute(
 							svcs[0].Namespace(),
 							svcs[0].Name(),
-							svcs[0].Port, // TODO(dfc) support more than one weighted service
+							int(svcs[0].Port), // TODO(dfc) support more than one weighted service
 							r.Websocket,
 							r.Timeout),
 					}
@@ -121,7 +121,7 @@ func (v *Visitor) Visit() map[string]*v2.RouteConfiguration {
 						Action: actionroute(
 							svcs[0].Namespace(),
 							svcs[0].Name(),
-							svcs[0].Port,
+							int(svcs[0].Port),
 							r.Websocket,
 							r.Timeout),
 					})


### PR DESCRIPTION
During dag recompute keep a reference to the serviceport object, not
just the port number, we need this for CDS to compute the correct
service name to match eds.

Signed-off-by: Dave Cheney <dave@cheney.net>