### PR TITLE
Write Status to Kubernetes IngressRoute object after DAG update 

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -47,6 +47,12 @@
   version = "v0.2"
 
 [[projects]]
+  name = "github.com/evanphx/json-patch"
+  packages = ["."]
+  revision = "afac545df32f2287a079e2dfb7ba2745a643747e"
+  version = "v3.0.0"
+
+[[projects]]
   name = "github.com/ghodss/yaml"
   packages = ["."]
   revision = "0ca9ea5df5451ffdf184b4428c902747c2c11cd7"
@@ -514,6 +520,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "b8ed62d2fbe8083f5d7e479ff9db0cc507d3cc2e9fbe621099930cd22b9a1d25"
+  inputs-digest = "45c6d5ef016faa48bdccad27072bb79786ac46a1757380b31f38a6b53d588c79"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/internal/contour/cluster_test.go
+++ b/internal/contour/cluster_test.go
@@ -23,6 +23,8 @@ import (
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 	"github.com/gogo/protobuf/types"
 	ingressroutev1 "github.com/heptio/contour/apis/contour/v1beta1"
+	"github.com/heptio/contour/internal/generated/clientset/versioned/fake"
+	"github.com/heptio/contour/internal/k8s"
 	"k8s.io/api/core/v1"
 	"k8s.io/api/extensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -322,7 +324,7 @@ func TestClusterVisit(t *testing.T) {
 									IntervalSeconds:         98,
 									UnhealthyThresholdCount: 97,
 									HealthyThresholdCount:   96,
-									Host:                    "foo-bar-host",
+									Host: "foo-bar-host",
 								},
 							}},
 						}},
