### PR TITLE
internal/contour: add CacheHandler.OnUpdate metrics

### DIFF
--- a/internal/contour/cachehandler.go
+++ b/internal/contour/cachehandler.go
@@ -20,6 +20,7 @@ import (
 	"github.com/heptio/contour/internal/dag"
 	"github.com/heptio/contour/internal/k8s"
 	"github.com/heptio/contour/internal/metrics"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
 )
 
@@ -39,6 +40,8 @@ type statusable interface {
 }
 
 func (ch *CacheHandler) OnChange(b *dag.Builder) {
+	timer := prometheus.NewTimer(ch.CacheHandlerOnUpdateSummary)
+	defer timer.ObserveDuration()
 	dag := b.Compute()
 	ch.setIngressRouteStatus(dag)
 	ch.updateListeners(dag)

--- a/internal/grpc/server_test.go
+++ b/internal/grpc/server_test.go
@@ -22,6 +22,8 @@ import (
 
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	"github.com/heptio/contour/internal/contour"
+	"github.com/heptio/contour/internal/metrics"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -180,7 +182,9 @@ func TestGRPCStreaming(t *testing.T) {
 			et = &contour.EndpointsTranslator{
 				FieldLogger: log,
 			}
-			var ch contour.CacheHandler
+			ch := contour.CacheHandler{
+				Metrics: metrics.NewMetrics(prometheus.NewRegistry()),
+			}
 			reh = &contour.ResourceEventHandler{
 				Notifier: &ch,
 			}
@@ -276,7 +280,9 @@ func TestGRPCFetching(t *testing.T) {
 			et := &contour.EndpointsTranslator{
 				FieldLogger: log,
 			}
-			var ch contour.CacheHandler
+			ch := contour.CacheHandler{
+				Metrics: metrics.NewMetrics(prometheus.NewRegistry()),
+			}
 			srv := NewAPI(log, map[string]Cache{
 				clusterType:  &ch.ClusterCache,
 				routeType:    &ch.RouteCache,

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -24,6 +24,8 @@ type Metrics struct {
 	ingressRouteInvalidGauge   *prometheus.GaugeVec
 	ingressRouteValidGauge     *prometheus.GaugeVec
 	ingressRouteOrphanedGauge  *prometheus.GaugeVec
+
+	CacheHandlerOnUpdateSummary prometheus.Summary
 }
 
 // IngressRouteMetric stores various metrics for IngressRoute objects
@@ -46,6 +48,8 @@ const (
 	IngressRouteInvalidGauge   = "contour_ingressroute_invalid_total"
 	IngressRouteValidGauge     = "contour_ingressroute_valid_total"
 	IngressRouteOrphanedGauge  = "contour_ingressroute_orphaned_total"
+
+	cacheHandlerOnUpdateSummary = "contour_cachehandler_onupdate_duration_seconds"
 )
 
 // NewMetrics creates a new set of metrics and registers them with
@@ -87,6 +91,11 @@ func NewMetrics(registry *prometheus.Registry) *Metrics {
 			},
 			[]string{"namespace"},
 		),
+		CacheHandlerOnUpdateSummary: prometheus.NewSummary(prometheus.SummaryOpts{
+			Name:       cacheHandlerOnUpdateSummary,
+			Help:       "Histogram for the runtime of xDS cache regeneration",
+			Objectives: map[float64]float64{0.5: 0.05, 0.9: 0.01, 0.99: 0.001},
+		}),
 	}
 	m.register(registry)
 	return &m
@@ -100,6 +109,7 @@ func (m *Metrics) register(registry *prometheus.Registry) {
 		m.ingressRouteInvalidGauge,
 		m.ingressRouteValidGauge,
 		m.ingressRouteOrphanedGauge,
+		m.CacheHandlerOnUpdateSummary,
 	)
 }
 


### PR DESCRIPTION
Fixes #575

Add prometheus metrics for CacheHandler.OnUpdate duration.

Signed-off-by: Dave Cheney <dave@cheney.net>