### PR TITLE
internal/contour: add ResourceEventHandler metrics

### DIFF
--- a/cmd/contour/contour.go
+++ b/cmd/contour/contour.go
@@ -161,6 +161,7 @@ func main() {
 		// register our custom metrics
 		metrics := metrics.NewMetrics(registry)
 		ch.Metrics = metrics
+		reh.Metrics = metrics
 
 		g.Add(func(stop <-chan struct{}) error {
 			debug.Start(stop, registry)

--- a/internal/contour/cluster_test.go
+++ b/internal/contour/cluster_test.go
@@ -23,6 +23,8 @@ import (
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 	"github.com/gogo/protobuf/types"
 	ingressroutev1 "github.com/heptio/contour/apis/contour/v1beta1"
+	"github.com/heptio/contour/internal/metrics"
+	"github.com/prometheus/client_golang/prometheus"
 	"k8s.io/api/core/v1"
 	"k8s.io/api/extensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -667,6 +669,7 @@ func TestClusterVisit(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			reh := ResourceEventHandler{
 				Notifier: new(nullNotifier),
+				Metrics:  metrics.NewMetrics(prometheus.NewRegistry()),
 			}
 			for _, o := range tc.objs {
 				reh.OnAdd(o)

--- a/internal/contour/listener_test.go
+++ b/internal/contour/listener_test.go
@@ -22,6 +22,8 @@ import (
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2/listener"
 	"github.com/gogo/protobuf/types"
 	ingressroutev1 "github.com/heptio/contour/apis/contour/v1beta1"
+	"github.com/heptio/contour/internal/metrics"
+	"github.com/prometheus/client_golang/prometheus"
 	"k8s.io/api/core/v1"
 	"k8s.io/api/extensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -418,6 +420,7 @@ func TestListenerVisit(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			reh := ResourceEventHandler{
 				Notifier: new(nullNotifier),
+				Metrics:  metrics.NewMetrics(prometheus.NewRegistry()),
 			}
 			for _, o := range tc.objs {
 				reh.OnAdd(o)

--- a/internal/contour/route_test.go
+++ b/internal/contour/route_test.go
@@ -23,6 +23,8 @@ import (
 	"github.com/gogo/protobuf/types"
 	ingressroutev1 "github.com/heptio/contour/apis/contour/v1beta1"
 	"github.com/heptio/contour/internal/dag"
+	"github.com/heptio/contour/internal/metrics"
+	"github.com/prometheus/client_golang/prometheus"
 	"k8s.io/api/core/v1"
 	"k8s.io/api/extensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -1170,6 +1172,7 @@ func TestRouteVisit(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			reh := ResourceEventHandler{
 				Notifier: new(nullNotifier),
+				Metrics:  metrics.NewMetrics(prometheus.NewRegistry()),
 			}
 			for _, o := range tc.objs {
 				reh.OnAdd(o)

--- a/internal/e2e/e2e.go
+++ b/internal/e2e/e2e.go
@@ -79,6 +79,7 @@ func setup(t *testing.T, opts ...func(*contour.ResourceEventHandler)) (cache.Res
 
 	reh := contour.ResourceEventHandler{
 		Notifier: ch,
+		Metrics:  ch.Metrics,
 	}
 
 	for _, opt := range opts {

--- a/internal/grpc/server_test.go
+++ b/internal/grpc/server_test.go
@@ -187,6 +187,7 @@ func TestGRPCStreaming(t *testing.T) {
 			}
 			reh = &contour.ResourceEventHandler{
 				Notifier: &ch,
+				Metrics:  ch.Metrics,
 			}
 			srv := NewAPI(log, map[string]Cache{
 				clusterType:  &ch.ClusterCache,

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -26,6 +26,7 @@ type Metrics struct {
 	ingressRouteOrphanedGauge  *prometheus.GaugeVec
 
 	CacheHandlerOnUpdateSummary prometheus.Summary
+	ResourceEventHandlerSummary *prometheus.SummaryVec
 }
 
 // IngressRouteMetric stores various metrics for IngressRoute objects
@@ -50,6 +51,7 @@ const (
 	IngressRouteOrphanedGauge  = "contour_ingressroute_orphaned_total"
 
 	cacheHandlerOnUpdateSummary = "contour_cachehandler_onupdate_duration_seconds"
+	resourceEventHandlerSummary = "contour_resourceeventhandler_duration_seconds"
 )
 
 // NewMetrics creates a new set of metrics and registers them with
@@ -96,6 +98,13 @@ func NewMetrics(registry *prometheus.Registry) *Metrics {
 			Help:       "Histogram for the runtime of xDS cache regeneration",
 			Objectives: map[float64]float64{0.5: 0.05, 0.9: 0.01, 0.99: 0.001},
 		}),
+		ResourceEventHandlerSummary: prometheus.NewSummaryVec(prometheus.SummaryOpts{
+			Name:       resourceEventHandlerSummary,
+			Help:       "Histogram for the runtime of k8s watcher events",
+			Objectives: map[float64]float64{0.5: 0.05, 0.9: 0.01, 0.99: 0.001},
+		},
+			[]string{"op"},
+		),
 	}
 	m.register(registry)
 	return &m
@@ -110,6 +119,7 @@ func (m *Metrics) register(registry *prometheus.Registry) {
 		m.ingressRouteValidGauge,
 		m.ingressRouteOrphanedGauge,
 		m.CacheHandlerOnUpdateSummary,
+		m.ResourceEventHandlerSummary,
 	)
 }
 


### PR DESCRIPTION
Fixes #574

Emit prometheus metrics for ResourceEventHandler events.

Signed-off-by: Dave Cheney <dave@cheney.net>