### PR TITLE
internal/metrics: refactor metrics package

### DIFF
--- a/cmd/contour/contour.go
+++ b/cmd/contour/contour.go
@@ -159,8 +159,7 @@ func main() {
 		registry.MustRegister(prometheus.NewGoCollector())
 
 		// register our custom metrics
-		metrics := metrics.NewMetrics()
-		metrics.RegisterPrometheus(registry)
+		metrics := metrics.NewMetrics(registry)
 		ch.Metrics = metrics
 
 		g.Add(func(stop <-chan struct{}) error {

--- a/cmd/contour/contour.go
+++ b/cmd/contour/contour.go
@@ -159,7 +159,7 @@ func main() {
 		registry.MustRegister(prometheus.NewGoCollector())
 
 		// register our custom metrics
-		metrics := metrics.NewMetrics(log)
+		metrics := metrics.NewMetrics()
 		metrics.RegisterPrometheus(registry)
 		ch.Metrics = metrics
 

--- a/internal/contour/cachehandler.go
+++ b/internal/contour/cachehandler.go
@@ -31,7 +31,7 @@ type CacheHandler struct {
 
 	IngressRouteStatus *k8s.IngressRouteStatus
 	logrus.FieldLogger
-	metrics.Metrics
+	*metrics.Metrics
 }
 
 type statusable interface {

--- a/internal/e2e/e2e.go
+++ b/internal/e2e/e2e.go
@@ -28,6 +28,8 @@ import (
 	"github.com/heptio/contour/internal/generated/clientset/versioned/fake"
 	cgrpc "github.com/heptio/contour/internal/grpc"
 	"github.com/heptio/contour/internal/k8s"
+	"github.com/heptio/contour/internal/metrics"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
 	"google.golang.org/grpc"
 	"k8s.io/api/core/v1"
@@ -66,10 +68,13 @@ func setup(t *testing.T, opts ...func(*contour.ResourceEventHandler)) (cache.Res
 	et := &contour.EndpointsTranslator{
 		FieldLogger: log,
 	}
+
+	r := prometheus.NewRegistry()
 	ch := &contour.CacheHandler{
 		IngressRouteStatus: &k8s.IngressRouteStatus{
 			Client: fake.NewSimpleClientset(),
 		},
+		Metrics: metrics.NewMetrics(r),
 	}
 
 	reh := contour.ResourceEventHandler{

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -14,16 +14,13 @@
 package metrics
 
 import (
-	"os"
-
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
 )
 
 // Metrics provide Prometheus metrics for the app
 type Metrics struct {
-	Registry *prometheus.Registry
-	Metrics  map[string]prometheus.Collector
+	Metrics map[string]prometheus.Collector
 	logrus.FieldLogger
 }
 
@@ -52,7 +49,6 @@ const (
 // NewMetrics returns a map of Prometheus metrics
 func NewMetrics(logger logrus.FieldLogger) Metrics {
 	return Metrics{
-		Registry:    prometheus.NewRegistry(),
 		FieldLogger: logger,
 		Metrics: map[string]prometheus.Collector{
 			IngressRouteTotalGauge: prometheus.NewGaugeVec(
@@ -95,17 +91,9 @@ func NewMetrics(logger logrus.FieldLogger) Metrics {
 }
 
 // RegisterPrometheus registers the Metrics
-func (m *Metrics) RegisterPrometheus(registerDefault bool) {
-
-	if registerDefault {
-		// Register detault process / go collectors
-		m.Registry.MustRegister(prometheus.NewProcessCollector(os.Getpid(), ""))
-		m.Registry.MustRegister(prometheus.NewGoCollector())
-	}
-
-	// Register with Prometheus's default registry
+func (m *Metrics) RegisterPrometheus(registry *prometheus.Registry) {
 	for _, v := range m.Metrics {
-		m.Registry.MustRegister(v)
+		registry.MustRegister(v)
 	}
 }
 

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -19,7 +19,7 @@ import (
 
 // Metrics provide Prometheus metrics for the app
 type Metrics struct {
-	Metrics map[string]prometheus.Collector
+	metrics map[string]prometheus.Collector
 }
 
 // IngressRouteMetric stores various metrics for IngressRoute objects
@@ -47,7 +47,7 @@ const (
 // NewMetrics returns a new Metrics value.
 func NewMetrics() Metrics {
 	return Metrics{
-		Metrics: map[string]prometheus.Collector{
+		metrics: map[string]prometheus.Collector{
 			IngressRouteTotalGauge: prometheus.NewGaugeVec(
 				prometheus.GaugeOpts{
 					Name: IngressRouteTotalGauge,
@@ -89,7 +89,7 @@ func NewMetrics() Metrics {
 
 // RegisterPrometheus registers the Metrics
 func (m *Metrics) RegisterPrometheus(registry *prometheus.Registry) {
-	for _, v := range m.Metrics {
+	for _, v := range m.metrics {
 		registry.MustRegister(v)
 	}
 }
@@ -98,31 +98,31 @@ func (m *Metrics) RegisterPrometheus(registry *prometheus.Registry) {
 func (m *Metrics) SetIngressRouteMetric(metrics IngressRouteMetric) {
 
 	for meta, value := range metrics.Total {
-		m, ok := m.Metrics[IngressRouteTotalGauge].(*prometheus.GaugeVec)
+		m, ok := m.metrics[IngressRouteTotalGauge].(*prometheus.GaugeVec)
 		if ok {
 			m.WithLabelValues(meta.Namespace).Set(float64(value))
 		}
 	}
 	for meta, value := range metrics.Invalid {
-		m, ok := m.Metrics[IngressRouteInvalidGauge].(*prometheus.GaugeVec)
+		m, ok := m.metrics[IngressRouteInvalidGauge].(*prometheus.GaugeVec)
 		if ok {
 			m.WithLabelValues(meta.Namespace, meta.VHost).Set(float64(value))
 		}
 	}
 	for meta, value := range metrics.Orphaned {
-		m, ok := m.Metrics[IngressRouteOrphanedGauge].(*prometheus.GaugeVec)
+		m, ok := m.metrics[IngressRouteOrphanedGauge].(*prometheus.GaugeVec)
 		if ok {
 			m.WithLabelValues(meta.Namespace).Set(float64(value))
 		}
 	}
 	for meta, value := range metrics.Valid {
-		m, ok := m.Metrics[IngressRouteValidGauge].(*prometheus.GaugeVec)
+		m, ok := m.metrics[IngressRouteValidGauge].(*prometheus.GaugeVec)
 		if ok {
 			m.WithLabelValues(meta.Namespace, meta.VHost).Set(float64(value))
 		}
 	}
 	for meta, value := range metrics.Root {
-		m, ok := m.Metrics[IngressRouteRootTotalGauge].(*prometheus.GaugeVec)
+		m, ok := m.metrics[IngressRouteRootTotalGauge].(*prometheus.GaugeVec)
 		if ok {
 			m.WithLabelValues(meta.Namespace).Set(float64(value))
 		}

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -44,9 +44,10 @@ const (
 	IngressRouteOrphanedGauge  = "contour_ingressroute_orphaned_total"
 )
 
-// NewMetrics returns a new Metrics value.
-func NewMetrics() Metrics {
-	return Metrics{
+// NewMetrics creates a new set of metrics and registers them with
+// the supplied registry.
+func NewMetrics(registry *prometheus.Registry) *Metrics {
+	m := Metrics{
 		metrics: map[string]prometheus.Collector{
 			IngressRouteTotalGauge: prometheus.NewGaugeVec(
 				prometheus.GaugeOpts{
@@ -85,10 +86,12 @@ func NewMetrics() Metrics {
 			),
 		},
 	}
+	m.register(registry)
+	return &m
 }
 
-// RegisterPrometheus registers the Metrics
-func (m *Metrics) RegisterPrometheus(registry *prometheus.Registry) {
+// register registers the Metrics with the supplied registry.
+func (m *Metrics) register(registry *prometheus.Registry) {
 	for _, v := range m.metrics {
 		registry.MustRegister(v)
 	}

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -15,13 +15,11 @@ package metrics
 
 import (
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/sirupsen/logrus"
 )
 
 // Metrics provide Prometheus metrics for the app
 type Metrics struct {
 	Metrics map[string]prometheus.Collector
-	logrus.FieldLogger
 }
 
 // IngressRouteMetric stores various metrics for IngressRoute objects
@@ -46,10 +44,9 @@ const (
 	IngressRouteOrphanedGauge  = "contour_ingressroute_orphaned_total"
 )
 
-// NewMetrics returns a map of Prometheus metrics
-func NewMetrics(logger logrus.FieldLogger) Metrics {
+// NewMetrics returns a new Metrics value.
+func NewMetrics() Metrics {
 	return Metrics{
-		FieldLogger: logger,
 		Metrics: map[string]prometheus.Collector{
 			IngressRouteTotalGauge: prometheus.NewGaugeVec(
 				prometheus.GaugeOpts{

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -20,7 +20,6 @@ import (
 	"github.com/prometheus/client_model/go"
 
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/sirupsen/logrus"
 )
 
 type testMetric struct {
@@ -147,7 +146,7 @@ func TestWriteMetric(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			r := prometheus.NewRegistry()
-			m := NewMetrics(logrus.New())
+			m := NewMetrics()
 			m.RegisterPrometheus(r)
 			m.SetIngressRouteMetric(tc.irMetrics)
 

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -146,12 +146,13 @@ func TestWriteMetric(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
+			r := prometheus.NewRegistry()
 			m := NewMetrics(logrus.New())
-			m.RegisterPrometheus(false)
+			m.RegisterPrometheus(r)
 			m.SetIngressRouteMetric(tc.irMetrics)
 
 			gatherers := prometheus.Gatherers{
-				m.Registry,
+				r,
 				prometheus.DefaultGatherer,
 			}
 

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -146,8 +146,7 @@ func TestWriteMetric(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			r := prometheus.NewRegistry()
-			m := NewMetrics()
-			m.RegisterPrometheus(r)
+			m := NewMetrics(r)
 			m.SetIngressRouteMetric(tc.irMetrics)
 
 			gatherers := prometheus.Gatherers{


### PR DESCRIPTION
Updates #575 
Updates #576 

This is a cleanup PR before adding the counters for #575 and #576.

- The creation of a registry is now handled by the caller of `metrics.NewMetrics`, this removes the need the boolean parameter to `metrics.RegisterMetrics`
- As the boolean is removed, metrics are automatically registered with a registry supplied by the called to `metrics.NewMetrics`
- Storing counters in a map is replaced by storing them as fields on the metrics object. This removed a bunch of type assertions and showed a bug in the e2e tests where metrics were not being properly initialised and thus discarded during e2e tests.