### PR TITLE
Gopkg.toml: upgrade to envoyproxy/go-control-plane@v0.4

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -44,6 +44,7 @@
     "envoy/api/v2/endpoint",
     "envoy/api/v2/listener",
     "envoy/api/v2/route",
+    "envoy/config/accesslog/v2",
     "envoy/config/filter/accesslog/v2",
     "envoy/config/filter/network/http_connection_manager/v2",
     "envoy/service/load_stats/v2",
@@ -568,6 +569,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "d7d4a6d3168a330458db2b55f22e1810e04a461b7af361ede736dc437f50f3bb"
+  inputs-digest = "d5ec28418b2a6f61fd04c03bbd3e5b9d5859b8d0bd2bcc5f6af9d3250bee02ad"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -49,8 +49,8 @@
     "envoy/service/load_stats/v2",
     "envoy/type"
   ]
-  revision = "469a90e97a000f23f2ab0bf494cdc8e1480a3dfa"
-  version = "v0.2"
+  revision = "c14704578b82128fab17743d91f870c406ef8d09"
+  version = "v0.4"
 
 [[projects]]
   name = "github.com/evanphx/json-patch"

--- a/internal/contour/cluster.go
+++ b/internal/contour/cluster.go
@@ -208,15 +208,12 @@ func edshealthcheck(hc *ingressroutev1.HealthCheck) []*core.HealthCheck {
 	}}
 }
 
-func secondsOrDefault(seconds int64, def time.Duration) *types.Duration {
+func secondsOrDefault(seconds int64, def time.Duration) *time.Duration {
 	if seconds != 0 {
-		return &types.Duration{
-			Seconds: seconds,
-		}
+		t := time.Duration(seconds) * time.Second
+		return &t
 	}
-	return &types.Duration{
-		Seconds: int64(def / time.Second),
-	}
+	return &def
 }
 
 func countOrDefault(count, def uint32) *types.UInt32Value {

--- a/internal/contour/cluster_test.go
+++ b/internal/contour/cluster_test.go
@@ -715,10 +715,8 @@ func clustermap(clusters ...*v2.Cluster) map[string]*v2.Cluster {
 	return m
 }
 
-func duration(d time.Duration) *types.Duration {
-	return &types.Duration{
-		Seconds: int64(d / time.Second),
-	}
+func duration(d time.Duration) *time.Duration {
+	return &d
 }
 
 func TestServiceName(t *testing.T) {

--- a/internal/contour/route.go
+++ b/internal/contour/route.go
@@ -246,7 +246,6 @@ func actionroute(services []*dag.Service, ws bool, timeout time.Duration) *route
 
 	// Loop over all the upstreams and add to slice
 	for _, svc := range services {
-
 		// Create the upstream
 		upstreams = append(upstreams, &route.WeightedCluster_ClusterWeight{
 			Name:   hashname(60, svc.Namespace(), svc.Name(), strconv.Itoa(int(svc.Port))),

--- a/internal/e2e/e2e.go
+++ b/internal/e2e/e2e.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2"
+	accesslog "github.com/envoyproxy/go-control-plane/envoy/config/accesslog/v2"
 	"github.com/gogo/protobuf/proto"
 	"github.com/gogo/protobuf/types"
 	"github.com/heptio/contour/internal/contour"
@@ -184,5 +185,16 @@ func assertEqual(t *testing.T, want, got *v2.DiscoveryResponse) {
 			ExpandAny: true,
 		}
 		t.Fatalf("\nexpected:\n%v\ngot:\n%v", m.Text(want), m.Text(got))
+	}
+}
+
+// fileAccessLog is defined here to avoid the conflict between the package that defines the
+// accesslog.AccessLog interface, "github.com/envoyproxy/go-control-plane/envoy/config/filter/accesslog/v2"
+// and the package the defines the FileAccessLog implement,
+// "github.com/envoyproxy/go-control-plane/envoy/config/accesslog/v2"
+
+func fileAccessLog(path string) *accesslog.FileAccessLog {
+	return &accesslog.FileAccessLog{
+		Path: path,
 	}
 }

--- a/internal/e2e/lds_test.go
+++ b/internal/e2e/lds_test.go
@@ -822,10 +822,8 @@ func httpfilter(routename string) listener.Filter {
 				},
 			},
 			AccessLog: []*accesslog.AccessLog{{
-				Name: "envoy.file_access_log",
-				Config: messageToStruct(&accesslog.FileAccessLog{
-					Path: "/dev/stdout",
-				}),
+				Name:   "envoy.file_access_log",
+				Config: messageToStruct(fileAccessLog("/dev/stdout")),
 			}},
 			UseRemoteAddress: &types.BoolValue{Value: true},
 			HttpFilters: []*envoy_config_v2_http_conn_mgr.HttpFilter{

--- a/internal/grpc/server.go
+++ b/internal/grpc/server.go
@@ -106,7 +106,15 @@ func (s *grpcServer) StreamEndpoints(srv v2.EndpointDiscoveryService_StreamEndpo
 }
 
 func (s *grpcServer) StreamLoadStats(srv envoy_service_v2.LoadReportingService_StreamLoadStatsServer) error {
-	return status.Errorf(codes.Unimplemented, "StreamLoadStats Unimplemented")
+	return status.Errorf(codes.Unimplemented, "StreamLoadStats unimplemented")
+}
+
+func (s *grpcServer) IncrementalClusters(v2.ClusterDiscoveryService_IncrementalClustersServer) error {
+	return status.Errorf(codes.Unimplemented, "IncrementalClusters unimplemented")
+}
+
+func (s *grpcServer) IncrementalRoutes(v2.RouteDiscoveryService_IncrementalRoutesServer) error {
+	return status.Errorf(codes.Unimplemented, "IncrementalRoutes unimplemented")
 }
 
 func (s *grpcServer) StreamListeners(srv v2.ListenerDiscoveryService_StreamListenersServer) error {

--- a/internal/k8s/status.go
+++ b/internal/k8s/status.go
@@ -29,7 +29,6 @@ type IngressRouteStatus struct {
 
 // SetStatus sets the IngressRoute status field to an Valid or Invalid status
 func (irs *IngressRouteStatus) SetStatus(status, desc string, existing *ingressroutev1.IngressRoute) error {
-
 	// Check if update needed by comparing status & desc
 	if existing.CurrentStatus != status || existing.Description != desc {
 		updated := existing.DeepCopy()


### PR DESCRIPTION
Fixes #534

Upgrade to go-control-place v0.4 to pick up improvements to duration
handling in healthcheck and circuitbreaking.

Signed-off-by: Dave Cheney <dave@cheney.net>