@@ -666,6 +668,9 @@ func TestClusterVisit(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			var d DAGAdapter
+			d.IngressRouteStatus = &k8s.IngressRouteStatus{
+				Client: fake.NewSimpleClientset(),
+			}
 			for _, o := range tc.objs {
 				d.OnAdd(o)
 			}

--- a/internal/contour/listener_test.go
+++ b/internal/contour/listener_test.go
@@ -22,6 +22,8 @@ import (
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2/listener"
 	"github.com/gogo/protobuf/types"
 	ingressroutev1 "github.com/heptio/contour/apis/contour/v1beta1"
+	"github.com/heptio/contour/internal/generated/clientset/versioned/fake"
+	"github.com/heptio/contour/internal/k8s"
 	"k8s.io/api/core/v1"
 	"k8s.io/api/extensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -417,6 +419,9 @@ func TestListenerVisit(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			var d DAGAdapter
+			d.IngressRouteStatus = &k8s.IngressRouteStatus{
+				Client: fake.NewSimpleClientset(),
+			}
 			for _, o := range tc.objs {
 				d.OnAdd(o)
 			}

--- a/internal/contour/route_test.go
+++ b/internal/contour/route_test.go
@@ -22,6 +22,8 @@ import (
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
 	"github.com/gogo/protobuf/types"
 	ingressroutev1 "github.com/heptio/contour/apis/contour/v1beta1"
+	"github.com/heptio/contour/internal/generated/clientset/versioned/fake"
+	"github.com/heptio/contour/internal/k8s"
 	"k8s.io/api/core/v1"
 	"k8s.io/api/extensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -1168,6 +1170,9 @@ func TestRouteVisit(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			var d DAGAdapter
+			d.IngressRouteStatus = &k8s.IngressRouteStatus{
+				Client: fake.NewSimpleClientset(),
+			}
 			for _, o := range tc.objs {
 				d.OnAdd(o)
 			}

--- a/internal/dag/dag_test.go
+++ b/internal/dag/dag_test.go
@@ -3662,81 +3662,81 @@ func TestDAGIngressRouteStatus(t *testing.T) {
 	}{
 		"valid ingressroute": {
 			objs: []*ingressroutev1.IngressRoute{ir1},
-			want: IngressrouteStatus{statuses: []Status{{object: ir1, status: "valid", msg: "valid IngressRoute"}}},
+			want: IngressrouteStatus{statuses: []Status{{object: ir1, status: "valid", description: "valid IngressRoute"}}},
 		},
 		"invalid port in service": {
 			objs: []*ingressroutev1.IngressRoute{ir2},
-			want: IngressrouteStatus{statuses: []Status{{object: ir2, status: "invalid", msg: `route "/foo": service "home": port must be in the range 1-65535`}}},
+			want: IngressrouteStatus{statuses: []Status{{object: ir2, status: "invalid", description: `route "/foo": service "home": port must be in the range 1-65535`}}},
 		},
 		"root ingressroute outside of roots namespace": {
 			objs: []*ingressroutev1.IngressRoute{ir3},
-			want: IngressrouteStatus{statuses: []Status{{object: ir3, status: "invalid", msg: "root IngressRoute cannot be defined in this namespace"}}},
+			want: IngressrouteStatus{statuses: []Status{{object: ir3, status: "invalid", description: "root IngressRoute cannot be defined in this namespace"}}},
 		},
 		"delegated route's match prefix does not match parent's prefix": {
 			objs: []*ingressroutev1.IngressRoute{ir1, ir4},
 			want: IngressrouteStatus{
-				statuses: []Status{{object: ir4, status: "invalid", msg: `the path prefix "/doesnotmatch" does not match the parent's path prefix "/prefix"`},
-					{object: ir1, status: "valid", msg: "valid IngressRoute"}},
+				statuses: []Status{{object: ir4, status: "invalid", description: `the path prefix "/doesnotmatch" does not match the parent's path prefix "/prefix"`},
+					{object: ir1, status: "valid", description: "valid IngressRoute"}},
 			},
 		},
 		"invalid weight in service": {
 			objs: []*ingressroutev1.IngressRoute{ir5},
-			want: IngressrouteStatus{statuses: []Status{{object: ir5, status: "invalid", msg: `route "/foo": service "home": weight must be greater than or equal to zero`}}},
+			want: IngressrouteStatus{statuses: []Status{{object: ir5, status: "invalid", description: `route "/foo": service "home": weight must be greater than or equal to zero`}}},
 		},
 		"root ingressroute does not specify FQDN": {
 			objs: []*ingressroutev1.IngressRoute{ir13},
-			want: IngressrouteStatus{statuses: []Status{{object: ir13, status: "invalid", msg: "Spec.VirtualHost.Fqdn must be specified"}}},
+			want: IngressrouteStatus{statuses: []Status{{object: ir13, status: "invalid", description: "Spec.VirtualHost.Fqdn must be specified"}}},
 		},
 		"self-edge produces a cycle": {
 			objs: []*ingressroutev1.IngressRoute{ir6},
-			want: IngressrouteStatus{statuses: []Status{{object: ir6, status: "invalid", msg: "route creates a delegation cycle: roots/self -> roots/self"}}},
+			want: IngressrouteStatus{statuses: []Status{{object: ir6, status: "invalid", description: "route creates a delegation cycle: roots/self -> roots/self"}}},
 		},
 		"child delegates to parent, producing a cycle": {
 			objs: []*ingressroutev1.IngressRoute{ir7, ir8},
 			want: IngressrouteStatus{
 				statuses: []Status{
-					{object: ir8, status: "invalid", msg: "route creates a delegation cycle: roots/parent -> roots/child -> roots/parent"},
-					{object: ir7, status: "valid", msg: "valid IngressRoute"}},
+					{object: ir8, status: "invalid", description: "route creates a delegation cycle: roots/parent -> roots/child -> roots/parent"},
+					{object: ir7, status: "valid", description: "valid IngressRoute"}},
 			},
 		},
 		"route has a list of services and also delegates": {
 			objs: []*ingressroutev1.IngressRoute{ir9},
-			want: IngressrouteStatus{statuses: []Status{{object: ir9, status: "invalid", msg: `route "/foo": cannot specify services and delegate in the same route`}}},
+			want: IngressrouteStatus{statuses: []Status{{object: ir9, status: "invalid", description: `route "/foo": cannot specify services and delegate in the same route`}}},
 		},
 		"ingressroute is an orphaned route": {
 			objs: []*ingressroutev1.IngressRoute{ir8},
-			want: IngressrouteStatus{statuses: []Status{{object: ir8, status: "orphaned", msg: "this IngressRoute is not part of a delegation chain from a root IngressRoute"}}},
+			want: IngressrouteStatus{statuses: []Status{{object: ir8, status: "orphaned", description: "this IngressRoute is not part of a delegation chain from a root IngressRoute"}}},
 		},
 		"ingressroute delegates to multiple ingressroutes, one is invalid": {
 			objs: []*ingressroutev1.IngressRoute{ir10, ir11, ir12},
 			want: IngressrouteStatus{
 				statuses: []Status{
-					{object: ir11, status: "valid", msg: "valid IngressRoute"},
-					{object: ir12, status: "invalid", msg: `route "/bar": service "foo": port must be in the range 1-65535`},
-					{object: ir10, status: "valid", msg: "valid IngressRoute"}},
+					{object: ir11, status: "valid", description: "valid IngressRoute"},
+					{object: ir12, status: "invalid", description: `route "/bar": service "foo": port must be in the range 1-65535`},
+					{object: ir10, status: "valid", description: "valid IngressRoute"}},
 			},
 		},
 		"invalid parent orphans children": {
 			objs: []*ingressroutev1.IngressRoute{ir14, ir11},
 			want: IngressrouteStatus{
 				statuses: []Status{
-					{object: ir14, status: "invalid", msg: "Spec.VirtualHost.Fqdn must be specified"},
-					{object: ir11, status: "orphaned", msg: "this IngressRoute is not part of a delegation chain from a root IngressRoute"}},
+					{object: ir14, status: "invalid", description: "Spec.VirtualHost.Fqdn must be specified"},
+					{object: ir11, status: "orphaned", description: "this IngressRoute is not part of a delegation chain from a root IngressRoute"}},
 			},
 		},
 		"multi-parent children is not orphaned when one of the parents is invalid": {
 			objs: []*ingressroutev1.IngressRoute{ir14, ir11, ir10},
 			want: IngressrouteStatus{
 				statuses: []Status{
-					{object: ir14, status: "invalid", msg: "Spec.VirtualHost.Fqdn must be specified"},
-					{object: ir11, status: "valid", msg: "valid IngressRoute"},
-					{object: ir10, status: "valid", msg: "valid IngressRoute"}},
+					{object: ir14, status: "invalid", description: "Spec.VirtualHost.Fqdn must be specified"},
+					{object: ir11, status: "valid", description: "valid IngressRoute"},
+					{object: ir10, status: "valid", description: "valid IngressRoute"}},
 			},
 		},
 		"dag version": {
 			objs:  []*ingressroutev1.IngressRoute{ir1},
 			objs2: []*ingressroutev1.IngressRoute{ir1},
-			want:  IngressrouteStatus{version: 1, statuses: []Status{{object: ir1, status: "valid", msg: "valid IngressRoute"}}},
+			want:  IngressrouteStatus{version: 1, statuses: []Status{{object: ir1, status: "valid", description: "valid IngressRoute"}}},
 		},
 	}
 

