### PR TITLE
internal/contour: decouple ResourceEventHandler and CacheHandler

### DIFF
--- a/cmd/contour/contour.go
+++ b/cmd/contour/contour.go
@@ -84,19 +84,21 @@ func main() {
 	serve.Flag("http-address", "address the http endpoint will bind too").Default("127.0.0.1").StringVar(&debug.Addr)
 	serve.Flag("http-port", "port the http endpoint will bind too").Default("8000").IntVar(&debug.Port)
 
-	reh := contour.ResourceEventHandler{
-		CacheHandler: contour.CacheHandler{
-			FieldLogger: log.WithField("context", "DAGAdapter"),
-		},
+	ch := contour.CacheHandler{
+		FieldLogger: log.WithField("context", "DAGAdapter"),
 	}
 
-	serve.Flag("envoy-http-access-log", "Envoy HTTP access log").Default(contour.DEFAULT_HTTP_ACCESS_LOG).StringVar(&reh.HTTPAccessLog)
-	serve.Flag("envoy-https-access-log", "Envoy HTTPS access log").Default(contour.DEFAULT_HTTPS_ACCESS_LOG).StringVar(&reh.HTTPSAccessLog)
-	serve.Flag("envoy-http-address", "Envoy HTTP listener address").StringVar(&reh.HTTPAddress)
-	serve.Flag("envoy-https-address", "Envoy HTTPS listener address").StringVar(&reh.HTTPSAddress)
-	serve.Flag("envoy-http-port", "Envoy HTTP listener port").IntVar(&reh.HTTPPort)
-	serve.Flag("envoy-https-port", "Envoy HTTPS listener port").IntVar(&reh.HTTPSPort)
-	serve.Flag("use-proxy-protocol", "Use PROXY protocol for all listeners").BoolVar(&reh.UseProxyProto)
+	reh := contour.ResourceEventHandler{
+		CacheHandler: &ch,
+	}
+
+	serve.Flag("envoy-http-access-log", "Envoy HTTP access log").Default(contour.DEFAULT_HTTP_ACCESS_LOG).StringVar(&ch.HTTPAccessLog)
+	serve.Flag("envoy-https-access-log", "Envoy HTTPS access log").Default(contour.DEFAULT_HTTPS_ACCESS_LOG).StringVar(&ch.HTTPSAccessLog)
+	serve.Flag("envoy-http-address", "Envoy HTTP listener address").StringVar(&ch.HTTPAddress)
+	serve.Flag("envoy-https-address", "Envoy HTTPS listener address").StringVar(&ch.HTTPSAddress)
+	serve.Flag("envoy-http-port", "Envoy HTTP listener port").IntVar(&ch.HTTPPort)
+	serve.Flag("envoy-https-port", "Envoy HTTPS listener port").IntVar(&ch.HTTPSPort)
+	serve.Flag("use-proxy-protocol", "Use PROXY protocol for all listeners").BoolVar(&ch.UseProxyProto)
 	serve.Flag("ingress-class-name", "Contour IngressClass name").StringVar(&reh.IngressClass)
 	serve.Flag("ingressroute-root-namespaces", "Restrict contour to searching these namespaces for root ingress routes").StringsVar(&reh.IngressRouteRootNamespaces)
 

--- a/cmd/contour/contour.go
+++ b/cmd/contour/contour.go
@@ -89,7 +89,7 @@ func main() {
 	}
 
 	reh := contour.ResourceEventHandler{
-		CacheHandler: &ch,
+		Notifier: &ch,
 	}
 
 	serve.Flag("envoy-http-access-log", "Envoy HTTP access log").Default(contour.DEFAULT_HTTP_ACCESS_LOG).StringVar(&ch.HTTPAccessLog)
@@ -140,7 +140,7 @@ func main() {
 		k8s.WatchSecrets(&g, client, wl, &reh)
 		k8s.WatchIngressRoutes(&g, contourClient, wl, &reh)
 
-		reh.IngressRouteStatus = &k8s.IngressRouteStatus{
+		ch.IngressRouteStatus = &k8s.IngressRouteStatus{
 			Client: contourClient,
 		}
 
@@ -153,7 +153,7 @@ func main() {
 
 		metrics := metrics.NewMetrics(log)
 		metrics.RegisterPrometheus(true)
-		reh.Metrics = metrics
+		ch.Metrics = metrics
 
 		g.Add(func(stop <-chan struct{}) error {
 			debug.Start(stop, metrics.Registry)
@@ -178,9 +178,9 @@ func main() {
 				listenerType = typePrefix + "Listener"
 			)
 			s := grpc.NewAPI(log, map[string]grpc.Cache{
-				clusterType:  &reh.ClusterCache,
-				routeType:    &reh.RouteCache,
-				listenerType: &reh.ListenerCache,
+				clusterType:  &ch.ClusterCache,
+				routeType:    &ch.RouteCache,
+				listenerType: &ch.ListenerCache,
 				endpointType: et,
 			})
 			log.Println("started")

--- a/internal/contour/cachehandler.go
+++ b/internal/contour/cachehandler.go
@@ -38,7 +38,7 @@ type statusable interface {
 	Statuses() []dag.Status
 }
 
-func (ch *CacheHandler) update(b *dag.Builder) {
+func (ch *CacheHandler) OnChange(b *dag.Builder) {
 	dag := b.Compute()
 	ch.setIngressRouteStatus(dag)
 	ch.updateListeners(dag)

--- a/internal/contour/cluster_test.go
+++ b/internal/contour/cluster_test.go
@@ -23,8 +23,6 @@ import (
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 	"github.com/gogo/protobuf/types"
 	ingressroutev1 "github.com/heptio/contour/apis/contour/v1beta1"
-	"github.com/heptio/contour/internal/generated/clientset/versioned/fake"
-	"github.com/heptio/contour/internal/k8s"
 	"k8s.io/api/core/v1"
 	"k8s.io/api/extensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -668,11 +666,7 @@ func TestClusterVisit(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			reh := ResourceEventHandler{
-				CacheHandler: &CacheHandler{
-					IngressRouteStatus: &k8s.IngressRouteStatus{
-						Client: fake.NewSimpleClientset(),
-					},
-				},
+				Notifier: new(nullNotifier),
 			}
 			for _, o := range tc.objs {
 				reh.OnAdd(o)

--- a/internal/contour/cluster_test.go
+++ b/internal/contour/cluster_test.go
@@ -668,7 +668,7 @@ func TestClusterVisit(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			reh := ResourceEventHandler{
-				CacheHandler: CacheHandler{
+				CacheHandler: &CacheHandler{
 					IngressRouteStatus: &k8s.IngressRouteStatus{
 						Client: fake.NewSimpleClientset(),
 					},

--- a/internal/contour/contour_test.go
+++ b/internal/contour/contour_test.go
@@ -17,6 +17,7 @@ import (
 	"testing"
 
 	"github.com/gogo/protobuf/proto"
+	"github.com/heptio/contour/internal/dag"
 	"github.com/sirupsen/logrus"
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -68,3 +69,7 @@ func ports(ps ...int32) []v1.EndpointPort {
 	}
 	return ports
 }
+
+type nullNotifier int
+
+func (nn *nullNotifier) OnChange(b *dag.Builder) {}

--- a/internal/contour/k8s.go
+++ b/internal/contour/k8s.go
@@ -34,7 +34,7 @@ type ResourceEventHandler struct {
 
 	dag.Builder
 
-	CacheHandler
+	*CacheHandler
 }
 
 func (reh *ResourceEventHandler) OnAdd(obj interface{}) {

--- a/internal/contour/k8s.go
+++ b/internal/contour/k8s.go
@@ -34,7 +34,16 @@ type ResourceEventHandler struct {
 
 	dag.Builder
 
-	*CacheHandler
+	Notifier
+}
+
+// Notifier supplies a callback to be called when changes occur
+// to a dag.Builder.
+type Notifier interface {
+
+	// OnChange is called to notify the callee that the
+	// contents of the *dag.Builder have changed.
+	OnChange(*dag.Builder)
 }
 
 func (reh *ResourceEventHandler) OnAdd(obj interface{}) {
@@ -69,7 +78,7 @@ func (reh *ResourceEventHandler) OnDelete(obj interface{}) {
 }
 
 func (reh *ResourceEventHandler) update() {
-	reh.CacheHandler.update(&reh.Builder)
+	reh.OnChange(&reh.Builder)
 }
 
 // validIngressClass returns true iff:

--- a/internal/contour/listener_test.go
+++ b/internal/contour/listener_test.go
@@ -22,8 +22,6 @@ import (
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2/listener"
 	"github.com/gogo/protobuf/types"
 	ingressroutev1 "github.com/heptio/contour/apis/contour/v1beta1"
-	"github.com/heptio/contour/internal/generated/clientset/versioned/fake"
-	"github.com/heptio/contour/internal/k8s"
 	"k8s.io/api/core/v1"
 	"k8s.io/api/extensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -419,11 +417,7 @@ func TestListenerVisit(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			reh := ResourceEventHandler{
-				CacheHandler: &CacheHandler{
-					IngressRouteStatus: &k8s.IngressRouteStatus{
-						Client: fake.NewSimpleClientset(),
-					},
-				},
+				Notifier: new(nullNotifier),
 			}
 			for _, o := range tc.objs {
 				reh.OnAdd(o)

--- a/internal/contour/listener_test.go
+++ b/internal/contour/listener_test.go
@@ -419,7 +419,7 @@ func TestListenerVisit(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			reh := ResourceEventHandler{
-				CacheHandler: CacheHandler{
+				CacheHandler: &CacheHandler{
 					IngressRouteStatus: &k8s.IngressRouteStatus{
 						Client: fake.NewSimpleClientset(),
 					},

--- a/internal/contour/route_test.go
+++ b/internal/contour/route_test.go
@@ -23,8 +23,6 @@ import (
 	"github.com/gogo/protobuf/types"
 	ingressroutev1 "github.com/heptio/contour/apis/contour/v1beta1"
 	"github.com/heptio/contour/internal/dag"
-	"github.com/heptio/contour/internal/generated/clientset/versioned/fake"
-	"github.com/heptio/contour/internal/k8s"
 	"k8s.io/api/core/v1"
 	"k8s.io/api/extensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -1171,11 +1169,7 @@ func TestRouteVisit(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			reh := ResourceEventHandler{
-				CacheHandler: &CacheHandler{
-					IngressRouteStatus: &k8s.IngressRouteStatus{
-						Client: fake.NewSimpleClientset(),
-					},
-				},
+				Notifier: new(nullNotifier),
 			}
 			for _, o := range tc.objs {
 				reh.OnAdd(o)

--- a/internal/contour/route_test.go
+++ b/internal/contour/route_test.go
@@ -1171,7 +1171,7 @@ func TestRouteVisit(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			reh := ResourceEventHandler{
-				CacheHandler: CacheHandler{
+				CacheHandler: &CacheHandler{
 					IngressRouteStatus: &k8s.IngressRouteStatus{
 						Client: fake.NewSimpleClientset(),
 					},

--- a/internal/e2e/e2e.go
+++ b/internal/e2e/e2e.go
@@ -67,7 +67,7 @@ func setup(t *testing.T, opts ...func(*contour.ResourceEventHandler)) (cache.Res
 		FieldLogger: log,
 	}
 	reh := contour.ResourceEventHandler{
-		CacheHandler: contour.CacheHandler{
+		CacheHandler: &contour.CacheHandler{
 			IngressRouteStatus: &k8s.IngressRouteStatus{
 				Client: fake.NewSimpleClientset(),
 			},

--- a/internal/e2e/e2e.go
+++ b/internal/e2e/e2e.go
@@ -66,12 +66,14 @@ func setup(t *testing.T, opts ...func(*contour.ResourceEventHandler)) (cache.Res
 	et := &contour.EndpointsTranslator{
 		FieldLogger: log,
 	}
-	reh := contour.ResourceEventHandler{
-		CacheHandler: &contour.CacheHandler{
-			IngressRouteStatus: &k8s.IngressRouteStatus{
-				Client: fake.NewSimpleClientset(),
-			},
+	ch := &contour.CacheHandler{
+		IngressRouteStatus: &k8s.IngressRouteStatus{
+			Client: fake.NewSimpleClientset(),
 		},
+	}
+
+	reh := contour.ResourceEventHandler{
+		Notifier: ch,
 	}
 
 	for _, opt := range opts {
@@ -84,9 +86,9 @@ func setup(t *testing.T, opts ...func(*contour.ResourceEventHandler)) (cache.Res
 	discard.Out = new(discardWriter)
 	// Resource types in xDS v2.
 	srv := cgrpc.NewAPI(discard, map[string]cgrpc.Cache{
-		clusterType:  &reh.ClusterCache,
-		routeType:    &reh.RouteCache,
-		listenerType: &reh.ListenerCache,
+		clusterType:  &ch.ClusterCache,
+		routeType:    &ch.RouteCache,
+		listenerType: &ch.ListenerCache,
 		endpointType: et,
 	})
 

--- a/internal/e2e/lds_test.go
+++ b/internal/e2e/lds_test.go
@@ -427,7 +427,7 @@ func TestLDSTLSMinimumProtocolVersion(t *testing.T) {
 
 func TestLDSIngressHTTPUseProxyProtocol(t *testing.T) {
 	rh, cc, done := setup(t, func(reh *contour.ResourceEventHandler) {
-		reh.UseProxyProto = true
+		reh.Notifier.(*contour.CacheHandler).UseProxyProto = true
 	})
 	defer done()
 
@@ -472,7 +472,7 @@ func TestLDSIngressHTTPUseProxyProtocol(t *testing.T) {
 
 func TestLDSIngressHTTPSUseProxyProtocol(t *testing.T) {
 	rh, cc, done := setup(t, func(reh *contour.ResourceEventHandler) {
-		reh.UseProxyProto = true
+		reh.Notifier.(*contour.CacheHandler).UseProxyProto = true
 	})
 	defer done()
 
@@ -545,10 +545,10 @@ func TestLDSIngressHTTPSUseProxyProtocol(t *testing.T) {
 
 func TestLDSCustomAddressAndPort(t *testing.T) {
 	rh, cc, done := setup(t, func(reh *contour.ResourceEventHandler) {
-		reh.HTTPAddress = "127.0.0.100"
-		reh.HTTPPort = 9100
-		reh.HTTPSAddress = "127.0.0.200"
-		reh.HTTPSPort = 9200
+		reh.Notifier.(*contour.CacheHandler).HTTPAddress = "127.0.0.100"
+		reh.Notifier.(*contour.CacheHandler).HTTPPort = 9100
+		reh.Notifier.(*contour.CacheHandler).HTTPSAddress = "127.0.0.200"
+		reh.Notifier.(*contour.CacheHandler).HTTPSPort = 9200
 	})
 	defer done()
 
@@ -622,7 +622,7 @@ func TestLDSCustomAddressAndPort(t *testing.T) {
 func TestLDSIngressRouteInsideRootNamespaces(t *testing.T) {
 	rh, cc, done := setup(t, func(reh *contour.ResourceEventHandler) {
 		reh.IngressRouteRootNamespaces = []string{"roots"}
-		reh.IngressRouteStatus = &k8s.IngressRouteStatus{
+		reh.Notifier.(*contour.CacheHandler).IngressRouteStatus = &k8s.IngressRouteStatus{
 			Client: fake.NewSimpleClientset(),
 		}
 	})
@@ -677,7 +677,7 @@ func TestLDSIngressRouteInsideRootNamespaces(t *testing.T) {
 func TestLDSIngressRouteOutsideRootNamespaces(t *testing.T) {
 	rh, cc, done := setup(t, func(reh *contour.ResourceEventHandler) {
 		reh.IngressRouteRootNamespaces = []string{"roots"}
-		reh.IngressRouteStatus = &k8s.IngressRouteStatus{
+		reh.Notifier.(*contour.CacheHandler).IngressRouteStatus = &k8s.IngressRouteStatus{
 			Client: fake.NewSimpleClientset(),
 		}
 	})

--- a/internal/e2e/rds_test.go
+++ b/internal/e2e/rds_test.go
@@ -1165,7 +1165,7 @@ func TestDefaultBackendDoesNotOverwriteNamedHost(t *testing.T) {
 func TestRDSIngressRouteInsideRootNamespaces(t *testing.T) {
 	rh, cc, done := setup(t, func(reh *contour.ResourceEventHandler) {
 		reh.IngressRouteRootNamespaces = []string{"roots"}
-		reh.IngressRouteStatus = &k8s.IngressRouteStatus{
+		reh.Notifier.(*contour.CacheHandler).IngressRouteStatus = &k8s.IngressRouteStatus{
 			Client: fake.NewSimpleClientset(),
 		}
 	})
@@ -1229,7 +1229,7 @@ func TestRDSIngressRouteInsideRootNamespaces(t *testing.T) {
 func TestRDSIngressRouteOutsideRootNamespaces(t *testing.T) {
 	rh, cc, done := setup(t, func(reh *contour.ResourceEventHandler) {
 		reh.IngressRouteRootNamespaces = []string{"roots"}
-		reh.IngressRouteStatus = &k8s.IngressRouteStatus{
+		reh.Notifier.(*contour.CacheHandler).IngressRouteStatus = &k8s.IngressRouteStatus{
 			Client: fake.NewSimpleClientset(),
 		}
 	})

--- a/internal/grpc/server_test.go
+++ b/internal/grpc/server_test.go
@@ -180,13 +180,14 @@ func TestGRPCStreaming(t *testing.T) {
 			et = &contour.EndpointsTranslator{
 				FieldLogger: log,
 			}
+			var ch contour.CacheHandler
 			reh = &contour.ResourceEventHandler{
-				CacheHandler: new(contour.CacheHandler),
+				Notifier: &ch,
 			}
 			srv := NewAPI(log, map[string]Cache{
-				clusterType:  &reh.ClusterCache,
-				routeType:    &reh.RouteCache,
-				listenerType: &reh.ListenerCache,
+				clusterType:  &ch.ClusterCache,
+				routeType:    &ch.RouteCache,
+				listenerType: &ch.ListenerCache,
 				endpointType: et,
 			})
 			var err error
@@ -275,13 +276,11 @@ func TestGRPCFetching(t *testing.T) {
 			et := &contour.EndpointsTranslator{
 				FieldLogger: log,
 			}
-			reh := &contour.ResourceEventHandler{
-				CacheHandler: new(contour.CacheHandler),
-			}
+			var ch contour.CacheHandler
 			srv := NewAPI(log, map[string]Cache{
-				clusterType:  &reh.ClusterCache,
-				routeType:    &reh.RouteCache,
-				listenerType: &reh.ListenerCache,
+				clusterType:  &ch.ClusterCache,
+				routeType:    &ch.RouteCache,
+				listenerType: &ch.ListenerCache,
 				endpointType: et,
 			})
 			var err error

--- a/internal/grpc/server_test.go
+++ b/internal/grpc/server_test.go
@@ -180,7 +180,9 @@ func TestGRPCStreaming(t *testing.T) {
 			et = &contour.EndpointsTranslator{
 				FieldLogger: log,
 			}
-			reh = new(contour.ResourceEventHandler)
+			reh = &contour.ResourceEventHandler{
+				CacheHandler: new(contour.CacheHandler),
+			}
 			srv := NewAPI(log, map[string]Cache{
 				clusterType:  &reh.ClusterCache,
 				routeType:    &reh.RouteCache,
@@ -273,7 +275,9 @@ func TestGRPCFetching(t *testing.T) {
 			et := &contour.EndpointsTranslator{
 				FieldLogger: log,
 			}
-			var reh contour.ResourceEventHandler
+			reh := &contour.ResourceEventHandler{
+				CacheHandler: new(contour.CacheHandler),
+			}
 			srv := NewAPI(log, map[string]Cache{
 				clusterType:  &reh.ClusterCache,
 				routeType:    &reh.RouteCache,


### PR DESCRIPTION
Fixes #576 

Introduce contour.Notifier to break the coupling between `contour.ResourceEventHandler` and `contour.CacheHandler`. The former is now only concerned with converting k8s watcher events into `dag.Builder` `Insert` and `Remove`s. After each event it calls `Notifier.OnChange` with the `dag.Builder`.
    
This has had some nice flow on effects into the contour tests, which are now completely unconcerned with the `CacheHandler` at all, they just care about calling visit on the results of calling `Compute` on a `*dag.Builder` passed to `Notifier.OnChange`.
    
On the downside, the type assertions added to the internal/e2e tests will certainly make me curse my former self when they blow up the next time I touch the types in internal/contour. So I've got that going for me.