### PR TITLE
Reduce long one liner argument statements into multiple shorter lines

### DIFF
--- a/deployment/deployment-grpc-v2/02-contour.yaml
+++ b/deployment/deployment-grpc-v2/02-contour.yaml
@@ -34,7 +34,12 @@ spec:
         - containerPort: 8443
           name: https
         command: ["envoy"]
-        args: ["-c", "/config/contour.yaml", "--service-cluster", "cluster0", "--service-node", "node0", "-l", "info", "--v2-config-only"]
+        args:
+        - --config-path /config/contour.yaml
+        - --service-cluster cluster0
+        - --service-node node0
+        - --log-level info
+        - --v2-config-only
         volumeMounts:
         - name: contour-config
           mountPath: /config

--- a/deployment/ds-grpc-v2/02-contour.yaml
+++ b/deployment/ds-grpc-v2/02-contour.yaml
@@ -35,7 +35,12 @@ spec:
         - containerPort: 8443
           name: https
         command: ["envoy"]
-        args: ["-c", "/config/contour.yaml", "--service-cluster", "cluster0", "--service-node", "node0", "-l", "info", "--v2-config-only"]
+        args:
+        - --config-path /config/contour.yaml
+        - --service-cluster cluster0
+        - --service-node node0
+        - --log-level info
+        - --v2-config-only
         volumeMounts:
         - name: contour-config
           mountPath: /config

--- a/deployment/ds-hostnet/02-contour.yaml
+++ b/deployment/ds-hostnet/02-contour.yaml
@@ -39,7 +39,12 @@ spec:
         - containerPort: 8443
           name: https
         command: ["envoy"]
-        args: ["-c", "/config/contour.yaml", "--service-cluster", "cluster0", "--service-node", "node0", "-l", "info", "--v2-config-only"]
+        args:
+        - --config-path /config/contour.yaml
+        - --service-cluster cluster0
+        - --service-node node0
+        - --log-level info
+        - --v2-config-only
         volumeMounts:
         - name: contour-config
           mountPath: /config

--- a/deployment/render/daemonset-norbac.yaml
+++ b/deployment/render/daemonset-norbac.yaml
@@ -168,7 +168,12 @@ spec:
         - containerPort: 8443
           name: https
         command: ["envoy"]
-        args: ["-c", "/config/contour.yaml", "--service-cluster", "cluster0", "--service-node", "node0", "-l", "info", "--v2-config-only"]
+        args:
+        - --config-path /config/contour.yaml
+        - --service-cluster cluster0
+        - --service-node node0
+        - --log-level info
+        - --v2-config-only
         volumeMounts:
         - name: contour-config
           mountPath: /config

--- a/deployment/render/daemonset-rbac.yaml
+++ b/deployment/render/daemonset-rbac.yaml
@@ -168,7 +168,12 @@ spec:
         - containerPort: 8443
           name: https
         command: ["envoy"]
-        args: ["-c", "/config/contour.yaml", "--service-cluster", "cluster0", "--service-node", "node0", "-l", "info", "--v2-config-only"]
+        args:
+        - --config-path /config/contour.yaml
+        - --service-cluster cluster0
+        - --service-node node0
+        - --log-level info
+        - --v2-config-only
         volumeMounts:
         - name: contour-config
           mountPath: /config

--- a/deployment/render/deployment-norbac.yaml
+++ b/deployment/render/deployment-norbac.yaml
@@ -167,7 +167,12 @@ spec:
         - containerPort: 8443
           name: https
         command: ["envoy"]
-        args: ["-c", "/config/contour.yaml", "--service-cluster", "cluster0", "--service-node", "node0", "-l", "info", "--v2-config-only"]
+        args:
+        - --config-path /config/contour.yaml
+        - --service-cluster cluster0
+        - --service-node node0
+        - --log-level info
+        - --v2-config-only
         volumeMounts:
         - name: contour-config
           mountPath: /config

--- a/deployment/render/deployment-rbac.yaml
+++ b/deployment/render/deployment-rbac.yaml
@@ -167,7 +167,12 @@ spec:
         - containerPort: 8443
           name: https
         command: ["envoy"]
-        args: ["-c", "/config/contour.yaml", "--service-cluster", "cluster0", "--service-node", "node0", "-l", "info", "--v2-config-only"]
+        args:
+        - --config-path /config/contour.yaml
+        - --service-cluster cluster0
+        - --service-node node0
+        - --log-level info
+        - --v2-config-only
         volumeMounts:
         - name: contour-config
           mountPath: /config

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -75,7 +75,11 @@ arguments may be passed into the contour command:
 
 ```yaml
   command: ["contour"]
-  args: ["serve", "--incluster", "--envoy-http-port=80", "--envoy-https-port=443"]
+  args: 
+  - serve
+  - --incluster
+  - --envoy-http-port=80
+  - --envoy-https-port=443
 ```
 
 See [Issue #547][4]


### PR DESCRIPTION
What does this MR do?

- Reduce long one liner args into multiple lines

Why is this MR needed?

- Enhance readability
- Easier readbility if adding additional optional arguments