### PR TITLE
internal/dag: fix IngressRouteStatuses.version computation

### DIFF
--- a/internal/dag/dag_test.go
+++ b/internal/dag/dag_test.go
@@ -3736,7 +3736,7 @@ func TestDAGIngressRouteStatus(t *testing.T) {
 		"dag version": {
 			objs:  []*ingressroutev1.IngressRoute{ir1},
 			objs2: []*ingressroutev1.IngressRoute{ir1},
-			want:  IngressrouteStatus{version: 1, statuses: []Status{{object: ir1, status: "valid", description: "valid IngressRoute"}}},
+			want:  IngressrouteStatus{version: 2, statuses: []Status{{object: ir1, status: "valid", description: "valid IngressRoute"}}},
 		},
 	}
 


### PR DESCRIPTION
Updates #445

Cleanup the computation of dag.version, and fix a bug where the version
assigned to the IngressRouteStatus was not incremented, thus
representing the version counter for the dag that would be replaced by
recompute.

The new value of 2 in the test fixture is caused by dh.Insert() calling
recompute internallary, then dh.Recompute() is called directly to
retrieve the current IngressRouteStatus.

Signed-off-by: Dave Cheney <dave@cheney.net>