### PR TITLE
internal/contour,dag: add test coverage to route.go:actionroute

### DIFF
--- a/internal/contour/route.go
+++ b/internal/contour/route.go
@@ -241,7 +241,7 @@ func prefixmatch(prefix string) route.RouteMatch {
 // action computes the cluster route action, a *route.Route_route for the
 // supplied ingress and backend.
 func actionroute(services []*dag.Service, ws bool, timeout time.Duration) *route.Route_Route {
-	totalWeight := 0
+	var totalWeight int
 	upstreams := []*route.WeightedCluster_ClusterWeight{}
 
 	// Loop over all the upstreams and add to slice
@@ -251,7 +251,6 @@ func actionroute(services []*dag.Service, ws bool, timeout time.Duration) *route
 			Name:   hashname(60, svc.Namespace(), svc.Name(), strconv.Itoa(int(svc.Port))),
 			Weight: &types.UInt32Value{Value: uint32(svc.Weight)},
 		})
-
 		totalWeight += svc.Weight
 	}
 

--- a/internal/dag/dag.go
+++ b/internal/dag/dag.go
@@ -198,7 +198,7 @@ func (sm *serviceMap) insert(svc *v1.Service, port *v1.ServicePort) *Service {
 	}
 
 	s := &Service{
-		object:      svc,
+		Object:      svc,
 		ServicePort: port,
 		Protocol:    protocol,
 
@@ -612,7 +612,7 @@ type Vertex interface {
 // Service represents a K8s Sevice as a DAG vertex. A Service is
 // a leaf in the DAG.
 type Service struct {
-	object *v1.Service
+	Object *v1.Service
 
 	*v1.ServicePort
 	Weight int
@@ -642,8 +642,8 @@ type Service struct {
 	MaxRetries int
 }
 
-func (s *Service) Name() string       { return s.object.Name }
-func (s *Service) Namespace() string  { return s.object.Namespace }
+func (s *Service) Name() string       { return s.Object.Name }
+func (s *Service) Namespace() string  { return s.Object.Namespace }
 func (s *Service) Visit(func(Vertex)) {}
 
 type portmeta struct {
@@ -654,8 +654,8 @@ type portmeta struct {
 
 func (s *Service) toMeta() portmeta {
 	return portmeta{
-		name:      s.object.Name,
-		namespace: s.object.Namespace,
+		name:      s.Object.Name,
+		namespace: s.Object.Namespace,
 		port:      s.Port,
 	}
 }

--- a/internal/dag/dag_test.go
+++ b/internal/dag/dag_test.go
@@ -830,7 +830,7 @@ func TestDAGInsert(t *testing.T) {
 							object: i1,
 							services: servicemap(
 								&Service{
-									object:      s1,
+									Object:      s1,
 									ServicePort: &s1.Spec.Ports[0],
 								},
 							),
@@ -854,7 +854,7 @@ func TestDAGInsert(t *testing.T) {
 							object: i1,
 							services: servicemap(
 								&Service{
-									object:      s1,
+									Object:      s1,
 									ServicePort: &s1.Spec.Ports[0],
 								},
 							),
@@ -968,7 +968,7 @@ func TestDAGInsert(t *testing.T) {
 							object: i4,
 							services: servicemap(
 								&Service{
-									object:      s1,
+									Object:      s1,
 									ServicePort: &s1.Spec.Ports[0],
 								},
 							),
@@ -992,7 +992,7 @@ func TestDAGInsert(t *testing.T) {
 							object: i4,
 							services: servicemap(
 								&Service{
-									object:      s1,
+									Object:      s1,
 									ServicePort: &s1.Spec.Ports[0],
 								},
 							),
@@ -1016,7 +1016,7 @@ func TestDAGInsert(t *testing.T) {
 							object: i5,
 							services: servicemap(
 								&Service{
-									object:      s1,
+									Object:      s1,
 									ServicePort: &s1.Spec.Ports[0],
 								},
 							),
@@ -1040,7 +1040,7 @@ func TestDAGInsert(t *testing.T) {
 							object: i5,
 							services: servicemap(
 								&Service{
-									object:      s1,
+									Object:      s1,
 									ServicePort: &s1.Spec.Ports[0],
 								},
 							),
@@ -1178,7 +1178,7 @@ func TestDAGInsert(t *testing.T) {
 							object: i6,
 							services: servicemap(
 								&Service{
-									object:      s1,
+									Object:      s1,
 									ServicePort: &s1.Spec.Ports[0],
 								},
 							),
@@ -1194,7 +1194,7 @@ func TestDAGInsert(t *testing.T) {
 							object: i6,
 							services: servicemap(
 								&Service{
-									object:      s1,
+									Object:      s1,
 									ServicePort: &s1.Spec.Ports[0],
 								},
 							),
@@ -1218,7 +1218,7 @@ func TestDAGInsert(t *testing.T) {
 							object: i6,
 							services: servicemap(
 								&Service{
-									object:      s1,
+									Object:      s1,
 									ServicePort: &s1.Spec.Ports[0],
 								},
 							),
@@ -1234,7 +1234,7 @@ func TestDAGInsert(t *testing.T) {
 							object: i6,
 							services: servicemap(
 								&Service{
-									object:      s1,
+									Object:      s1,
 									ServicePort: &s1.Spec.Ports[0],
 								},
 							),
@@ -1259,7 +1259,7 @@ func TestDAGInsert(t *testing.T) {
 							object: i6,
 							services: servicemap(
 								&Service{
-									object:      s1,
+									Object:      s1,
 									ServicePort: &s1.Spec.Ports[0],
 								},
 							),
@@ -1275,7 +1275,7 @@ func TestDAGInsert(t *testing.T) {
 							object: i6,
 							services: servicemap(
 								&Service{
-									object:      s1,
+									Object:      s1,
 									ServicePort: &s1.Spec.Ports[0],
 								},
 							),
@@ -1291,7 +1291,7 @@ func TestDAGInsert(t *testing.T) {
 							object: i6,
 							services: servicemap(
 								&Service{
-									object:      s1,
+									Object:      s1,
 									ServicePort: &s1.Spec.Ports[0],
 								},
 							),
@@ -1319,7 +1319,7 @@ func TestDAGInsert(t *testing.T) {
 							object: i6,
 							services: servicemap(
 								&Service{
-									object:      s1,
+									Object:      s1,
 									ServicePort: &s1.Spec.Ports[0],
 								},
 							),
@@ -1334,7 +1334,7 @@ func TestDAGInsert(t *testing.T) {
 							object: i6,
 							services: servicemap(
 								&Service{
-									object:      s1,
+									Object:      s1,
 									ServicePort: &s1.Spec.Ports[0],
 								},
 							),
@@ -1350,7 +1350,7 @@ func TestDAGInsert(t *testing.T) {
 							object: i6,
 							services: servicemap(
 								&Service{
-									object:      s1,
+									Object:      s1,
 									ServicePort: &s1.Spec.Ports[0],
 								},
 							),
@@ -1398,7 +1398,7 @@ func TestDAGInsert(t *testing.T) {
 							object: i7,
 							services: servicemap(
 								&Service{
-									object:      s1,
+									Object:      s1,
 									ServicePort: &s1.Spec.Ports[0],
 								},
 							),
@@ -1408,7 +1408,7 @@ func TestDAGInsert(t *testing.T) {
 							object: i7,
 							services: servicemap(
 								&Service{
-									object:      s2,
+									Object:      s2,
 									ServicePort: &s1.Spec.Ports[0],
 								},
 							),
@@ -1431,7 +1431,7 @@ func TestDAGInsert(t *testing.T) {
 							object: i8,
 							services: servicemap(
 								&Service{
-									object:      s1,
+									Object:      s1,
 									ServicePort: &s1.Spec.Ports[0],
 								},
 							),
@@ -1441,7 +1441,7 @@ func TestDAGInsert(t *testing.T) {
 							object: i8,
 							services: servicemap(
 								&Service{
-									object:      s2,
+									Object:      s2,
 									ServicePort: &s2.Spec.Ports[0],
 								},
 							),
@@ -1473,7 +1473,7 @@ func TestDAGInsert(t *testing.T) {
 							object: i9,
 							services: servicemap(
 								&Service{
-									object:      s1,
+									Object:      s1,
 									ServicePort: &s1.Spec.Ports[0],
 								},
 							),
@@ -1483,7 +1483,7 @@ func TestDAGInsert(t *testing.T) {
 							object: i9,
 							services: servicemap(
 								&Service{
-									object:      s2,
+									Object:      s2,
 									ServicePort: &s2.Spec.Ports[0],
 								},
 							),
@@ -1528,7 +1528,7 @@ func TestDAGInsert(t *testing.T) {
 							object: i6a,
 							services: servicemap(
 								&Service{
-									object:      s1,
+									Object:      s1,
 									ServicePort: &s1.Spec.Ports[0],
 								},
 							),
@@ -1554,7 +1554,7 @@ func TestDAGInsert(t *testing.T) {
 							object: i6b,
 							services: servicemap(
 								&Service{
-									object:      s1,
+									Object:      s1,
 									ServicePort: &s1.Spec.Ports[0],
 								},
 							),
@@ -1572,7 +1572,7 @@ func TestDAGInsert(t *testing.T) {
 							object: i6b,
 							services: servicemap(
 								&Service{
-									object:      s1,
+									Object:      s1,
 									ServicePort: &s1.Spec.Ports[0],
 								},
 							),
@@ -1615,7 +1615,7 @@ func TestDAGInsert(t *testing.T) {
 							object: ir1,
 							services: servicemap(
 								&Service{
-									object:      s1,
+									Object:      s1,
 									ServicePort: &s1.Spec.Ports[0],
 								},
 							),
@@ -1637,7 +1637,7 @@ func TestDAGInsert(t *testing.T) {
 							object: ir2,
 							services: servicemap(
 								&Service{
-									object:      s2,
+									Object:      s2,
 									ServicePort: &s2.Spec.Ports[0],
 								},
 							),
@@ -1659,11 +1659,11 @@ func TestDAGInsert(t *testing.T) {
 							object: ir2,
 							services: servicemap(
 								&Service{
-									object:      s1,
+									Object:      s1,
 									ServicePort: &s1.Spec.Ports[0],
 								},
 								&Service{
-									object:      s2,
+									Object:      s2,
 									ServicePort: &s2.Spec.Ports[0],
 								},
 							),
@@ -1687,7 +1687,7 @@ func TestDAGInsert(t *testing.T) {
 							object: i10,
 							services: servicemap(
 								&Service{
-									object:      s1,
+									Object:      s1,
 									ServicePort: &s1.Spec.Ports[0],
 								},
 							),
@@ -1704,7 +1704,7 @@ func TestDAGInsert(t *testing.T) {
 							object: i10,
 							services: servicemap(
 								&Service{
-									object:      s1,
+									Object:      s1,
 									ServicePort: &s1.Spec.Ports[0],
 								},
 							),
@@ -1731,7 +1731,7 @@ func TestDAGInsert(t *testing.T) {
 							object: i11,
 							services: servicemap(
 								&Service{
-									object:      s1,
+									Object:      s1,
 									ServicePort: &s1.Spec.Ports[0],
 								},
 							),
@@ -1741,7 +1741,7 @@ func TestDAGInsert(t *testing.T) {
 							object: i11,
 							services: servicemap(
 								&Service{
-									object:      s1,
+									Object:      s1,
 									ServicePort: &s1.Spec.Ports[0],
 								},
 							),
@@ -1766,7 +1766,7 @@ func TestDAGInsert(t *testing.T) {
 							object: i12a,
 							services: servicemap(
 								&Service{
-									object:      s1,
+									Object:      s1,
 									ServicePort: &s1.Spec.Ports[0],
 								},
 							),
@@ -1791,7 +1791,7 @@ func TestDAGInsert(t *testing.T) {
 							object: i12b,
 							services: servicemap(
 								&Service{
-									object:      s1,
+									Object:      s1,
 									ServicePort: &s1.Spec.Ports[0],
 								},
 							),
@@ -1816,7 +1816,7 @@ func TestDAGInsert(t *testing.T) {
 							object: i12c,
 							services: servicemap(
 								&Service{
-									object:      s1,
+									Object:      s1,
 									ServicePort: &s1.Spec.Ports[0],
 								},
 							),
@@ -1840,7 +1840,7 @@ func TestDAGInsert(t *testing.T) {
 							object: ir4,
 							services: servicemap(
 								&Service{
-									object:      s4,
+									Object:      s4,
 									ServicePort: &s4.Spec.Ports[0],
 								},
 							),
@@ -1850,7 +1850,7 @@ func TestDAGInsert(t *testing.T) {
 							object: ir5,
 							services: servicemap(
 								&Service{
-									object:      s5,
+									Object:      s5,
 									ServicePort: &s5.Spec.Ports[0],
 								},
 							),
@@ -1873,7 +1873,7 @@ func TestDAGInsert(t *testing.T) {
 							object: i13a,
 							services: servicemap(
 								&Service{
-									object:      s13a,
+									Object:      s13a,
 									ServicePort: &s13a.Spec.Ports[0],
 								},
 							),
@@ -1884,7 +1884,7 @@ func TestDAGInsert(t *testing.T) {
 							object: i13b,
 							services: servicemap(
 								&Service{
-									object:      s13b,
+									Object:      s13b,
 									ServicePort: &s13b.Spec.Ports[0],
 								},
 							),
@@ -1901,7 +1901,7 @@ func TestDAGInsert(t *testing.T) {
 							object: i13a,
 							services: servicemap(
 								&Service{
-									object:      s13a,
+									Object:      s13a,
 									ServicePort: &s13a.Spec.Ports[0],
 								},
 							),
@@ -1912,7 +1912,7 @@ func TestDAGInsert(t *testing.T) {
 							object: i13b,
 							services: servicemap(
 								&Service{
-									object:      s13b,
+									Object:      s13b,
 									ServicePort: &s13b.Spec.Ports[0],
 								},
 							),
@@ -1938,7 +1938,7 @@ func TestDAGInsert(t *testing.T) {
 							object: i3a,
 							services: servicemap(
 								&Service{
-									object:      s3a,
+									Object:      s3a,
 									Protocol:    "h2c",
 									ServicePort: &s3a.Spec.Ports[0],
 								},
@@ -1962,7 +1962,7 @@ func TestDAGInsert(t *testing.T) {
 							object: i3a,
 							services: servicemap(
 								&Service{
-									object:      s3b,
+									Object:      s3b,
 									Protocol:    "h2",
 									ServicePort: &s3b.Spec.Ports[0],
 								},
@@ -1987,7 +1987,7 @@ func TestDAGInsert(t *testing.T) {
 							object: i1,
 							services: servicemap(
 								&Service{
-									object:             s1b,
+									Object:             s1b,
 									ServicePort:        &s1b.Spec.Ports[0],
 									MaxConnections:     9000,
 									MaxPendingRequests: 4096,
@@ -2506,7 +2506,7 @@ func TestDAGRemove(t *testing.T) {
 							object: i6,
 							services: servicemap(
 								&Service{
-									object:      s1,
+									Object:      s1,
 									ServicePort: &s1.Spec.Ports[0],
 								},
 							),
@@ -2521,7 +2521,7 @@ func TestDAGRemove(t *testing.T) {
 							object: i6,
 							services: servicemap(
 								&Service{
-									object:      s1,
+									Object:      s1,
 									ServicePort: &s1.Spec.Ports[0],
 								},
 							),
@@ -2593,7 +2593,7 @@ func TestDAGRemove(t *testing.T) {
 							object: i7,
 							services: servicemap(
 								&Service{
-									object:      s1,
+									Object:      s1,
 									ServicePort: &s1.Spec.Ports[0],
 								},
 							),
@@ -2731,7 +2731,7 @@ func TestDAGRemove(t *testing.T) {
 							object: ir5,
 							services: servicemap(
 								&Service{
-									object:      s1,
+									Object:      s1,
 									ServicePort: &s1.Spec.Ports[0],
 								},
 							),
@@ -2836,7 +2836,7 @@ func (r *Route) String() string {
 }
 
 func (s *Service) String() string {
-	return fmt.Sprintf("service: %s/%s {serviceport: %v}", s.object.Namespace, s.object.Name, s.ServicePort)
+	return fmt.Sprintf("service: %s/%s {serviceport: %v}", s.Object.Namespace, s.Object.Name, s.ServicePort)
 }
 
 func (s *Secret) String() string {
@@ -2895,7 +2895,7 @@ func TestServiceMapLookup(t *testing.T) {
 			meta: meta{name: "service1", namespace: "default"},
 			port: intstr.FromInt(8080),
 			want: &Service{
-				object:      s1,
+				Object:      s1,
 				ServicePort: &s1.Spec.Ports[0],
 			},
 		},
@@ -2903,7 +2903,7 @@ func TestServiceMapLookup(t *testing.T) {
 			meta: meta{name: "service1", namespace: "default"},
 			port: intstr.FromString("http"),
 			want: &Service{
-				object:      s1,
+				Object:      s1,
 				ServicePort: &s1.Spec.Ports[0],
 			},
 		},
@@ -2911,7 +2911,7 @@ func TestServiceMapLookup(t *testing.T) {
 			meta: meta{name: "service1", namespace: "default"},
 			port: intstr.Parse("8080"),
 			want: &Service{
-				object:      s1,
+				Object:      s1,
 				ServicePort: &s1.Spec.Ports[0],
 			},
 		},
@@ -2919,7 +2919,7 @@ func TestServiceMapLookup(t *testing.T) {
 			meta: meta{name: "service1", namespace: "default"},
 			port: intstr.FromString("8080"),
 			want: &Service{
-				object:      s1,
+				Object:      s1,
 				ServicePort: &s1.Spec.Ports[0],
 			},
 		},


### PR DESCRIPTION
Fixes #506 by adding tests to `actionroute()` in `route.go`.

The downside is that I had to export the `Object` field of the `dag.Service` struct to add these tests.

Tests:
```
=== RUN   TestActionRoute
=== RUN   TestActionRoute/single_service
=== RUN   TestActionRoute/single_service_with_timeout
=== RUN   TestActionRoute/single_service_with_infinite_timeout
=== RUN   TestActionRoute/single_service_with_websockets
=== RUN   TestActionRoute/single_service_with_websockets_and_timeout
=== RUN   TestActionRoute/multiple_services
=== RUN   TestActionRoute/multiple_weighted_services
=== RUN   TestActionRoute/multiple_weighted_services_and_one_with_no_weight_specified
--- PASS: TestActionRoute (0.00s)
    --- PASS: TestActionRoute/single_service (0.00s)
    --- PASS: TestActionRoute/single_service_with_timeout (0.00s)
    --- PASS: TestActionRoute/single_service_with_infinite_timeout (0.00s)
    --- PASS: TestActionRoute/single_service_with_websockets (0.00s)
    --- PASS: TestActionRoute/single_service_with_websockets_and_timeout (0.00s)
    --- PASS: TestActionRoute/multiple_services (0.00s)
    --- PASS: TestActionRoute/multiple_weighted_services (0.00s)
    --- PASS: TestActionRoute/multiple_weighted_services_and_one_with_no_weight_specified (0.00s)
PASS
ok  	github.com/heptio/contour/internal/contour	0.027s
```
