### PR TITLE
Fix mismatch in load balancing strategy validation

### DIFF
--- a/deployment/common/common.yaml
+++ b/deployment/common/common.yaml
@@ -50,6 +50,8 @@ spec:
                 - RoundRobin
                 - WeightedLeastRequest
                 - Random
+                - RingHash
+                - Maglev
             healthCheck:
               type: object
               required:

--- a/deployment/render/daemonset-norbac.yaml
+++ b/deployment/render/daemonset-norbac.yaml
@@ -53,6 +53,8 @@ spec:
                 - RoundRobin
                 - WeightedLeastRequest
                 - Random
+                - RingHash
+                - Maglev
             healthCheck:
               type: object
               required:

--- a/deployment/render/daemonset-rbac.yaml
+++ b/deployment/render/daemonset-rbac.yaml
@@ -53,6 +53,8 @@ spec:
                 - RoundRobin
                 - WeightedLeastRequest
                 - Random
+                - RingHash
+                - Maglev
             healthCheck:
               type: object
               required:

--- a/deployment/render/deployment-norbac.yaml
+++ b/deployment/render/deployment-norbac.yaml
@@ -53,6 +53,8 @@ spec:
                 - RoundRobin
                 - WeightedLeastRequest
                 - Random
+                - RingHash
+                - Maglev
             healthCheck:
               type: object
               required:

--- a/deployment/render/deployment-rbac.yaml
+++ b/deployment/render/deployment-rbac.yaml
@@ -53,6 +53,8 @@ spec:
                 - RoundRobin
                 - WeightedLeastRequest
                 - Random
+                - RingHash
+                - Maglev
             healthCheck:
               type: object
               required:

--- a/docs/ingressroute.md
+++ b/docs/ingressroute.md
@@ -357,11 +357,11 @@ IngressRoute weighting follows some specific rules:
 Each upstream service can have a load balancing strategy applied to determine which of its Endpoints is selected for the request.
 The following list are the options available to choose from:
 
-- RoundRobin: Each healthy upstream Endpoint is selected in round robin order (Default strategy if none selected).
-- WeightedLeastRequest: The least request strategy uses an O(1) algorithm which selects two random healthy Endpoints and picks the Endpoint which has fewer active requests. Note: This algorithm is simple and sufficient for load testing. It should not be used where true weighted least request behavior is desired.
-- Ring hash: The ring/modulo hash load balancer implements consistent hashing to upstream Endpoints.
-- Maglev: The Maglev strategy implements consistent hashing to upstream Endpoints
-- Random: The random strategy selects a random healthy Endpoints.
+- `RoundRobin`: Each healthy upstream Endpoint is selected in round robin order (Default strategy if none selected).
+- `WeightedLeastRequest`: The least request strategy uses an O(1) algorithm which selects two random healthy Endpoints and picks the Endpoint which has fewer active requests. Note: This algorithm is simple and sufficient for load testing. It should not be used where true weighted least request behavior is desired.
+- `RingHash`: The ring/modulo hash load balancer implements consistent hashing to upstream Endpoints.
+- `Maglev`: The Maglev strategy implements consistent hashing to upstream Endpoints
+- `Random`: The random strategy selects a random healthy Endpoints.
 
 More information on the load balancing strategy can be found in [Envoy's documentation](https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/load_balancing.html).
 


### PR DESCRIPTION
Fixed the CRD deployment file to have the full list of load balancing strategies available. Also improved the documentation to make it more clear which load balancing strategies can be used in the IngressRoute.

Fixes #530 

