### PR TITLE
cmd/contour: split /metrics and /health away from /debug endpoint

### DIFF
--- a/cmd/contour/contour.go
+++ b/cmd/contour/contour.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/heptio/contour/internal/debug"
 	clientset "github.com/heptio/contour/internal/generated/clientset/versioned"
+	"github.com/heptio/contour/internal/httpsvc"
 	"github.com/heptio/workgroup"
 	"github.com/prometheus/client_golang/prometheus"
 	kingpin "gopkg.in/alecthomas/kingpin.v2"
@@ -82,7 +83,9 @@ func main() {
 
 	// configuration parameters for debug service
 	debug := debug.Service{
-		FieldLogger: log.WithField("context", "debugsvc"),
+		Service: httpsvc.Service{
+			FieldLogger: log.WithField("context", "debugsvc"),
+		},
 	}
 
 	serve.Flag("http-address", "address the http endpoint will bind too").Default("127.0.0.1").StringVar(&debug.Addr)

--- a/cmd/contour/contour.go
+++ b/cmd/contour/contour.go
@@ -81,16 +81,6 @@ func main() {
 	xdsAddr := serve.Flag("xds-address", "xDS gRPC API address").Default("127.0.0.1").String()
 	xdsPort := serve.Flag("xds-port", "xDS gRPC API port").Default("8001").Int()
 
-	// configuration parameters for debug service
-	debug := debug.Service{
-		Service: httpsvc.Service{
-			FieldLogger: log.WithField("context", "debugsvc"),
-		},
-	}
-
-	serve.Flag("http-address", "address the http endpoint will bind too").Default("127.0.0.1").StringVar(&debug.Addr)
-	serve.Flag("http-port", "port the http endpoint will bind too").Default("8000").IntVar(&debug.Port)
-
 	ch := contour.CacheHandler{
 		FieldLogger: log.WithField("context", "CacheHandler"),
 	}
@@ -101,6 +91,28 @@ func main() {
 			FieldLogger: log.WithField("context", "HoldoffNotifier"),
 		},
 	}
+
+	// configuration parameters for debug service
+	debugsvc := debug.Service{
+		Service: httpsvc.Service{
+			FieldLogger: log.WithField("context", "debugsvc"),
+		},
+		// plumb the DAGAdapter's Builder through
+		// to the debug handler
+		Builder: &reh.Builder,
+	}
+
+	serve.Flag("debug-http-address", "address the debug http endpoint will bind too").Default("127.0.0.1").StringVar(&debugsvc.Addr)
+	serve.Flag("debug-http-port", "port the debug http endpoint will bind too").Default("6060").IntVar(&debugsvc.Port)
+
+	metricsvc := metrics.Service{
+		Service: httpsvc.Service{
+			FieldLogger: log.WithField("context", "metricsvc"),
+		},
+	}
+
+	serve.Flag("http-address", "address the metrics http endpoint will bind too").Default("0.0.0.0").StringVar(&metricsvc.Addr)
+	serve.Flag("http-port", "port the metrics http endpoint will bind too").Default("8000").IntVar(&metricsvc.Port)
 
 	serve.Flag("envoy-http-access-log", "Envoy HTTP access log").Default(contour.DEFAULT_HTTP_ACCESS_LOG).StringVar(&ch.HTTPAccessLog)
 	serve.Flag("envoy-https-access-log", "Envoy HTTPS access log").Default(contour.DEFAULT_HTTPS_ACCESS_LOG).StringVar(&ch.HTTPSAccessLog)
@@ -132,10 +144,6 @@ func main() {
 		log.Infof("args: %v", args)
 		var g workgroup.Group
 
-		// plumb the DAGAdapter's Builder through
-		// to the debug handler
-		debug.Builder = &reh.Builder
-
 		// client-go uses glog which requires initialisation as a side effect of calling
 		// flag.Parse (see #118 and https://github.com/golang/glog/blob/master/glog.go#L679)
 		// However kingpin owns our flag parsing, so we defer calling flag.Parse until
@@ -165,6 +173,7 @@ func main() {
 		k8s.WatchEndpoints(&g, client, wl, et)
 
 		registry := prometheus.NewRegistry()
+		metricsvc.Registry = registry
 
 		// register detault process / go collectors
 		registry.MustRegister(prometheus.NewProcessCollector(os.Getpid(), ""))
@@ -175,10 +184,8 @@ func main() {
 		ch.Metrics = metrics
 		reh.Metrics = metrics
 
-		g.Add(func(stop <-chan struct{}) error {
-			debug.Start(stop, registry)
-			return nil
-		})
+		g.Add(debugsvc.Start)
+		g.Add(metricsvc.Start)
 
 		g.Add(func(stop <-chan struct{}) error {
 			log := log.WithField("context", "grpc")

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -29,14 +29,14 @@ Then navigate to [http://127.0.0.1:9001/](http://127.0.0.1:9001/) to access the 
 
 ## Accessing Contour's /debug/pprof service
 
-Contour exposes the [net/http/pprof] handlers for `go tool pprof` and `go tool trace` by default on `127.0.0.1:8000`.
+Contour exposes the [net/http/pprof][5] handlers for `go tool pprof` and `go tool trace` by default on `127.0.0.1:6060`.
 This service is useful for profiling Contour. 
 To access it from your workstation use `kubectl port-forward` like so,
 ```
 # Get one of the pods that matches the deployment/daemonset
 CONTOUR_POD=$(kubectl -n heptio-contour get pod -l app=contour -o jsonpath='{.items[0].metadata.name}')
 # Do the port forward to that pod
-kubectl -n heptio-contour port-forward $CONTOUR_POD 8000
+kubectl -n heptio-contour port-forward $CONTOUR_POD 6060
 ```
 
 ## Interrogate Contour's gRPC API
@@ -90,3 +90,4 @@ See [Issue #547][4]
 [2]: https://github.com/envoyproxy/envoy/issues/1269
 [3]: minikube.md
 [4]: https://github.com/heptio/contour/issues/547
+[5]: https://golang.org/pkg/net/http/pprof/

--- a/internal/debug/dot.go
+++ b/internal/debug/dot.go
@@ -18,14 +18,12 @@ import (
 	"io"
 
 	"github.com/heptio/contour/internal/dag"
-	"github.com/sirupsen/logrus"
 )
 
 // quick and dirty dot debugging package
 
 type dotWriter struct {
 	*dag.Builder
-	logrus.FieldLogger
 }
 
 type pair struct {

--- a/internal/httpsvc/http.go
+++ b/internal/httpsvc/http.go
@@ -1,0 +1,68 @@
+// Copyright © 2018 Heptio
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package httpsvc provides a HTTP/1.x Service which is compatible with the
+// workgroup.Group API.
+package httpsvc
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/sirupsen/logrus"
+)
+
+// Service is a HTTP/1.x endpoint which is compatible with the workgroup.Group API.
+type Service struct {
+	Addr string
+	Port int
+
+	logrus.FieldLogger
+	http.ServeMux
+}
+
+// Start fulfills the g.Start contract.
+// When stop is closed the http server will shutdown.
+func (svc *Service) Start(stop <-chan struct{}) (err error) {
+	defer func() {
+		if err != nil {
+			svc.WithError(err).Error("terminated with error")
+		} else {
+			svc.Info("stopped")
+		}
+	}()
+
+	s := http.Server{
+		Addr:           fmt.Sprintf("%s:%d", svc.Addr, svc.Port),
+		Handler:        &svc.ServeMux,
+		ReadTimeout:    10 * time.Second,
+		WriteTimeout:   5 * time.Minute, // allow for long trace requests
+		MaxHeaderBytes: 1 << 11,         // 8kb should be enough for anyone
+	}
+
+	go func() {
+		// wait for stop signal from group.
+		<-stop
+
+		// shutdown the server with 5 seconds grace.
+		ctx := context.Background()
+		ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+		defer cancel()
+		s.Shutdown(ctx)
+	}()
+
+	svc.WithField("address", s.Addr).Info("started")
+	return s.ListenAndServe()
+}


### PR DESCRIPTION
Fixes #588 

This PR bifurcates the previous port 8000 debug http service grab bag into two.

Port 8000 is retained and reallocated to hosting `/metrics` and `/health` endpoints, the `--http-addr` and `--http-port` flags are routed through to this http handler. This should reduce the impact of this change on the gimbal metric gathering configurations. While the port has not changed, but default this listener binds to 0.0.0.0, rather than 127.0.0.1.

The remaining /debug/pprof and /debug/dag endpoints are redirected to a new handler which listens on 127.0.0.1:6060. This address is configurable with `--debug-http-addr` and `--debug-http-port`.
