### PR TITLE
internal/dag: make dag.Compute idempotent

### DIFF
--- a/internal/contour/cluster.go
+++ b/internal/contour/cluster.go
@@ -106,19 +106,18 @@ func (c *clusterCache) Values(filter func(string) bool) []proto.Message {
 // clusterVisitor walks a *dag.DAG and produces a map of *v2.Clusters.
 type clusterVisitor struct {
 	*ClusterCache
-	*dag.DAG
+	visitable
 
 	clusters map[string]*v2.Cluster
 }
 
 func (v *clusterVisitor) Visit() map[string]*v2.Cluster {
 	v.clusters = make(map[string]*v2.Cluster)
-	v.DAG.Visit(v.visit)
+	v.visitable.Visit(v.visit)
 	return v.clusters
 }
 
 func (v *clusterVisitor) visit(vertex dag.Vertex) {
-
 	if service, ok := vertex.(*dag.Service); ok {
 		v.edscluster(service)
 	}

--- a/internal/contour/cluster_test.go
+++ b/internal/contour/cluster_test.go
@@ -676,7 +676,7 @@ func TestClusterVisit(t *testing.T) {
 			}
 			v := clusterVisitor{
 				ClusterCache: new(ClusterCache),
-				DAG:          &d.DAG,
+				visitable:    d.Compute(),
 			}
 			got := v.Visit()
 			if !reflect.DeepEqual(tc.want, got) {

--- a/internal/contour/listener.go
+++ b/internal/contour/listener.go
@@ -191,7 +191,7 @@ const (
 
 type listenerVisitor struct {
 	*ListenerCache
-	*dag.DAG
+	visitable
 }
 
 func (v *listenerVisitor) Visit() map[string]*v2.Listener {
@@ -204,7 +204,7 @@ func (v *listenerVisitor) Visit() map[string]*v2.Listener {
 	filters := []listener.Filter{
 		httpfilter(ENVOY_HTTPS_LISTENER, v.httpsAccessLog()),
 	}
-	v.DAG.Visit(func(vh dag.Vertex) {
+	v.visitable.Visit(func(vh dag.Vertex) {
 		switch vh := vh.(type) {
 		case *dag.VirtualHost:
 			// we only create on http listener so record the fact

--- a/internal/contour/listener_test.go
+++ b/internal/contour/listener_test.go
@@ -425,14 +425,13 @@ func TestListenerVisit(t *testing.T) {
 			for _, o := range tc.objs {
 				d.OnAdd(o)
 			}
-			d.Recompute()
 			lc := tc.ListenerCache
 			if lc == nil {
 				lc = new(ListenerCache)
 			}
 			v := listenerVisitor{
 				ListenerCache: lc,
-				DAG:           &d.DAG,
+				visitable:     d.Compute(),
 			}
 			got := v.Visit()
 			if !reflect.DeepEqual(tc.want, got) {

--- a/internal/contour/route.go
+++ b/internal/contour/route.go
@@ -95,7 +95,7 @@ func (c *routeCache) Values(filter func(string) bool) []proto.Message {
 
 type routeVisitor struct {
 	*RouteCache
-	*dag.DAG
+	visitable
 }
 
 func (v *routeVisitor) Visit() map[string]*v2.RouteConfiguration {
@@ -109,7 +109,7 @@ func (v *routeVisitor) Visit() map[string]*v2.RouteConfiguration {
 		ingress_http.Name:  ingress_http,
 		ingress_https.Name: ingress_https,
 	}
-	v.DAG.Visit(func(vh dag.Vertex) {
+	v.visitable.Visit(func(vh dag.Vertex) {
 		switch vh := vh.(type) {
 		case *dag.VirtualHost:
 			hostname := vh.FQDN()

--- a/internal/contour/route_test.go
+++ b/internal/contour/route_test.go
@@ -1183,7 +1183,7 @@ func TestRouteVisit(t *testing.T) {
 			}
 			v := routeVisitor{
 				RouteCache: rc,
-				DAG:        &d.DAG,
+				visitable:  d.Compute(),
 			}
 			got := v.Visit()
 			if !reflect.DeepEqual(tc.want, got) {

--- a/internal/dag/dag_test.go
+++ b/internal/dag/dag_test.go
@@ -1810,10 +1810,10 @@ func TestDAGInsert(t *testing.T) {
 			for _, o := range tc.objs {
 				d.Insert(o)
 			}
-			d.Recompute()
+			dag := d.Compute()
 
 			got := make(map[hostport]Vertex)
-			d.Visit(func(v Vertex) {
+			dag.Visit(func(v Vertex) {
 				switch v := v.(type) {
 				case *VirtualHost:
 					got[hostport{host: v.FQDN(), port: v.Port}] = v
@@ -2527,14 +2527,14 @@ func TestDAGRemove(t *testing.T) {
 			for _, o := range tc.insert {
 				d.Insert(o)
 			}
-			d.Recompute()
+			d.Compute()
 			for _, o := range tc.remove {
 				d.Remove(o)
 			}
-			d.Recompute()
+			dag := d.Compute()
 
 			got := make(map[hostport]Vertex)
-			d.Visit(func(v Vertex) {
+			dag.Visit(func(v Vertex) {
 				switch v := v.(type) {
 				case *VirtualHost:
 					got[hostport{host: v.FQDN(), port: v.Port}] = v
@@ -2718,10 +2718,10 @@ func TestDAGIngressRouteCycle(t *testing.T) {
 	var d DAG
 	d.Insert(ir2)
 	d.Insert(ir1)
-	d.Recompute()
+	dag := d.Compute()
 
 	got := make(map[hostport]*VirtualHost)
-	d.Visit(func(v Vertex) {
+	dag.Visit(func(v Vertex) {
 		if v, ok := v.(*VirtualHost); ok {
 			got[hostport{host: v.FQDN(), port: v.Port}] = v
 		}
@@ -2761,10 +2761,10 @@ func TestDAGIngressRouteCycleSelfEdge(t *testing.T) {
 
 	var d DAG
 	d.Insert(ir1)
-	d.Recompute()
+	dag := d.Compute()
 
 	got := make(map[hostport]*VirtualHost)
-	d.Visit(func(v Vertex) {
+	dag.Visit(func(v Vertex) {
 		if v, ok := v.(*VirtualHost); ok {
 			got[hostport{host: v.FQDN(), port: v.Port}] = v
 		}
@@ -2799,10 +2799,10 @@ func TestDAGIngressRouteDelegatesToNonExistent(t *testing.T) {
 
 	var d DAG
 	d.Insert(ir1)
-	d.Recompute()
+	dag := d.Compute()
 
 	got := make(map[hostport]*VirtualHost)
-	d.Visit(func(v Vertex) {
+	dag.Visit(func(v Vertex) {
 		if v, ok := v.(*VirtualHost); ok {
 			got[hostport{host: v.FQDN(), port: v.Port}] = v
 		}
@@ -2852,10 +2852,10 @@ func TestDAGIngressRouteDelegatePrefixDoesntMatch(t *testing.T) {
 	var d DAG
 	d.Insert(ir2)
 	d.Insert(ir1)
-	d.Recompute()
+	dag := d.Compute()
 
 	got := make(map[hostport]*VirtualHost)
-	d.Visit(func(v Vertex) {
+	dag.Visit(func(v Vertex) {
 		if v, ok := v.(*VirtualHost); ok {
 			got[hostport{host: v.FQDN(), port: v.Port}] = v
 		}
@@ -2959,10 +2959,10 @@ func TestDAGRootNamespaces(t *testing.T) {
 			for _, o := range tc.objs {
 				d.Insert(o)
 			}
-			d.Recompute()
+			dag := d.Compute()
 
 			var count int
-			d.Visit(func(v Vertex) {
+			dag.Visit(func(v Vertex) {
 				if _, ok := v.(*VirtualHost); ok {
 					count++
 				}
@@ -3017,10 +3017,10 @@ func TestDAGIngressRouteDelegatePrefixMatchesStringPrefixButNotPathPrefix(t *tes
 	var d DAG
 	d.Insert(ir2)
 	d.Insert(ir1)
-	d.Recompute()
+	dag := d.Compute()
 
 	got := make(map[hostport]*VirtualHost)
-	d.Visit(func(v Vertex) {
+	dag.Visit(func(v Vertex) {
 		if v, ok := v.(*VirtualHost); ok {
 			got[hostport{host: v.FQDN(), port: v.Port}] = v
 		}
@@ -3474,8 +3474,7 @@ func TestDAGIngressRouteStatus(t *testing.T) {
 			for _, o := range tc.objs {
 				d.Insert(o)
 			}
-			d.Recompute()
-			got := d.Statuses()
+			got := d.Compute().Statuses()
 			if len(tc.want) != len(got) {
 				t.Fatalf("expected %d statuses, but got %d", len(tc.want), len(got))
 			}

--- a/internal/debug/dot.go
+++ b/internal/debug/dot.go
@@ -87,7 +87,7 @@ func (dw *dotWriter) writeDot(w io.Writer) {
 		})
 	}
 
-	dw.DAG.Visit(visit)
+	dw.DAG.Compute().Visit(visit)
 
 	fmt.Fprintln(w, "}")
 }


### PR DESCRIPTION
Updates #445

This is an early PR of the infrastructure to address the O(N) cost of
DAG.Recompute.

This PR replaces DAG.Recompute with a new method, DAG.Compute which
returns a interface with Visit and Statuses methods. This means the
current dag.dag is no longer stored on the parent dag.DAG value.

The result of this is computation of a dag.dag from the source dag.DAG
(I really have to find better names) is now idempotent. The result from
calling DAG.Compute is stable, you can visit it as many times as you
want and it will not change from under you, nor will the values reported
by Statuses skew with respect to Visit.

The intention of this change is to decouple the following

1. DAG.Insert, Remove operations arrising from k8s watchers firing.
These are always handled syncronously inside the watcher loop.
2. DAG.Compute, is called synchronously inside the same loop as 1, but
can in the future be handed off on a channel to another process. That
is, passing the dag.DAG to something else which will call it's Compute
method at some later time.
3. The resulting value from calling DAG.Compute can be handed off again,
or processed in parallel as it is now stable.

One side effect of this change is calles to the debug handler call
DAG.Compute, rather than visiting the most recently computed dag. This
shouldn't be a problem in operation and we can add a cache if this shows
up in profiles.

Signed-off-by: Dave Cheney <dave@cheney.net>