### PR TITLE
Disable panic threshold

### DIFF
--- a/internal/contour/cluster.go
+++ b/internal/contour/cluster.go
@@ -24,6 +24,7 @@ import (
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2/auth"
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2/cluster"
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
+	envoy_type "github.com/envoyproxy/go-control-plane/envoy/type"
 	"github.com/gogo/protobuf/proto"
 	"github.com/gogo/protobuf/types"
 	ingressroutev1 "github.com/heptio/contour/apis/contour/v1beta1"
@@ -138,6 +139,11 @@ func (v *clusterVisitor) edscluster(svc *dag.Service) {
 		EdsClusterConfig: edsconfig("contour", servicename(svc.Namespace(), svc.Name(), svc.ServicePort.Name)),
 		ConnectTimeout:   250 * time.Millisecond,
 		LbPolicy:         edslbstrategy(svc.LoadBalancerStrategy),
+		CommonLbConfig: &v2.Cluster_CommonLbConfig{
+			HealthyPanicThreshold: &envoy_type.Percent{ // Disable HealthyPanicThreshold
+				Value: 0,
+			},
+		},
 	}
 
 	// Set HealthCheck if requested

--- a/internal/contour/cluster_test.go
+++ b/internal/contour/cluster_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2/cluster"
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
+	envoy_type "github.com/envoyproxy/go-control-plane/envoy/type"
 	"github.com/gogo/protobuf/types"
 	ingressroutev1 "github.com/heptio/contour/apis/contour/v1beta1"
 	"github.com/heptio/contour/internal/metrics"
@@ -72,6 +73,11 @@ func TestClusterVisit(t *testing.T) {
 					},
 					ConnectTimeout: 250 * time.Millisecond,
 					LbPolicy:       v2.Cluster_ROUND_ROBIN,
+					CommonLbConfig: &v2.Cluster_CommonLbConfig{
+						HealthyPanicThreshold: &envoy_type.Percent{ // Disable HealthyPanicThreshold
+							Value: 0,
+						},
+					},
 				}),
 		},
 		"single named service": {
@@ -107,6 +113,11 @@ func TestClusterVisit(t *testing.T) {
 					},
 					ConnectTimeout: 250 * time.Millisecond,
 					LbPolicy:       v2.Cluster_ROUND_ROBIN,
+					CommonLbConfig: &v2.Cluster_CommonLbConfig{
+						HealthyPanicThreshold: &envoy_type.Percent{ // Disable HealthyPanicThreshold
+							Value: 0,
+						},
+					},
 				}),
 		},
 		"h2c upstream": {
@@ -147,6 +158,11 @@ func TestClusterVisit(t *testing.T) {
 					ConnectTimeout:       250 * time.Millisecond,
 					LbPolicy:             v2.Cluster_ROUND_ROBIN,
 					Http2ProtocolOptions: &core.Http2ProtocolOptions{},
+					CommonLbConfig: &v2.Cluster_CommonLbConfig{
+						HealthyPanicThreshold: &envoy_type.Percent{ // Disable HealthyPanicThreshold
+							Value: 0,
+						},
+					},
 				},
 			),
 		},
@@ -183,6 +199,11 @@ func TestClusterVisit(t *testing.T) {
 					},
 					ConnectTimeout: 250 * time.Millisecond,
 					LbPolicy:       v2.Cluster_ROUND_ROBIN,
+					CommonLbConfig: &v2.Cluster_CommonLbConfig{
+						HealthyPanicThreshold: &envoy_type.Percent{ // Disable HealthyPanicThreshold
+							Value: 0,
+						},
+					},
 				}),
 		},
 		"two service ports": {
@@ -230,6 +251,11 @@ func TestClusterVisit(t *testing.T) {
 					},
 					ConnectTimeout: 250 * time.Millisecond,
 					LbPolicy:       v2.Cluster_ROUND_ROBIN,
+					CommonLbConfig: &v2.Cluster_CommonLbConfig{
+						HealthyPanicThreshold: &envoy_type.Percent{ // Disable HealthyPanicThreshold
+							Value: 0,
+						},
+					},
 				},
 				&v2.Cluster{
 					Name: "default/backend/8080",
@@ -240,6 +266,11 @@ func TestClusterVisit(t *testing.T) {
 					},
 					ConnectTimeout: 250 * time.Millisecond,
 					LbPolicy:       v2.Cluster_ROUND_ROBIN,
+					CommonLbConfig: &v2.Cluster_CommonLbConfig{
+						HealthyPanicThreshold: &envoy_type.Percent{ // Disable HealthyPanicThreshold
+							Value: 0,
+						},
+					},
 				},
 			),
 		},
@@ -299,6 +330,11 @@ func TestClusterVisit(t *testing.T) {
 							},
 						},
 					}},
+					CommonLbConfig: &v2.Cluster_CommonLbConfig{
+						HealthyPanicThreshold: &envoy_type.Percent{ // Disable HealthyPanicThreshold
+							Value: 0,
+						},
+					},
 				},
 			),
 		},
@@ -363,6 +399,11 @@ func TestClusterVisit(t *testing.T) {
 							},
 						},
 					}},
+					CommonLbConfig: &v2.Cluster_CommonLbConfig{
+						HealthyPanicThreshold: &envoy_type.Percent{ // Disable HealthyPanicThreshold
+							Value: 0,
+						},
+					},
 				},
 			),
 		},
