### PR TITLE
internal/contour: add HoldoffNotifier

### DIFF
--- a/cmd/contour/contour.go
+++ b/cmd/contour/contour.go
@@ -89,11 +89,14 @@ func main() {
 	serve.Flag("http-port", "port the http endpoint will bind too").Default("8000").IntVar(&debug.Port)
 
 	ch := contour.CacheHandler{
-		FieldLogger: log.WithField("context", "DAGAdapter"),
+		FieldLogger: log.WithField("context", "CacheHandler"),
 	}
 
 	reh := contour.ResourceEventHandler{
-		Notifier: &ch,
+		Notifier: &contour.HoldoffNotifier{
+			Notifier:    &ch,
+			FieldLogger: log.WithField("context", "HoldoffNotifier"),
+		},
 	}
 
 	serve.Flag("envoy-http-access-log", "Envoy HTTP access log").Default(contour.DEFAULT_HTTP_ACCESS_LOG).StringVar(&ch.HTTPAccessLog)

--- a/internal/contour/holdoff.go
+++ b/internal/contour/holdoff.go
@@ -1,0 +1,69 @@
+// Copyright © 2018 Heptio
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package contour contains the translation business logic that listens
+// to Kubernetes ResourceEventHandler events and translates those into
+// additions/deletions in caches connected to the Envoy xDS gRPC API server.
+package contour
+
+import (
+	"sync"
+	"time"
+
+	"github.com/heptio/contour/internal/dag"
+	"github.com/sirupsen/logrus"
+)
+
+const (
+	holdoffDelay    = 100 * time.Millisecond
+	holdoffMaxDelay = 500 * time.Millisecond
+)
+
+// A HoldoffNotifier delays calls to OnChange in the hope of
+// coalescing rapid calls into a single update.
+type HoldoffNotifier struct {
+
+	// Notifier to be called after delay.
+	Notifier
+
+	logrus.FieldLogger
+
+	mu    sync.Mutex
+	timer *time.Timer
+	last  time.Time
+}
+
+func (hn *HoldoffNotifier) OnChange(builder *dag.Builder) {
+	hn.mu.Lock()
+	defer hn.mu.Unlock()
+	if hn.timer != nil {
+		hn.timer.Stop()
+	}
+	since := time.Since(hn.last)
+	if since > 500*time.Millisecond {
+		// update immediately
+		hn.WithField("last update", since).Info("forcing update")
+		hn.Notifier.OnChange(builder)
+		hn.last = time.Now()
+		return
+	}
+
+	hn.WithField("remaining", holdoffMaxDelay-since).Info("delaying update")
+	hn.timer = time.AfterFunc(holdoffDelay, func() {
+		hn.mu.Lock()
+		defer hn.mu.Unlock()
+		hn.WithField("last update", time.Since(hn.last)).Info("performing delayed update")
+		hn.Notifier.OnChange(builder)
+		hn.last = time.Now()
+	})
+}


### PR DESCRIPTION
Fixes #577

This PR introduces a HoldoffNotifier implementation that delays the
notification of the underlying Notifier by 100 ms since the previous
call to HoldoffNotifier.OnChange or 500ms, whichever is the smaller.

The 100ms/500ms values are currently hard coded, a future PR may make
them configurable, which will allow this type to be used in the e2e
tests -- currently the e2e tests go directly to the
contour.CacheHandler Notifier.

Tracing shows a modest improvement in utilisation before:

![screen shot 2018-07-26 at 8 08 27 pm](https://user-images.githubusercontent.com/7171/43256317-b8e494e8-910f-11e8-9eea-3b99877466db.png)

And after:

![screen shot 2018-07-26 at 8 09 04 pm](https://user-images.githubusercontent.com/7171/43256335-c075652a-910f-11e8-87f2-f42b16369bc6.png)

This change. This is synthetic data where the dag.Builder contains a lot of services and ingresses, but few match (as the fixture is random data), so the resulting dag.DAG will be small.

Signed-off-by: Dave Cheney <dave@cheney.net>