### PR TITLE
Pin the alpine image to a version rather than :latest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,6 @@ COPY internal internal
 COPY apis apis
 RUN CGO_ENABLED=0 GOOS=linux go install -ldflags="-w -s" -v github.com/heptio/contour/cmd/contour
 
-FROM alpine:latest
+FROM alpine:3.7
 RUN apk --no-cache add ca-certificates
 COPY --from=0 /go/bin/contour /bin/contour


### PR DESCRIPTION
Right now the Dockerfile used to build the Contour image is looking for `alpine:latest`. This PR pins it to the last release to avoid issues with unknown latest tags. 

Reason is right now the :latest tag is broken in docker hub and no builds will happen. 

Signed-off-by: Steve Sloka <steves@heptio.com>