@@ -404,6 +445,11 @@ func TestClusterVisit(t *testing.T) {
 					},
 					ConnectTimeout: 250 * time.Millisecond,
 					LbPolicy:       v2.Cluster_ROUND_ROBIN,
+					CommonLbConfig: &v2.Cluster_CommonLbConfig{
+						HealthyPanicThreshold: &envoy_type.Percent{ // Disable HealthyPanicThreshold
+							Value: 0,
+						},
+					},
 				},
 			),
 		},
@@ -445,6 +491,11 @@ func TestClusterVisit(t *testing.T) {
 					},
 					ConnectTimeout: 250 * time.Millisecond,
 					LbPolicy:       v2.Cluster_LEAST_REQUEST,
+					CommonLbConfig: &v2.Cluster_CommonLbConfig{
+						HealthyPanicThreshold: &envoy_type.Percent{ // Disable HealthyPanicThreshold
+							Value: 0,
+						},
+					},
 				},
 			),
 		},
@@ -486,6 +537,11 @@ func TestClusterVisit(t *testing.T) {
 					},
 					ConnectTimeout: 250 * time.Millisecond,
 					LbPolicy:       v2.Cluster_RING_HASH,
+					CommonLbConfig: &v2.Cluster_CommonLbConfig{
+						HealthyPanicThreshold: &envoy_type.Percent{ // Disable HealthyPanicThreshold
+							Value: 0,
+						},
+					},
 				},
 			),
 		},
@@ -527,6 +583,11 @@ func TestClusterVisit(t *testing.T) {
 					},
 					ConnectTimeout: 250 * time.Millisecond,
 					LbPolicy:       v2.Cluster_MAGLEV,
+					CommonLbConfig: &v2.Cluster_CommonLbConfig{
+						HealthyPanicThreshold: &envoy_type.Percent{ // Disable HealthyPanicThreshold
+							Value: 0,
+						},
+					},
 				},
 			),
 		},
@@ -568,6 +629,11 @@ func TestClusterVisit(t *testing.T) {
 					},
 					ConnectTimeout: 250 * time.Millisecond,
 					LbPolicy:       v2.Cluster_RANDOM,
+					CommonLbConfig: &v2.Cluster_CommonLbConfig{
+						HealthyPanicThreshold: &envoy_type.Percent{ // Disable HealthyPanicThreshold
+							Value: 0,
+						},
+					},
 				},
 			),
 		},
@@ -609,6 +675,11 @@ func TestClusterVisit(t *testing.T) {
 					},
 					ConnectTimeout: 250 * time.Millisecond,
 					LbPolicy:       v2.Cluster_ROUND_ROBIN,
+					CommonLbConfig: &v2.Cluster_CommonLbConfig{
+						HealthyPanicThreshold: &envoy_type.Percent{ // Disable HealthyPanicThreshold
+							Value: 0,
+						},
+					},
 				},
 			),
 		},
@@ -659,6 +730,11 @@ func TestClusterVisit(t *testing.T) {
 							MaxRequests:        uint32t(404),
 							MaxRetries:         uint32t(7),
 						}},
+					},
+					CommonLbConfig: &v2.Cluster_CommonLbConfig{
+						HealthyPanicThreshold: &envoy_type.Percent{ // Disable HealthyPanicThreshold
+							Value: 0,
+						},
 					},
 				},
 			),

--- a/internal/e2e/cds_test.go
+++ b/internal/e2e/cds_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	envoy_cluster "github.com/envoyproxy/go-control-plane/envoy/api/v2/cluster"
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
+	envoy_type "github.com/envoyproxy/go-control-plane/envoy/type"
 	"github.com/gogo/protobuf/types"
 	"google.golang.org/grpc"
 	"k8s.io/api/core/v1"
@@ -526,6 +527,11 @@ func TestClusterCircuitbreakerAnnotations(t *testing.T) {
 						MaxRetries:         uint32t(7),
 					}},
 				},
+				CommonLbConfig: &v2.Cluster_CommonLbConfig{
+					HealthyPanicThreshold: &envoy_type.Percent{ // Disable HealthyPanicThreshold
+						Value: 0,
+					},
+				},
 			}),
 		},
 		TypeUrl: clusterType,
@@ -566,6 +572,11 @@ func TestClusterCircuitbreakerAnnotations(t *testing.T) {
 					Thresholds: []*envoy_cluster.CircuitBreakers_Thresholds{{
 						MaxPendingRequests: uint32t(9999),
 					}},
+				},
+				CommonLbConfig: &v2.Cluster_CommonLbConfig{
+					HealthyPanicThreshold: &envoy_type.Percent{ // Disable HealthyPanicThreshold
+						Value: 0,
+					},
 				},
 			}),
 		},
@@ -617,6 +628,11 @@ func cluster(name, servicename string) *v2.Cluster {
 		},
 		ConnectTimeout: 250 * time.Millisecond,
 		LbPolicy:       v2.Cluster_ROUND_ROBIN,
+		CommonLbConfig: &v2.Cluster_CommonLbConfig{
+			HealthyPanicThreshold: &envoy_type.Percent{ // Disable HealthyPanicThreshold
+				Value: 0,
+			},
+		},
 	}
 }
 


### PR DESCRIPTION
Fixes #579 by disabling the Envoy Healthy Panic Threshold. 

Signed-off-by: Steve Sloka <steves@heptio.com>