--- a/internal/e2e/e2e.go
+++ b/internal/e2e/e2e.go
@@ -24,7 +24,9 @@ import (
 	"github.com/gogo/protobuf/proto"
 	"github.com/gogo/protobuf/types"
 	"github.com/heptio/contour/internal/contour"
+	"github.com/heptio/contour/internal/generated/clientset/versioned/fake"
 	cgrpc "github.com/heptio/contour/internal/grpc"
+	"github.com/heptio/contour/internal/k8s"
 	"github.com/sirupsen/logrus"
 	"google.golang.org/grpc"
 	"k8s.io/api/core/v1"
@@ -64,6 +66,10 @@ func setup(t *testing.T, opts ...func(*contour.DAGAdapter)) (cache.ResourceEvent
 		FieldLogger: log,
 	}
 	var da contour.DAGAdapter
+	da.IngressRouteStatus = &k8s.IngressRouteStatus{
+		Client: fake.NewSimpleClientset(),
+	}
+
 	for _, opt := range opts {
 		opt(&da)
 	}

--- a/internal/e2e/lds_test.go
+++ b/internal/e2e/lds_test.go
@@ -31,6 +31,8 @@ import (
 	"github.com/gogo/protobuf/proto"
 	"github.com/gogo/protobuf/types"
 	"github.com/heptio/contour/internal/contour"
+	"github.com/heptio/contour/internal/generated/clientset/versioned/fake"
+	"github.com/heptio/contour/internal/k8s"
 	"google.golang.org/grpc"
 	"k8s.io/api/core/v1"
 	"k8s.io/api/extensions/v1beta1"
@@ -620,6 +622,9 @@ func TestLDSCustomAddressAndPort(t *testing.T) {
 func TestLDSIngressRouteInsideRootNamespaces(t *testing.T) {
 	rh, cc, done := setup(t, func(da *contour.DAGAdapter) {
 		da.IngressRouteRootNamespaces = []string{"roots"}
+		da.IngressRouteStatus = &k8s.IngressRouteStatus{
+			Client: fake.NewSimpleClientset(),
+		}
 	})
 	defer done()
 
@@ -672,6 +677,9 @@ func TestLDSIngressRouteInsideRootNamespaces(t *testing.T) {
 func TestLDSIngressRouteOutsideRootNamespaces(t *testing.T) {
 	rh, cc, done := setup(t, func(da *contour.DAGAdapter) {
 		da.IngressRouteRootNamespaces = []string{"roots"}
+		da.IngressRouteStatus = &k8s.IngressRouteStatus{
+			Client: fake.NewSimpleClientset(),
+		}
 	})
 	defer done()
 

--- a/internal/e2e/rds_test.go
+++ b/internal/e2e/rds_test.go
@@ -25,6 +25,8 @@ import (
 	"github.com/gogo/protobuf/types"
 	ingressroutev1 "github.com/heptio/contour/apis/contour/v1beta1"
 	"github.com/heptio/contour/internal/contour"
+	"github.com/heptio/contour/internal/generated/clientset/versioned/fake"
+	"github.com/heptio/contour/internal/k8s"
 	"google.golang.org/grpc"
 	"k8s.io/api/core/v1"
 	"k8s.io/api/extensions/v1beta1"
@@ -1163,6 +1165,9 @@ func TestDefaultBackendDoesNotOverwriteNamedHost(t *testing.T) {
 func TestRDSIngressRouteInsideRootNamespaces(t *testing.T) {
 	rh, cc, done := setup(t, func(da *contour.DAGAdapter) {
 		da.IngressRouteRootNamespaces = []string{"roots"}
+		da.IngressRouteStatus = &k8s.IngressRouteStatus{
+			Client: fake.NewSimpleClientset(),
+		}
 	})
 	defer done()
 
@@ -1224,6 +1229,9 @@ func TestRDSIngressRouteInsideRootNamespaces(t *testing.T) {
 func TestRDSIngressRouteOutsideRootNamespaces(t *testing.T) {
 	rh, cc, done := setup(t, func(da *contour.DAGAdapter) {
 		da.IngressRouteRootNamespaces = []string{"roots"}
+		da.IngressRouteStatus = &k8s.IngressRouteStatus{
+			Client: fake.NewSimpleClientset(),
+		}
 	})
 	defer done()
 

--- a/internal/k8s/status.go
+++ b/internal/k8s/status.go
@@ -1,0 +1,65 @@
+// Copyright © 2018 Heptio
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package k8s
+
+import (
+	"encoding/json"
+
+	jsonpatch "github.com/evanphx/json-patch"
+	ingressroutev1 "github.com/heptio/contour/apis/contour/v1beta1"
+	clientset "github.com/heptio/contour/internal/generated/clientset/versioned"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+// IngressRouteStatus allows for updating the object's Status field
+type IngressRouteStatus struct {
+	Client clientset.Interface
+}
+
+// SetStatus sets the IngressRoute status field to an Valid or Invalid status
+func (irs *IngressRouteStatus) SetStatus(status, desc string, existing *ingressroutev1.IngressRoute) error {
+
+	// Check if update needed by comparing status & desc
+	if existing.CurrentStatus != status || existing.Description != desc {
+		updated := existing.DeepCopy()
+		updated.Status = ingressroutev1.Status{
+			CurrentStatus: status,
+			Description:   desc,
+		}
+		return irs.setStatus(existing, updated)
+	}
+	return nil
+}
+
+func (irs *IngressRouteStatus) setStatus(existing, updated *ingressroutev1.IngressRoute) error {
+	existingBytes, err := json.Marshal(existing)
+	if err != nil {
+		return err
+	}
+	// Need to set the resource version of the updated endpoints to the resource
+	// version of the current service. Otherwise, the resulting patch does not
+	// have a resource version, and the server complains.
+	updated.ResourceVersion = existing.ResourceVersion
+	updatedBytes, err := json.Marshal(updated)
+	if err != nil {
+		return err
+	}
+	patchBytes, err := jsonpatch.CreateMergePatch(existingBytes, updatedBytes)
+	if err != nil {
+		return err
+	}
+
+	_, err = irs.Client.ContourV1beta1().IngressRoutes(existing.GetNamespace()).Patch(existing.GetName(), types.MergePatchType, patchBytes)
+	return err
+}

--- a/internal/k8s/status_test.go
+++ b/internal/k8s/status_test.go
@@ -1,0 +1,114 @@
+// Copyright © 2018 Heptio
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package k8s
+
+import (
+	"fmt"
+	"testing"
+
+	ingressroutev1beta1 "github.com/heptio/contour/apis/contour/v1beta1"
+	"github.com/heptio/contour/internal/generated/clientset/versioned/fake"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	k8stesting "k8s.io/client-go/testing"
+)
+
+func TestSetStatus(t *testing.T) {
+	tests := map[string]struct {
+		msg           string
+		desc          string
+		existing      *ingressroutev1beta1.IngressRoute
+		expectedPatch string
+		expectedVerbs []string
+	}{
+		"simple update": {
+			msg:  "valid",
+			desc: "this is a valid IR",
+			existing: &ingressroutev1beta1.IngressRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "default",
+				},
+				Status: ingressroutev1beta1.Status{
+					CurrentStatus: "",
+					Description:   "",
+				},
+			},
+			expectedPatch: `{"status":{"currentStatus":"valid","description":"this is a valid IR"}}`,
+			expectedVerbs: []string{"patch"},
+		},
+		"no update": {
+			msg:  "valid",
+			desc: "this is a valid IR",
+			existing: &ingressroutev1beta1.IngressRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "default",
+				},
+				Status: ingressroutev1beta1.Status{
+					CurrentStatus: "valid",
+					Description:   "this is a valid IR",
+				},
+			},
+			expectedPatch: ``,
+			expectedVerbs: []string{},
+		},
+		"replace existing status": {
+			msg:  "valid",
+			desc: "this is a valid IR",
+			existing: &ingressroutev1beta1.IngressRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "default",
+				},
+				Status: ingressroutev1beta1.Status{
+					CurrentStatus: "invalid",
+					Description:   "boo hiss",
+				},
+			},
+			expectedPatch: `{"status":{"currentStatus":"valid","description":"this is a valid IR"}}`,
+			expectedVerbs: []string{"patch"},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			var gotPatchBytes []byte
+			client := fake.NewSimpleClientset(tc.existing)
+			client.PrependReactor("patch", "ingressroutes", func(action k8stesting.Action) (bool, runtime.Object, error) {
+				switch patchAction := action.(type) {
+				default:
+					return true, nil, fmt.Errorf("got unexpected action of type: %T", action)
+				case k8stesting.PatchActionImpl:
+					gotPatchBytes = patchAction.GetPatch()
+					return true, tc.existing, nil
+				}
+			})
+			irs := IngressRouteStatus{
+				Client: client,
+			}
+			irs.SetStatus(tc.msg, tc.desc, tc.existing)
+
+			if len(client.Actions()) != len(tc.expectedVerbs) {
+				t.Fatalf("Expected verbs mismatch: want: %d, got: %d", len(tc.expectedVerbs), len(client.Actions()))
+			}
+
+			client.ContourV1beta1().IngressRoutes("default").Get("test", metav1.GetOptions{})
+
+			if tc.expectedPatch != string(gotPatchBytes) {
+				t.Fatalf("expected patch: %s, got: %s", tc.expectedPatch, string(gotPatchBytes))
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #524 by updating IngressRoute Status fields after a DAG update. It only updates when the status changes (e.g. msg != ir.msg or desc != ir.desc)

Signed-off-by: Steve Sloka <steves@heptio.com>