### PR TITLE
Makefile: fix gofmt target

### DIFF
--- a/internal/contour/annotations_test.go
+++ b/internal/contour/annotations_test.go
@@ -140,7 +140,7 @@ func TestWebsocketRoutes(t *testing.T) {
 				},
 			},
 			want: map[string]*types.BoolValue{
-				"/ws1": &types.BoolValue{Value: true},
+				"/ws1": {Value: true},
 			},
 		},
 		"multiple values": {
@@ -150,8 +150,8 @@ func TestWebsocketRoutes(t *testing.T) {
 				},
 			},
 			want: map[string]*types.BoolValue{
-				"/ws1": &types.BoolValue{Value: true},
-				"/ws2": &types.BoolValue{Value: true},
+				"/ws1": {Value: true},
+				"/ws2": {Value: true},
 			},
 		},
 		"multiple values with spaces and invalid entries": {
@@ -161,8 +161,8 @@ func TestWebsocketRoutes(t *testing.T) {
 				},
 			},
 			want: map[string]*types.BoolValue{
-				"/ws1": &types.BoolValue{Value: true},
-				"/ws2": &types.BoolValue{Value: true},
+				"/ws1": {Value: true},
+				"/ws2": {Value: true},
 			},
 		},
 	}

--- a/internal/contour/cluster_test.go
+++ b/internal/contour/cluster_test.go
@@ -324,7 +324,7 @@ func TestClusterVisit(t *testing.T) {
 									IntervalSeconds:         98,
 									UnhealthyThresholdCount: 97,
 									HealthyThresholdCount:   96,
-									Host: "foo-bar-host",
+									Host:                    "foo-bar-host",
 								},
 							}},
 						}},

