### PR TITLE
internal/dag: combine ingressroute status with dag roots

### DIFF
--- a/internal/contour/adapter.go
+++ b/internal/contour/adapter.go
@@ -45,7 +45,8 @@ func (d *DAGAdapter) OnAdd(obj interface{}) {
 	if !d.validIngressClass(obj) {
 		return
 	}
-	d.setIngressRouteStatus(d.ResourceEventHandler.OnAdd(obj))
+	d.ResourceEventHandler.OnAdd(obj)
+	d.setIngressRouteStatus()
 	d.updateListeners()
 	d.updateRoutes()
 	d.updateClusters()
@@ -62,7 +63,8 @@ func (d *DAGAdapter) OnUpdate(oldObj, newObj interface{}) {
 		// to remove the old object and _not_ insert the new object.
 		d.OnDelete(oldObj)
 	default:
-		d.setIngressRouteStatus(d.ResourceEventHandler.OnUpdate(oldObj, newObj))
+		d.ResourceEventHandler.OnUpdate(oldObj, newObj)
+		d.setIngressRouteStatus()
 		d.updateListeners()
 		d.updateRoutes()
 		d.updateClusters()
@@ -71,14 +73,15 @@ func (d *DAGAdapter) OnUpdate(oldObj, newObj interface{}) {
 
 func (d *DAGAdapter) OnDelete(obj interface{}) {
 	// no need to check ingress class here
-	d.setIngressRouteStatus(d.ResourceEventHandler.OnDelete(obj))
+	d.ResourceEventHandler.OnDelete(obj)
+	d.setIngressRouteStatus()
 	d.updateListeners()
 	d.updateRoutes()
 	d.updateClusters()
 }
 
-func (d *DAGAdapter) setIngressRouteStatus(statuses dag.IngressrouteStatus) {
-	for _, s := range statuses.GetStatuses() {
+func (d *DAGAdapter) setIngressRouteStatus() {
+	for _, s := range d.Statuses() {
 		err := d.IngressRouteStatus.SetStatus(s.Status, s.Description, s.Object)
 		if err != nil {
 			d.FieldLogger.Errorf("Error Setting Status of IngressRoute: ", err)

--- a/internal/dag/dag_test.go
+++ b/internal/dag/dag_test.go
@@ -3656,92 +3656,77 @@ func TestDAGIngressRouteStatus(t *testing.T) {
 	}
 
 	tests := map[string]struct {
-		objs  []*ingressroutev1.IngressRoute
-		objs2 []*ingressroutev1.IngressRoute
-		want  IngressrouteStatus
+		objs []*ingressroutev1.IngressRoute
+		want []Status
 	}{
 		"valid ingressroute": {
 			objs: []*ingressroutev1.IngressRoute{ir1},
-			want: IngressrouteStatus{statuses: []Status{{Object: ir1, Status: "valid", Description: "valid IngressRoute"}}},
+			want: []Status{{Object: ir1, Status: "valid", Description: "valid IngressRoute"}},
 		},
 		"invalid port in service": {
 			objs: []*ingressroutev1.IngressRoute{ir2},
-			want: IngressrouteStatus{statuses: []Status{{Object: ir2, Status: "invalid", Description: `route "/foo": service "home": port must be in the range 1-65535`}}},
+			want: []Status{{Object: ir2, Status: "invalid", Description: `route "/foo": service "home": port must be in the range 1-65535`}},
 		},
 		"root ingressroute outside of roots namespace": {
 			objs: []*ingressroutev1.IngressRoute{ir3},
-			want: IngressrouteStatus{statuses: []Status{{Object: ir3, Status: "invalid", Description: "root IngressRoute cannot be defined in this namespace"}}},
+			want: []Status{{Object: ir3, Status: "invalid", Description: "root IngressRoute cannot be defined in this namespace"}},
 		},
 		"delegated route's match prefix does not match parent's prefix": {
 			objs: []*ingressroutev1.IngressRoute{ir1, ir4},
-			want: IngressrouteStatus{
-				statuses: []Status{
-					{Object: ir4, Status: "invalid", Description: `the path prefix "/doesnotmatch" does not match the parent's path prefix "/prefix"`},
-					{Object: ir1, Status: "valid", Description: "valid IngressRoute"},
-				},
+			want: []Status{
+				{Object: ir4, Status: "invalid", Description: `the path prefix "/doesnotmatch" does not match the parent's path prefix "/prefix"`},
+				{Object: ir1, Status: "valid", Description: "valid IngressRoute"},
 			},
 		},
 		"invalid weight in service": {
 			objs: []*ingressroutev1.IngressRoute{ir5},
-			want: IngressrouteStatus{statuses: []Status{{Object: ir5, Status: "invalid", Description: `route "/foo": service "home": weight must be greater than or equal to zero`}}},
+			want: []Status{{Object: ir5, Status: "invalid", Description: `route "/foo": service "home": weight must be greater than or equal to zero`}},
 		},
 		"root ingressroute does not specify FQDN": {
 			objs: []*ingressroutev1.IngressRoute{ir13},
-			want: IngressrouteStatus{statuses: []Status{{Object: ir13, Status: "invalid", Description: "Spec.VirtualHost.Fqdn must be specified"}}},
+			want: []Status{{Object: ir13, Status: "invalid", Description: "Spec.VirtualHost.Fqdn must be specified"}},
 		},
 		"self-edge produces a cycle": {
 			objs: []*ingressroutev1.IngressRoute{ir6},
-			want: IngressrouteStatus{statuses: []Status{{Object: ir6, Status: "invalid", Description: "route creates a delegation cycle: roots/self -> roots/self"}}},
+			want: []Status{{Object: ir6, Status: "invalid", Description: "route creates a delegation cycle: roots/self -> roots/self"}},
 		},
 		"child delegates to parent, producing a cycle": {
 			objs: []*ingressroutev1.IngressRoute{ir7, ir8},
-			want: IngressrouteStatus{
-				statuses: []Status{
-					{Object: ir8, Status: "invalid", Description: "route creates a delegation cycle: roots/parent -> roots/child -> roots/parent"},
-					{Object: ir7, Status: "valid", Description: "valid IngressRoute"},
-				},
+			want: []Status{
+				{Object: ir8, Status: "invalid", Description: "route creates a delegation cycle: roots/parent -> roots/child -> roots/parent"},
+				{Object: ir7, Status: "valid", Description: "valid IngressRoute"},
 			},
 		},
 		"route has a list of services and also delegates": {
 			objs: []*ingressroutev1.IngressRoute{ir9},
-			want: IngressrouteStatus{statuses: []Status{{Object: ir9, Status: "invalid", Description: `route "/foo": cannot specify services and delegate in the same route`}}},
+			want: []Status{{Object: ir9, Status: "invalid", Description: `route "/foo": cannot specify services and delegate in the same route`}},
 		},
 		"ingressroute is an orphaned route": {
 			objs: []*ingressroutev1.IngressRoute{ir8},
-			want: IngressrouteStatus{statuses: []Status{{Object: ir8, Status: "orphaned", Description: "this IngressRoute is not part of a delegation chain from a root IngressRoute"}}},
+			want: []Status{{Object: ir8, Status: "orphaned", Description: "this IngressRoute is not part of a delegation chain from a root IngressRoute"}},
 		},
 		"ingressroute delegates to multiple ingressroutes, one is invalid": {
 			objs: []*ingressroutev1.IngressRoute{ir10, ir11, ir12},
-			want: IngressrouteStatus{
-				statuses: []Status{
-					{Object: ir11, Status: "valid", Description: "valid IngressRoute"},
-					{Object: ir12, Status: "invalid", Description: `route "/bar": service "foo": port must be in the range 1-65535`},
-					{Object: ir10, Status: "valid", Description: "valid IngressRoute"}},
+			want: []Status{
+				{Object: ir11, Status: "valid", Description: "valid IngressRoute"},
+				{Object: ir12, Status: "invalid", Description: `route "/bar": service "foo": port must be in the range 1-65535`},
+				{Object: ir10, Status: "valid", Description: "valid IngressRoute"},
 			},
 		},
 		"invalid parent orphans children": {
 			objs: []*ingressroutev1.IngressRoute{ir14, ir11},
-			want: IngressrouteStatus{
-				statuses: []Status{
-					{Object: ir14, Status: "invalid", Description: "Spec.VirtualHost.Fqdn must be specified"},
-					{Object: ir11, Status: "orphaned", Description: "this IngressRoute is not part of a delegation chain from a root IngressRoute"},
-				},
+			want: []Status{
+				{Object: ir14, Status: "invalid", Description: "Spec.VirtualHost.Fqdn must be specified"},
+				{Object: ir11, Status: "orphaned", Description: "this IngressRoute is not part of a delegation chain from a root IngressRoute"},
 			},
 		},
 		"multi-parent children is not orphaned when one of the parents is invalid": {
 			objs: []*ingressroutev1.IngressRoute{ir14, ir11, ir10},
-			want: IngressrouteStatus{
-				statuses: []Status{
-					{Object: ir14, Status: "invalid", Description: "Spec.VirtualHost.Fqdn must be specified"},
-					{Object: ir11, Status: "valid", Description: "valid IngressRoute"},
-					{Object: ir10, Status: "valid", Description: "valid IngressRoute"},
-				},
+			want: []Status{
+				{Object: ir14, Status: "invalid", Description: "Spec.VirtualHost.Fqdn must be specified"},
+				{Object: ir11, Status: "valid", Description: "valid IngressRoute"},
+				{Object: ir10, Status: "valid", Description: "valid IngressRoute"},
 			},
-		},
-		"dag version": {
-			objs:  []*ingressroutev1.IngressRoute{ir1},
-			objs2: []*ingressroutev1.IngressRoute{ir1},
-			want:  IngressrouteStatus{version: 2, statuses: []Status{{Object: ir1, Status: "valid", Description: "valid IngressRoute"}}},
 		},
 	}
 
@@ -3752,14 +3737,15 @@ func TestDAGIngressRouteStatus(t *testing.T) {
 			for _, o := range tc.objs {
 				d.Insert(o)
 			}
-			got := d.Recompute()
-			if len(tc.want.statuses) != len(got.statuses) {
-				t.Fatalf("expected %d statuses, but got %d", len(tc.want.statuses), len(got.statuses))
+			d.Recompute()
+			got := d.Statuses()
+			if len(tc.want) != len(got) {
+				t.Fatalf("expected %d statuses, but got %d", len(tc.want), len(got))
 			}
 
-			for _, ex := range tc.want.statuses {
+			for _, ex := range tc.want {
 				var found bool
-				for _, g := range got.statuses {
+				for _, g := range got {
 					if reflect.DeepEqual(ex, g) {
 						found = true
 						break
@@ -3767,17 +3753,6 @@ func TestDAGIngressRouteStatus(t *testing.T) {
 				}
 				if !found {
 					t.Fatalf("expected to find:\n%v\nbut did not find it in:\n%v", ex, got)
-				}
-			}
-
-			// Run 2nd recompute
-			if tc.objs2 != nil {
-				for _, o := range tc.objs2 {
-					d.Insert(o)
-				}
-				got = d.Recompute()
-				if tc.want.version != got.version {
-					t.Fatalf("expected version %d, but got %d", tc.want.version, got.version)
 				}
 			}
 		})

--- a/internal/dag/k8s.go
+++ b/internal/dag/k8s.go
@@ -18,18 +18,18 @@ type ResourceEventHandler struct {
 	DAG
 }
 
-func (r *ResourceEventHandler) OnAdd(obj interface{}) IngressrouteStatus {
+func (r *ResourceEventHandler) OnAdd(obj interface{}) {
 	r.Insert(obj)
-	return r.Recompute()
+	r.Recompute()
 }
 
-func (r *ResourceEventHandler) OnUpdate(oldObj, newObj interface{}) IngressrouteStatus {
+func (r *ResourceEventHandler) OnUpdate(oldObj, newObj interface{}) {
 	r.Remove(oldObj)
 	r.Insert(newObj)
-	return r.Recompute()
+	r.Recompute()
 }
 
-func (r *ResourceEventHandler) OnDelete(obj interface{}) IngressrouteStatus {
+func (r *ResourceEventHandler) OnDelete(obj interface{}) {
 	r.Remove(obj)
-	return r.Recompute()
+	r.Recompute()
 }


### PR DESCRIPTION
Updates #445

This PR merges the return values from `DAG.recompute`; the `dag.dag` and the
`[]Status` list, into one, the `dag.dag`. Thus a `dag.dag`'s set of roots, and
the status while generating those roots are bound together.

This has the side effect of removing the return parameter from
`DAGAdater`'s `OnAdd`/`Update`/`Remove` methods, allowing it to fulfil the
cache.ResourceEventHandler interface directly.

This PR also merges the `dag.dag.version` and `IngressrouteStatus.version`
field as they were derive from the same place, so storing the value
twice had no value. The `IngressrouteStatus.GetVersion` accessor was not
used and was removed. This meant that IngressrouteStatus was just a
wrapper around `[]Status`, so it was also removed.

A note about skew between the contents of `dag.dag.roots` and
`dad.dag.status`:

Previously `d.Recompute` returned the set of status objects which was
passed to `d.setIngressRouteStatus`, then the` updateLIstener`, `Route`, and
`Cluster` methods were called. Now `d.Recompute` places the status on the
`d.current` field, and `d.setIngressRoute` retrieves it via the `DAG.Statuses`
method.

This PR retains the observed behaviour; status is updated before the
gRPC caches. Neither before or after this PR is there a guarantee that
the gRPC caches would be updated with the _same_ version of the dag that
`d.setIngressResourceStatus` is uses. It was, and still is possible that
each of the four update methods, `d.setIngressRouteStatus`,
`d.updateListeners`, `d.updateRoutes`, and `d.updateClusters` could use a
different version of the dag, either via `DAG.Visit` or `DAG.Statuses` if
multiple k8s watchers fire at the same time.

Signed-off-by: Dave Cheney <dave@cheney.net>