### PR TITLE
Makefile: fix gofmt target (again)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,4 +55,4 @@ updategenerated:
 
 gofmt:  
 	@echo Checking code is gofmted
-	@test -z "$(shell gofmt -s -l $(SRCDIRS) | tee /dev/stderr)" || gofmt -s -d -e $(SRCDIRS)
+	@test -z "$(shell gofmt -s -l -d -e $(SRCDIRS) | tee /dev/stderr)"

--- a/internal/contour/cluster_test.go
+++ b/internal/contour/cluster_test.go
@@ -319,12 +319,12 @@ func TestClusterVisit(t *testing.T) {
 								Name: "backend",
 								Port: 80,
 								HealthCheck: &ingressroutev1.HealthCheck{
+									Host:                    "foo-bar-host",
 									Path:                    "/healthy",
 									TimeoutSeconds:          99,
 									IntervalSeconds:         98,
 									UnhealthyThresholdCount: 97,
 									HealthyThresholdCount:   96,
-									Host:                    "foo-bar-host",
 								},
 							}},
 						}},


### PR DESCRIPTION
Fix gofmt target so it fails the build.

Also, fix a small formatting incompatibility between Go 1.10 and Go
1.11. The gofmt rules have changed slightly, so avoid that by moving the
Host line to the top of the declaration where the rules do not
differ.

Signed-off-by: Dave Cheney <dave@cheney.net>