--- a/internal/contour/listener_test.go
+++ b/internal/contour/listener_test.go
@@ -56,7 +56,7 @@ func TestListenerVisit(t *testing.T) {
 				},
 			},
 			want: map[string]*v2.Listener{
-				ENVOY_HTTP_LISTENER: &v2.Listener{
+				ENVOY_HTTP_LISTENER: {
 					Name:    ENVOY_HTTP_LISTENER,
 					Address: socketaddress("0.0.0.0", 8080),
 					FilterChains: []listener.FilterChain{
@@ -90,7 +90,7 @@ func TestListenerVisit(t *testing.T) {
 				},
 			},
 			want: map[string]*v2.Listener{
-				ENVOY_HTTP_LISTENER: &v2.Listener{
+				ENVOY_HTTP_LISTENER: {
 					Name:    ENVOY_HTTP_LISTENER,
 					Address: socketaddress("0.0.0.0", 8080),
 					FilterChains: []listener.FilterChain{
@@ -126,14 +126,14 @@ func TestListenerVisit(t *testing.T) {
 				},
 			},
 			want: map[string]*v2.Listener{
-				ENVOY_HTTP_LISTENER: &v2.Listener{
+				ENVOY_HTTP_LISTENER: {
 					Name:    ENVOY_HTTP_LISTENER,
 					Address: socketaddress("0.0.0.0", 8080),
 					FilterChains: []listener.FilterChain{
 						filterchain(false, httpfilter(ENVOY_HTTP_LISTENER, DEFAULT_HTTP_ACCESS_LOG)),
 					},
 				},
-				ENVOY_HTTPS_LISTENER: &v2.Listener{
+				ENVOY_HTTPS_LISTENER: {
 					Name:    ENVOY_HTTPS_LISTENER,
 					Address: socketaddress("0.0.0.0", 8443),
 					FilterChains: []listener.FilterChain{{
@@ -175,7 +175,7 @@ func TestListenerVisit(t *testing.T) {
 				},
 			},
 			want: map[string]*v2.Listener{
-				ENVOY_HTTP_LISTENER: &v2.Listener{
+				ENVOY_HTTP_LISTENER: {
 					Name:    ENVOY_HTTP_LISTENER,
 					Address: socketaddress("0.0.0.0", 8080),
 					FilterChains: []listener.FilterChain{
@@ -219,14 +219,14 @@ func TestListenerVisit(t *testing.T) {
 				},
 			},
 			want: map[string]*v2.Listener{
-				ENVOY_HTTP_LISTENER: &v2.Listener{
+				ENVOY_HTTP_LISTENER: {
 					Name:    ENVOY_HTTP_LISTENER,
 					Address: socketaddress("0.0.0.0", 8080),
 					FilterChains: []listener.FilterChain{
 						filterchain(false, httpfilter(ENVOY_HTTP_LISTENER, DEFAULT_HTTP_ACCESS_LOG)),
 					},
 				},
-				ENVOY_HTTPS_LISTENER: &v2.Listener{
+				ENVOY_HTTPS_LISTENER: {
 					Name:    ENVOY_HTTPS_LISTENER,
 					Address: socketaddress("0.0.0.0", 8443),
 					FilterChains: []listener.FilterChain{{
@@ -291,7 +291,7 @@ func TestListenerVisit(t *testing.T) {
 				},
 			},
 			want: map[string]*v2.Listener{
-				ENVOY_HTTPS_LISTENER: &v2.Listener{
+				ENVOY_HTTPS_LISTENER: {
 					Name:    ENVOY_HTTPS_LISTENER,
 					Address: socketaddress("0.0.0.0", 8443),
 					FilterChains: []listener.FilterChain{{
@@ -339,14 +339,14 @@ func TestListenerVisit(t *testing.T) {
 				},
 			},
 			want: map[string]*v2.Listener{
-				ENVOY_HTTP_LISTENER: &v2.Listener{
+				ENVOY_HTTP_LISTENER: {
 					Name:    ENVOY_HTTP_LISTENER,
 					Address: socketaddress("127.0.0.100", 9100),
 					FilterChains: []listener.FilterChain{
 						filterchain(false, httpfilter(ENVOY_HTTP_LISTENER, DEFAULT_HTTP_ACCESS_LOG)),
 					},
 				},
-				ENVOY_HTTPS_LISTENER: &v2.Listener{
+				ENVOY_HTTPS_LISTENER: {
 					Name:    ENVOY_HTTPS_LISTENER,
 					Address: socketaddress("127.0.0.200", 9200),
 					FilterChains: []listener.FilterChain{{
@@ -391,14 +391,14 @@ func TestListenerVisit(t *testing.T) {
 				},
 			},
 			want: map[string]*v2.Listener{
-				ENVOY_HTTP_LISTENER: &v2.Listener{
+				ENVOY_HTTP_LISTENER: {
 					Name:    ENVOY_HTTP_LISTENER,
 					Address: socketaddress("0.0.0.0", 8080),
 					FilterChains: []listener.FilterChain{
 						filterchain(true, httpfilter(ENVOY_HTTP_LISTENER, DEFAULT_HTTP_ACCESS_LOG)),
 					},
 				},
-				ENVOY_HTTPS_LISTENER: &v2.Listener{
+				ENVOY_HTTPS_LISTENER: {
 					Name:    ENVOY_HTTPS_LISTENER,
 					Address: socketaddress("0.0.0.0", 8443),
 					FilterChains: []listener.FilterChain{{

--- a/internal/contour/route_test.go
+++ b/internal/contour/route_test.go
@@ -44,10 +44,10 @@ func TestRouteVisit(t *testing.T) {
 		"nothing": {
 			objs: nil,
 			want: map[string]*v2.RouteConfiguration{
-				"ingress_http": &v2.RouteConfiguration{
+				"ingress_http": {
 					Name: "ingress_http",
 				},
-				"ingress_https": &v2.RouteConfiguration{
+				"ingress_https": {
 					Name: "ingress_https",
 				},
 			},
@@ -81,7 +81,7 @@ func TestRouteVisit(t *testing.T) {
 				},
 			},
 			want: map[string]*v2.RouteConfiguration{
-				"ingress_http": &v2.RouteConfiguration{
+				"ingress_http": {
 					Name: "ingress_http",
 					VirtualHosts: []route.VirtualHost{{
 						Name:    "*",
@@ -92,7 +92,7 @@ func TestRouteVisit(t *testing.T) {
 						}},
 					}},
 				},
-				"ingress_https": &v2.RouteConfiguration{
+				"ingress_https": {
 					Name: "ingress_https",
 				},
 			},
@@ -134,7 +134,7 @@ func TestRouteVisit(t *testing.T) {
 				},
 			},
 			want: map[string]*v2.RouteConfiguration{
-				"ingress_http": &v2.RouteConfiguration{
+				"ingress_http": {
 					Name: "ingress_http",
 					VirtualHosts: []route.VirtualHost{{
 						Name:    "www.example.com",
@@ -145,7 +145,7 @@ func TestRouteVisit(t *testing.T) {
 						}},
 					}},
 				},
-				"ingress_https": &v2.RouteConfiguration{
+				"ingress_https": {
 					Name: "ingress_https",
 				},
 			},
@@ -190,7 +190,7 @@ func TestRouteVisit(t *testing.T) {
 				},
 			},
 			want: map[string]*v2.RouteConfiguration{
-				"ingress_http": &v2.RouteConfiguration{
+				"ingress_http": {
 					Name: "ingress_http",
 					VirtualHosts: []route.VirtualHost{{
 						Name:    "*", // default backend
@@ -201,7 +201,7 @@ func TestRouteVisit(t *testing.T) {
 						}},
 					}},
 				},
-				"ingress_https": &v2.RouteConfiguration{
+				"ingress_https": {
 					Name: "ingress_https", // no https for default backend
 				},
 			},
@@ -256,7 +256,7 @@ func TestRouteVisit(t *testing.T) {
 				},
 			},
 			want: map[string]*v2.RouteConfiguration{
-				"ingress_http": &v2.RouteConfiguration{
+				"ingress_http": {
 					Name: "ingress_http",
 					VirtualHosts: []route.VirtualHost{{
 						Name:    "www.example.com",
@@ -267,7 +267,7 @@ func TestRouteVisit(t *testing.T) {
 						}},
 					}},
 				},
-				"ingress_https": &v2.RouteConfiguration{
+				"ingress_https": {
 					Name: "ingress_https",
 					VirtualHosts: []route.VirtualHost{{
 						Name:    "www.example.com",
@@ -327,7 +327,7 @@ func TestRouteVisit(t *testing.T) {
 				},
 			},
 			want: map[string]*v2.RouteConfiguration{
-				"ingress_http": &v2.RouteConfiguration{
+				"ingress_http": {
 					Name: "ingress_http",
 					VirtualHosts: []route.VirtualHost{{
 						Name:    "www.example.com",
@@ -338,7 +338,7 @@ func TestRouteVisit(t *testing.T) {
 						}},
 					}},
 				},
-				"ingress_https": &v2.RouteConfiguration{
+				"ingress_https": {
 					Name: "ingress_https",
 					/* TODO(dfc) no support for routes on https for ingressroute, yet
 					VirtualHosts: []route.VirtualHost{{
@@ -405,10 +405,10 @@ func TestRouteVisit(t *testing.T) {
 				},
 			},
 			want: map[string]*v2.RouteConfiguration{
-				"ingress_http": &v2.RouteConfiguration{
+				"ingress_http": {
 					Name: "ingress_http",
 				},
-				"ingress_https": &v2.RouteConfiguration{
+				"ingress_https": {
 					Name: "ingress_https",
 					VirtualHosts: []route.VirtualHost{{
 						Name:    "www.example.com",
@@ -474,7 +474,7 @@ func TestRouteVisit(t *testing.T) {
 				},
 			},
 			want: map[string]*v2.RouteConfiguration{
-				"ingress_http": &v2.RouteConfiguration{
+				"ingress_http": {
 					Name: "ingress_http",
 					VirtualHosts: []route.VirtualHost{{
 						Name:    "www.example.com",
@@ -489,7 +489,7 @@ func TestRouteVisit(t *testing.T) {
 						}},
 					}},
 				},
-				"ingress_https": &v2.RouteConfiguration{
+				"ingress_https": {
 					Name: "ingress_https",
 					VirtualHosts: []route.VirtualHost{{
 						Name:    "www.example.com",
@@ -551,7 +551,7 @@ func TestRouteVisit(t *testing.T) {
 				},
 			},
 			want: map[string]*v2.RouteConfiguration{
-				"ingress_http": &v2.RouteConfiguration{
+				"ingress_http": {
 					Name: "ingress_http",
 					VirtualHosts: []route.VirtualHost{{
 						Name:    "www.example.com",
@@ -565,7 +565,7 @@ func TestRouteVisit(t *testing.T) {
 						}},
 					}},
 				},
-				"ingress_https": &v2.RouteConfiguration{
+				"ingress_https": {
 					Name: "ingress_https",
 				},
 			},
@@ -602,7 +602,7 @@ func TestRouteVisit(t *testing.T) {
 				},
 			},
 			want: map[string]*v2.RouteConfiguration{
-				"ingress_http": &v2.RouteConfiguration{
+				"ingress_http": {
 					Name: "ingress_http",
 					VirtualHosts: []route.VirtualHost{{
 						Name:    "*",
@@ -613,7 +613,7 @@ func TestRouteVisit(t *testing.T) {
 						}},
 					}},
 				},
-				"ingress_https": &v2.RouteConfiguration{
+				"ingress_https": {
 					Name: "ingress_https",
 				},
 			},
@@ -650,7 +650,7 @@ func TestRouteVisit(t *testing.T) {
 				},
 			},
 			want: map[string]*v2.RouteConfiguration{
-				"ingress_http": &v2.RouteConfiguration{
+				"ingress_http": {
 					Name: "ingress_http",
 					VirtualHosts: []route.VirtualHost{{
 						Name:    "*",
@@ -661,7 +661,7 @@ func TestRouteVisit(t *testing.T) {
 						}},
 					}},
 				},
-				"ingress_https": &v2.RouteConfiguration{
+				"ingress_https": {
 					Name: "ingress_https",
 				},
 			},
@@ -698,7 +698,7 @@ func TestRouteVisit(t *testing.T) {
 				},
 			},
 			want: map[string]*v2.RouteConfiguration{
-				"ingress_http": &v2.RouteConfiguration{
+				"ingress_http": {
 					Name: "ingress_http",
 					VirtualHosts: []route.VirtualHost{{
 						Name:    "*",
@@ -709,7 +709,7 @@ func TestRouteVisit(t *testing.T) {
 						}},
 					}},
 				},
-				"ingress_https": &v2.RouteConfiguration{
+				"ingress_https": {
 					Name: "ingress_https",
 				},
 			},
@@ -754,7 +754,7 @@ func TestRouteVisit(t *testing.T) {
 				},
 			},
 			want: map[string]*v2.RouteConfiguration{
-				"ingress_http": &v2.RouteConfiguration{
+				"ingress_http": {
 					Name: "ingress_http",
 					VirtualHosts: []route.VirtualHost{{
 						Name:    "d31bb322ca62bb395acad00b3cbf45a3aa1010ca28dca7cddb4f7db786fa",
@@ -765,7 +765,7 @@ func TestRouteVisit(t *testing.T) {
 						}},
 					}},
 				},
-				"ingress_https": &v2.RouteConfiguration{
+				"ingress_https": {
 					Name: "ingress_https",
 				},
 			},
@@ -802,10 +802,10 @@ func TestRouteVisit(t *testing.T) {
 				},
 			},
 			want: map[string]*v2.RouteConfiguration{
-				"ingress_http": &v2.RouteConfiguration{
+				"ingress_http": {
 					Name: "ingress_http", // expected to be empty, the ingress class is ignored
 				},
-				"ingress_https": &v2.RouteConfiguration{
+				"ingress_https": {
 					Name: "ingress_https", // expected to be empty, the ingress class is ignored
 				},
 			},
@@ -842,7 +842,7 @@ func TestRouteVisit(t *testing.T) {
 				},
 			},
 			want: map[string]*v2.RouteConfiguration{
-				"ingress_http": &v2.RouteConfiguration{
+				"ingress_http": {
 					Name: "ingress_http",
 					VirtualHosts: []route.VirtualHost{{
 						Name:    "*",
@@ -853,7 +853,7 @@ func TestRouteVisit(t *testing.T) {
 						}},
 					}},
 				},
-				"ingress_https": &v2.RouteConfiguration{
+				"ingress_https": {
 					Name: "ingress_https",
 				},
 			},
@@ -912,7 +912,7 @@ func TestRouteVisit(t *testing.T) {
 				},
 			},
 			want: map[string]*v2.RouteConfiguration{
-				"ingress_http": &v2.RouteConfiguration{
+				"ingress_http": {
 					Name: "ingress_http",
 					VirtualHosts: []route.VirtualHost{{
 						Name:    "www.example.com",
@@ -940,7 +940,7 @@ func TestRouteVisit(t *testing.T) {
 						}},
 					}},
 				},
-				"ingress_https": &v2.RouteConfiguration{
+				"ingress_https": {
 					Name: "ingress_https",
 				},
 			},
@@ -1000,7 +1000,7 @@ func TestRouteVisit(t *testing.T) {
 				},
 			},
 			want: map[string]*v2.RouteConfiguration{
-				"ingress_http": &v2.RouteConfiguration{
+				"ingress_http": {
 					Name: "ingress_http",
 					VirtualHosts: []route.VirtualHost{{
 						Name:    "www.example.com",
@@ -1028,7 +1028,7 @@ func TestRouteVisit(t *testing.T) {
 						}},
 					}},
 				},
-				"ingress_https": &v2.RouteConfiguration{
+				"ingress_https": {
 					Name: "ingress_https",
 				},
 			},
@@ -1089,7 +1089,7 @@ func TestRouteVisit(t *testing.T) {
 				},
 			},
 			want: map[string]*v2.RouteConfiguration{
-				"ingress_http": &v2.RouteConfiguration{
+				"ingress_http": {
 					Name: "ingress_http",
 					VirtualHosts: []route.VirtualHost{{
 						Name:    "www.example.com",
@@ -1117,7 +1117,7 @@ func TestRouteVisit(t *testing.T) {
 						}},
 					}},
 				},
-				"ingress_https": &v2.RouteConfiguration{
+				"ingress_https": {
 					Name: "ingress_https",
 				},
 			},
@@ -1157,10 +1157,10 @@ func TestRouteVisit(t *testing.T) {
 				},
 			},
 			want: map[string]*v2.RouteConfiguration{
-				"ingress_http": &v2.RouteConfiguration{
+				"ingress_http": {
 					Name: "ingress_http", // should be blank, no fqdn defined.
 				},
-				"ingress_https": &v2.RouteConfiguration{
+				"ingress_https": {
 					Name: "ingress_https",
 				},
 			},

--- a/internal/dag/dag_test.go
+++ b/internal/dag/dag_test.go
@@ -2883,7 +2883,7 @@ func TestServiceMapLookup(t *testing.T) {
 		},
 	}
 	services := map[meta]*v1.Service{
-		meta{name: "service1", namespace: "default"}: s1,
+		{name: "service1", namespace: "default"}: s1,
 	}
 
 	tests := map[string]struct {


### PR DESCRIPTION
Adding goreportcard showed that some source files were not properly
formatted. I'm not sure where I copy pasta'd the current gofmt check,
but it didn't do what it said on the tin.

Replace with a better copy pasta version and break out the check into
its own target.

Signed-off-by: Dave Cheney <dave@cheney.net>