### PR TITLE
internal/dag: remove d.Recompute from dag.ResourceEventHandler

### DIFF
--- a/internal/contour/adapter.go
+++ b/internal/contour/adapter.go
@@ -48,6 +48,7 @@ func (d *DAGAdapter) OnAdd(obj interface{}) {
 		return
 	}
 	d.ResourceEventHandler.OnAdd(obj)
+	d.Recompute()
 	d.setIngressRouteStatus()
 	d.updateListeners()
 	d.updateRoutes()
@@ -67,6 +68,7 @@ func (d *DAGAdapter) OnUpdate(oldObj, newObj interface{}) {
 		d.OnDelete(oldObj)
 	default:
 		d.ResourceEventHandler.OnUpdate(oldObj, newObj)
+		d.Recompute()
 		d.setIngressRouteStatus()
 		d.updateListeners()
 		d.updateRoutes()
@@ -78,6 +80,7 @@ func (d *DAGAdapter) OnUpdate(oldObj, newObj interface{}) {
 func (d *DAGAdapter) OnDelete(obj interface{}) {
 	// no need to check ingress class here
 	d.ResourceEventHandler.OnDelete(obj)
+	d.Recompute()
 	d.setIngressRouteStatus()
 	d.updateListeners()
 	d.updateRoutes()

--- a/internal/dag/k8s.go
+++ b/internal/dag/k8s.go
@@ -20,16 +20,13 @@ type ResourceEventHandler struct {
 
 func (r *ResourceEventHandler) OnAdd(obj interface{}) {
 	r.Insert(obj)
-	r.Recompute()
 }
 
 func (r *ResourceEventHandler) OnUpdate(oldObj, newObj interface{}) {
 	r.Remove(oldObj)
 	r.Insert(newObj)
-	r.Recompute()
 }
 
 func (r *ResourceEventHandler) OnDelete(obj interface{}) {
 	r.Remove(obj)
-	r.Recompute()
 }


### PR DESCRIPTION
This PR moves the call to DAG.Recompute from the
dag.ResourceEventHandler k8s shim to contour.Adapter. This places this
call at the same level as the other post update grpc and status updates.

Signed-off-by: Dave Cheney <dave@cheney.net>