### PR TITLE
internal/dag: validate ingressroutes and produce a list that contains a status entry for each

### DIFF
--- a/internal/dag/dag.go
+++ b/internal/dag/dag.go
@@ -409,6 +409,10 @@ func (d *DAG) processIngressRoute(ir *ingressroutev1.IngressRoute, prefixMatch s
 	}()
 
 	for _, route := range ir.Spec.Routes {
+		// route cannot both delegate and point to services
+		if len(route.Services) > 0 && route.Delegate.Name != "" {
+			return []validationError{{object: ir, msg: fmt.Sprintf("route %q: cannot specify services and delegate in the same route", route.Match)}}
+		}
 		// base case: The route points to services, so we add them to the vhost
 		if len(route.Services) > 0 {
 			if !matchesPathPrefix(route.Match, prefixMatch) {

--- a/internal/dag/dag.go
+++ b/internal/dag/dag.go
@@ -379,6 +379,10 @@ func (d *DAG) recompute() (dag, []ingressrouteStatus) {
 		}
 
 		host := ir.Spec.VirtualHost.Fqdn
+		if len(strings.TrimSpace(host)) == 0 {
+			status = append(status, ingressrouteStatus{object: ir, status: "invalid", msg: "Spec.VirtualHost.Fqdn must be specified"})
+			continue
+		}
 
 		if tls := ir.Spec.VirtualHost.TLS; tls != nil {
 			// attach secrets to TLS enabled vhosts

--- a/internal/dag/dag.go
+++ b/internal/dag/dag.go
@@ -416,9 +416,6 @@ func (d *DAG) recompute() (dag, []ingressrouteStatus) {
 
 func (d *DAG) processIngressRoute(ir *ingressroutev1.IngressRoute, prefixMatch string, visited []*ingressroutev1.IngressRoute, host string, service func(m meta, port intstr.IntOrString) *Service, vhost func(host string, port int) *VirtualHost, orphaned map[meta]bool) []ingressrouteStatus {
 	visited = append(visited, ir)
-	defer func() {
-		visited = visited[:len(visited)-1]
-	}()
 
 	var status []ingressrouteStatus
 	for _, route := range ir.Spec.Routes {

--- a/internal/dag/dag.go
+++ b/internal/dag/dag.go
@@ -429,7 +429,7 @@ func (d *DAG) processIngressRoute(ir *ingressroutev1.IngressRoute, prefixMatch s
 		// base case: The route points to services, so we add them to the vhost
 		if len(route.Services) > 0 {
 			if !matchesPathPrefix(route.Match, prefixMatch) {
-				return []ingressrouteStatus{{object: ir, status: "invalid", msg: "the path prefix does not match the parent's path prefix"}}
+				return []ingressrouteStatus{{object: ir, status: "invalid", msg: fmt.Sprintf("the path prefix %q does not match the parent's path prefix %q", route.Match, prefixMatch)}}
 			}
 			r := &Route{
 				path:   route.Match,

--- a/internal/dag/dag.go
+++ b/internal/dag/dag.go
@@ -439,7 +439,7 @@ func (d *DAG) processIngressRoute(ir *ingressroutev1.IngressRoute, prefixMatch s
 				if s.Port < 1 || s.Port > 65535 {
 					return []ingressrouteStatus{{object: ir, status: "invalid", msg: fmt.Sprintf("route %q: service %q: port must be in the range 1-65535", route.Match, s.Name)}}
 				}
-				if s.Weight != nil && *s.Weight < 0 {
+				if s.Weight < 0 {
 					return []ingressrouteStatus{{object: ir, status: "invalid", msg: fmt.Sprintf("route %q: service %q: weight must be greater than or equal to zero", route.Match, s.Name)}}
 				}
 				m := meta{name: s.Name, namespace: ir.Namespace}

--- a/internal/dag/dag.go
+++ b/internal/dag/dag.go
@@ -145,12 +145,9 @@ func (d *DAG) Recompute() {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 	version := d.dag.version
-	var status []ingressrouteStatus
-	d.dag, status = d.recompute()
+	// TODO(abrand): Handle status returned by recompute
+	d.dag, _ = d.recompute()
 	d.dag.version = version + 1
-	for _, s := range status {
-		fmt.Printf("%v\n", s)
-	}
 }
 
 // serviceMap memoise access to a service map, built
@@ -393,9 +390,8 @@ func (d *DAG) recompute() (dag, []ingressrouteStatus) {
 			}
 		}
 
-		var visited []*ingressroutev1.IngressRoute
 		prefixMatch := ""
-		ve := d.processIngressRoute(ir, prefixMatch, visited, host, service, vhost, orphaned)
+		ve := d.processIngressRoute(ir, prefixMatch, nil, host, service, vhost, orphaned)
 		status = append(status, ve...)
 	}
 

--- a/internal/dag/dag.go
+++ b/internal/dag/dag.go
@@ -444,7 +444,7 @@ func (d *DAG) processIngressRoute(ir *ingressroutev1.IngressRoute, prefixMatch s
 					return []ingressrouteStatus{{object: ir, status: "invalid", msg: fmt.Sprintf("route %q: service %q: port must be in the range 1-65535", route.Match, s.Name)}}
 				}
 				if s.Weight != nil && *s.Weight < 0 {
-					return []ingressrouteStatus{{object: ir, status: "invalid", msg: fmt.Sprintf("route %q: service %q: weight must be greater than zero", route.Match, s.Name)}}
+					return []ingressrouteStatus{{object: ir, status: "invalid", msg: fmt.Sprintf("route %q: service %q: weight must be greater than or equal to zero", route.Match, s.Name)}}
 				}
 				m := meta{name: s.Name, namespace: ir.Namespace}
 				if svc := service(m, intstr.FromInt(s.Port)); svc != nil {

--- a/internal/dag/dag_test.go
+++ b/internal/dag/dag_test.go
@@ -3681,7 +3681,7 @@ func TestDAGIngressRouteStatus(t *testing.T) {
 		},
 		"invalid weight in service": {
 			objs: []*ingressroutev1.IngressRoute{ir5},
-			want: []ingressrouteStatus{{object: ir5, status: "invalid", msg: `route "/foo": service "home": weight must be greater than zero`}},
+			want: []ingressrouteStatus{{object: ir5, status: "invalid", msg: `route "/foo": service "home": weight must be greater than or equal to zero`}},
 		},
 		"root ingressroute does not specify FQDN": {
 			objs: []*ingressroutev1.IngressRoute{ir13},

--- a/internal/dag/dag_test.go
+++ b/internal/dag/dag_test.go
@@ -3467,7 +3467,6 @@ func TestDAGIngressRouteStatus(t *testing.T) {
 	}
 
 	// ir5 is invalid because its service weight is less than zero
-	w := -10
 	ir5 := &ingressroutev1.IngressRoute{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "roots",
@@ -3482,7 +3481,7 @@ func TestDAGIngressRouteStatus(t *testing.T) {
 				Services: []ingressroutev1.Service{{
 					Name:   "home",
 					Port:   8080,
-					Weight: &w,
+					Weight: -10,
 				}},
 			}},
 		},

--- a/internal/dag/dag_test.go
+++ b/internal/dag/dag_test.go
@@ -3674,7 +3674,7 @@ func TestDAGIngressRouteStatus(t *testing.T) {
 		"delegated route's match prefix does not match parent's prefix": {
 			objs: []*ingressroutev1.IngressRoute{ir1, ir4},
 			want: []ingressrouteStatus{
-				{object: ir4, status: "invalid", msg: "the path prefix does not match the parent's path prefix"},
+				{object: ir4, status: "invalid", msg: `the path prefix "/doesnotmatch" does not match the parent's path prefix "/prefix"`},
 				{object: ir1, status: "valid", msg: "valid IngressRoute"},
 			},
 		},

--- a/internal/dag/dag_test.go
+++ b/internal/dag/dag_test.go
@@ -3621,6 +3621,24 @@ func TestDAGIngressRouteStatus(t *testing.T) {
 		},
 	}
 
+	// ir13 is invalid because it does not specify and FQDN
+	ir13 := &ingressroutev1.IngressRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "roots",
+			Name:      "parent",
+		},
+		Spec: ingressroutev1.IngressRouteSpec{
+			VirtualHost: &ingressroutev1.VirtualHost{},
+			Routes: []ingressroutev1.Route{{
+				Match: "/foo",
+				Services: []ingressroutev1.Service{{
+					Name: "foo",
+					Port: 8080,
+				}},
+			}},
+		},
+	}
+
 	tests := map[string]struct {
 		objs []*ingressroutev1.IngressRoute
 		want []ingressrouteStatus
@@ -3647,6 +3665,10 @@ func TestDAGIngressRouteStatus(t *testing.T) {
 		"invalid weight in service": {
 			objs: []*ingressroutev1.IngressRoute{ir5},
 			want: []ingressrouteStatus{{object: ir5, status: "invalid", msg: `route "/foo": service "home": weight must be greater than zero`}},
+		},
+		"root ingressroute does not specify FQDN": {
+			objs: []*ingressroutev1.IngressRoute{ir13},
+			want: []ingressrouteStatus{{object: ir13, status: "invalid", msg: "Spec.VirtualHost.Fqdn must be specified"}},
 		},
 		"self-edge produces a cycle": {
 			objs: []*ingressroutev1.IngressRoute{ir6},

--- a/internal/dag/dag_test.go
+++ b/internal/dag/dag_test.go
@@ -3596,6 +3596,10 @@ func TestDAGIngressRouteValidation(t *testing.T) {
 			objs: []*ingressroutev1.IngressRoute{ir9},
 			want: []validationError{{object: ir9, msg: `route "/foo": cannot specify services and delegate in the same route`}},
 		},
+		"ingressroute is an orphaned route": {
+			objs: []*ingressroutev1.IngressRoute{ir8},
+			want: []validationError{{object: ir8, msg: "this IngressRoute is not part of a delegation chain from a root IngressRoute"}},
+		},
 	}
 
 	for name, tc := range tests {


### PR DESCRIPTION
Fixes #490 

The first step towards updating the status of IngressRoute (IR) resources is adding the validation that will determine the status.

Validation is performed while we are recomputing the DAG. There might be some validation that can be done before, but I think this will do for now. The `recompute` method of the DAG now also returns a list of statuses, each containing the IR in question, its status and a human readable message that explains the status.

Currently, the statuses are printed out to STDOUT instead of written up to the API server. This will be handled in a follow-up PR. 

This PR adds the following status checks for IRs:
- Negative weight provided in the route definition
- Invalid port number provided for service
- Prefix in parent does not match route in delegated route
- Root IR created in a namespace other than the root namespaces
- A given Route of an IR both delegates to another IR and has a list of services
- Orphaned route
- Delegation chain produces a cycle
- Root IR must specify fqdn

Specific check notes:

**Orphan detection**
When recomputing the DAG, initialize an empty map that keeps track of the non-root IngressRoutes that we have seen and mark them as orphaned. Whenever we follow an edge to a non-root IngressRoute, we mark that IngressRoute as not orphaned. Once we have finished processing all the IngressRoutes, we can determine which IngressRoutes are orphaned by iterating over the map.

**Cycle detection**
Before this PR, we were using a map to keep track of the IngressRoutes we had already visited. This worked, but prevented us from knowing the path we took to reach the IngressRoute that we are processing. Instead of using a map, switch to using a stack so that we can use to build the delegation path we have taken, and thus return it in the validation error message in the case of a cycle.

Additionally, the cycle check needs to be performed before we follow an edge that produces a cycle, so that we can mark the source IngressRoute as invalid, instead of the target.