### PR TITLE
Dockerfile: garden Dockerfile

### DIFF
--- a/Dockerfile.race
+++ b/Dockerfile.race
@@ -8,8 +8,7 @@ RUN dep ensure -v -vendor-only
 COPY cmd cmd
 COPY internal internal
 COPY apis apis
-RUN CGO_ENABLED=0 GOOS=linux go build -o /go/bin/contour -ldflags="-w -s" -v github.com/heptio/contour/cmd/contour
+RUN GOOS=linux go build -race -o /go/bin/contour -ldflags="-w -s" -v github.com/heptio/contour/cmd/contour
 
-FROM alpine:3.7 AS final
-RUN apk --no-cache add ca-certificates
+FROM golang:1.10.3 AS final
 COPY --from=build /go/bin/contour /bin/contour

--- a/Makefile
+++ b/Makefile
@@ -9,10 +9,13 @@ VERSION ?= $(GIT_REF)
 test: install
 	go test ./...
 
+test-race: | test
+	go test -race ./...
+
 vet: | test
 	go vet ./...
 
-check: test vet staticcheck unused
+check: test test-race vet staticcheck unused
 	@echo Checking code is gofmted
 	@bash -c 'if [ -n "$(gofmt -s -l .)" ]; then echo "Go code is not formatted:"; gofmt -s -d -e .; exit 1;fi'
 	@echo Checking rendered files are up to date


### PR DESCRIPTION
- Upgrade to Go 1.10.3
- Use named targets
- Add race build

Signed-off-by: Dave Cheney <dave@cheney.net>