### PR TITLE
internal/{dag,contour}: reimplement kubernetes/ingress.class support

### DIFF
--- a/internal/contour/cluster_test.go
+++ b/internal/contour/cluster_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 	"github.com/gogo/protobuf/types"
 	ingressroutev1 "github.com/heptio/contour/apis/contour/v1beta1"
-	"github.com/heptio/contour/internal/dag"
 	"k8s.io/api/core/v1"
 	"k8s.io/api/extensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -323,7 +322,7 @@ func TestClusterVisit(t *testing.T) {
 									IntervalSeconds:         98,
 									UnhealthyThresholdCount: 97,
 									HealthyThresholdCount:   96,
-									Host:                    "foo-bar-host",
+									Host: "foo-bar-host",
 								},
 							}},
 						}},
@@ -666,14 +665,13 @@ func TestClusterVisit(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			var d dag.DAG
+			var d DAGAdapter
 			for _, o := range tc.objs {
-				d.Insert(o)
+				d.OnAdd(o)
 			}
-			d.Recompute()
 			v := clusterVisitor{
 				ClusterCache: new(ClusterCache),
-				DAG:          &d,
+				DAG:          &d.DAG,
 			}
 			got := v.Visit()
 			if !reflect.DeepEqual(tc.want, got) {

--- a/internal/contour/listener_test.go
+++ b/internal/contour/listener_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2/listener"
 	"github.com/gogo/protobuf/types"
 	ingressroutev1 "github.com/heptio/contour/apis/contour/v1beta1"
-	"github.com/heptio/contour/internal/dag"
 	"k8s.io/api/core/v1"
 	"k8s.io/api/extensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -417,9 +416,9 @@ func TestListenerVisit(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			var d dag.DAG
+			var d DAGAdapter
 			for _, o := range tc.objs {
-				d.Insert(o)
+				d.OnAdd(o)
 			}
 			d.Recompute()
 			lc := tc.ListenerCache
@@ -428,7 +427,7 @@ func TestListenerVisit(t *testing.T) {
 			}
 			v := listenerVisitor{
 				ListenerCache: lc,
-				DAG:           &d,
+				DAG:           &d.DAG,
 			}
 			got := v.Visit()
 			if !reflect.DeepEqual(tc.want, got) {

--- a/internal/dag/dag.go
+++ b/internal/dag/dag.go
@@ -96,7 +96,6 @@ func (d *DAG) Insert(obj interface{}) {
 			d.ingresses = make(map[meta]*v1beta1.Ingress)
 		}
 		d.ingresses[m] = obj
-
 	case *ingressroutev1.IngressRoute:
 		m := meta{name: obj.Name, namespace: obj.Namespace}
 		if d.ingressroutes == nil {


### PR DESCRIPTION
Fixes #483

Reimplement ingress.class support in contour's DAGAdapter. There is some
trickiness in ensuring that if an ingress is edited from valid (matching
the ingress.class rules) to invalid then the previous version needs to
be purged from the DAG cache. The internal/e2e tests now capture this.

Signed-off-by: Dave Cheney <dave@cheney.net>