### PR TITLE
internal/: Implement TLS & min tls protocol version

### DIFF
--- a/apis/contour/v1beta1/ingressroute.go
+++ b/apis/contour/v1beta1/ingressroute.go
@@ -47,6 +47,8 @@ type VirtualHost struct {
 type TLS struct {
 	// required, the name of a secret in the current namespace
 	SecretName string `json:"secretName"`
+	// Minimum TLS version this vhost should negotiate
+	MinimumProtocolVersion string `json:"minimumProtocolVersion"`
 }
 
 // Route contains the set of routes for a virtual host

--- a/deployment/common/common.yaml
+++ b/deployment/common/common.yaml
@@ -44,6 +44,12 @@ spec:
                     secretName:
                       type: string
                       pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$ # DNS-1123
+                    minimumProtocolVersion:
+                      type: string
+                      enum:
+                        - 1.3
+                        - 1.2
+                        - 1.1
             strategy:
               type: string
               enum:

--- a/deployment/render/daemonset-norbac.yaml
+++ b/deployment/render/daemonset-norbac.yaml
@@ -47,6 +47,12 @@ spec:
                     secretName:
                       type: string
                       pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$ # DNS-1123
+                    minimumProtocolVersion:
+                      type: string
+                      enum:
+                        - 1.3
+                        - 1.2
+                        - 1.1
             strategy:
               type: string
               enum:

--- a/deployment/render/daemonset-rbac.yaml
+++ b/deployment/render/daemonset-rbac.yaml
@@ -47,6 +47,12 @@ spec:
                     secretName:
                       type: string
                       pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$ # DNS-1123
+                    minimumProtocolVersion:
+                      type: string
+                      enum:
+                        - 1.3
+                        - 1.2
+                        - 1.1
             strategy:
               type: string
               enum:

--- a/deployment/render/deployment-norbac.yaml
+++ b/deployment/render/deployment-norbac.yaml
@@ -47,6 +47,12 @@ spec:
                     secretName:
                       type: string
                       pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$ # DNS-1123
+                    minimumProtocolVersion:
+                      type: string
+                      enum:
+                        - 1.3
+                        - 1.2
+                        - 1.1
             strategy:
               type: string
               enum:

--- a/deployment/render/deployment-rbac.yaml
+++ b/deployment/render/deployment-rbac.yaml
@@ -47,6 +47,12 @@ spec:
                     secretName:
                       type: string
                       pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$ # DNS-1123
+                    minimumProtocolVersion:
+                      type: string
+                      enum:
+                        - 1.3
+                        - 1.2
+                        - 1.1
             strategy:
               type: string
               enum:

--- a/design/ingressroute-design.md
+++ b/design/ingressroute-design.md
@@ -72,6 +72,8 @@ spec:
     tls:
       # required, the name of a secret in the current namespace
       secretName: google-tls
+      # optional: minimum TLS version this vhost should negotiate
+      minimumProtocolVersion: "1.3"
       # other properties like cipher suites may be added later
   strategy: RoundRobin # (Optional) LB Algorithm to apply to all services, defaults for all services
   healthCheck (Optional):
@@ -165,6 +167,13 @@ The following list are the options available to choose from:
 - **Random:** The random load balancer selects a random healthy host
 
 More documentation on Envoy's lb support can be found here: [https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/load_balancing.html](https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/load_balancing.html)
+
+### TLS
+
+- **minimumProtocolVersion**: Define the minimum TLS version a vhost should negotiate. Allowed values:
+  - 1.3
+  - 1.2
+  - 1.1 (Default)
 
 ### Healthcheck
 

--- a/docs/ingressroute.md
+++ b/docs/ingressroute.md
@@ -216,7 +216,7 @@ spec:
           port: 80
 ```
 
-##### TLS (Not supported in beta.1)
+##### TLS
 
 IngressRoutes follow a similar pattern to Ingress for configuring TLS credentials.
 
@@ -260,6 +260,11 @@ spec:
         - name: s1
           port: 80
 ```
+
+The TLS **Minimum Protocol Version** a vhost should negotiate can be specified by setting the spec.virtualhost.tls.minimumProtocolVersion:
+  - 1.3
+  - 1.2
+  - 1.1 (Default)
 
 ### Routing
 

--- a/internal/contour/route_test.go
+++ b/internal/contour/route_test.go
@@ -341,15 +341,14 @@ func TestRouteVisit(t *testing.T) {
 				},
 				"ingress_https": {
 					Name: "ingress_https",
-					/* TODO(dfc) no support for routes on https for ingressroute, yet
 					VirtualHosts: []route.VirtualHost{{
 						Name:    "www.example.com",
 						Domains: []string{"www.example.com", "www.example.com:443"},
 						Routes: []route.Route{{
 							Match:  prefixmatch("/"),
-							Action: routeroute("default/kuard/8080"),
+							Action: routeroute("default/backend/8080"),
 						}},
-					}}, */
+					}},
 				},
 			},
 		},

--- a/internal/dag/builder.go
+++ b/internal/dag/builder.go
@@ -470,8 +470,8 @@ func (irp *ingressRouteProcessor) process(ir *ingressroutev1.IngressRoute, prefi
 			}
 			irp.vhost(irp.host, 80).routes[r.path] = r
 
-			if ok := irp.svhost(irp.host, 443); ok != nil {
-				if ok.secret != nil {
+			if hst := irp.svhost(irp.host, 443); hst != nil {
+				if hst.secret != nil {
 					irp.svhost(irp.host, 443).routes[r.path] = r
 				}
 			}

--- a/internal/dag/builder.go
+++ b/internal/dag/builder.go
@@ -367,7 +367,17 @@ func (b *Builder) compute() *DAG {
 			m := meta{name: tls.SecretName, namespace: ir.Namespace}
 			if sec := secret(m); sec != nil {
 				svhost(host, 443).secret = sec
-				svhost(host, 443).MinProtoVersion = auth.TlsParameters_TLSv1_1 // TODO(dfc) issue 467
+
+				// process min protocol version
+				switch ir.Spec.VirtualHost.TLS.MinimumProtocolVersion {
+				case "1.3":
+					svhost(host, 443).MinProtoVersion = auth.TlsParameters_TLSv1_3
+				case "1.2":
+					svhost(host, 443).MinProtoVersion = auth.TlsParameters_TLSv1_2
+				default:
+					// any other value is interpreted as TLS/1.1
+					svhost(host, 443).MinProtoVersion = auth.TlsParameters_TLSv1_1
+				}
 			}
 		}
 
@@ -376,6 +386,7 @@ func (b *Builder) compute() *DAG {
 			host:          host,
 			service:       service,
 			vhost:         vhost,
+			svhost:        svhost,
 			ingressroutes: b.ingressroutes,
 			orphaned:      orphaned,
 		}
@@ -388,7 +399,9 @@ func (b *Builder) compute() *DAG {
 		dag.roots = append(dag.roots, vh)
 	}
 	for _, svh := range _svhosts {
-		dag.roots = append(dag.roots, svh)
+		if svh.secret != nil {
+			dag.roots = append(dag.roots, svh)
+		}
 	}
 
 	for meta, orph := range orphaned {
@@ -420,6 +433,7 @@ type ingressRouteProcessor struct {
 	host          string
 	service       func(m meta, port intstr.IntOrString) *Service
 	vhost         func(host string, port int) *VirtualHost
+	svhost        func(host string, port int) *SecureVirtualHost
 	ingressroutes map[meta]*ingressroutev1.IngressRoute
 	orphaned      map[meta]bool
 }
@@ -455,6 +469,12 @@ func (irp *ingressRouteProcessor) process(ir *ingressroutev1.IngressRoute, prefi
 				}
 			}
 			irp.vhost(irp.host, 80).routes[r.path] = r
+
+			if ok := irp.svhost(irp.host, 443); ok != nil {
+				if ok.secret != nil {
+					irp.svhost(irp.host, 443).routes[r.path] = r
+				}
+			}
 			continue
 		}
 

--- a/internal/dag/builder_test.go
+++ b/internal/dag/builder_test.go
@@ -655,6 +655,101 @@ func TestDAGInsert(t *testing.T) {
 		},
 	}
 
+	// ir6 has TLS and does not specifiy min tls version
+	ir6 := &ingressroutev1.IngressRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "example-com",
+			Namespace: "default",
+		},
+		Spec: ingressroutev1.IngressRouteSpec{
+			VirtualHost: &ingressroutev1.VirtualHost{
+				Fqdn: "foo.com",
+				TLS: &ingressroutev1.TLS{
+					SecretName: "secret",
+				},
+			},
+			Routes: []ingressroutev1.Route{{
+				Match: "/",
+				Services: []ingressroutev1.Service{{
+					Name: "kuard",
+					Port: 8080,
+				}},
+			}},
+		},
+	}
+
+	// ir7 has TLS and specifies min tls version of 1.2
+	ir7 := &ingressroutev1.IngressRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "example-com",
+			Namespace: "default",
+		},
+		Spec: ingressroutev1.IngressRouteSpec{
+			VirtualHost: &ingressroutev1.VirtualHost{
+				Fqdn: "foo.com",
+				TLS: &ingressroutev1.TLS{
+					SecretName:             "secret",
+					MinimumProtocolVersion: "1.2",
+				},
+			},
+			Routes: []ingressroutev1.Route{{
+				Match: "/",
+				Services: []ingressroutev1.Service{{
+					Name: "kuard",
+					Port: 8080,
+				}},
+			}},
+		},
+	}
+
+	// ir8 has TLS and specifies min tls version of 1.3
+	ir8 := &ingressroutev1.IngressRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "example-com",
+			Namespace: "default",
+		},
+		Spec: ingressroutev1.IngressRouteSpec{
+			VirtualHost: &ingressroutev1.VirtualHost{
+				Fqdn: "foo.com",
+				TLS: &ingressroutev1.TLS{
+					SecretName:             "secret",
+					MinimumProtocolVersion: "1.3",
+				},
+			},
+			Routes: []ingressroutev1.Route{{
+				Match: "/",
+				Services: []ingressroutev1.Service{{
+					Name: "kuard",
+					Port: 8080,
+				}},
+			}},
+		},
+	}
+
+	// ir9 has TLS and specifies an invalid min tls version of 0.9999
+	ir9 := &ingressroutev1.IngressRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "example-com",
+			Namespace: "default",
+		},
+		Spec: ingressroutev1.IngressRouteSpec{
+			VirtualHost: &ingressroutev1.VirtualHost{
+				Fqdn: "foo.com",
+				TLS: &ingressroutev1.TLS{
+					SecretName:             "secret",
+					MinimumProtocolVersion: "0.9999",
+				},
+			},
+			Routes: []ingressroutev1.Route{{
+				Match: "/",
+				Services: []ingressroutev1.Service{{
+					Name: "kuard",
+					Port: 8080,
+				}},
+			}},
+		},
+	}
+
 	s5 := &v1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "blog-admin",
@@ -1471,6 +1566,142 @@ func TestDAGInsert(t *testing.T) {
 							},
 						)),
 					),
+				}},
+		},
+		"insert ingressroute without tls version": {
+			objs: []interface{}{
+				ir6, s1, sec1,
+			},
+			want: []Vertex{
+				&VirtualHost{
+					Port: 80,
+					host: "foo.com",
+					routes: routemap(
+						route("/", ir6, servicemap(
+							&Service{
+								Object:      s1,
+								ServicePort: &s1.Spec.Ports[0],
+							},
+						)),
+					),
+				},
+				&SecureVirtualHost{
+					Port:            443,
+					MinProtoVersion: auth.TlsParameters_TLSv1_1,
+					host:            "foo.com",
+					routes: routemap(
+						route("/", ir6, servicemap(
+							&Service{
+								Object:      s1,
+								ServicePort: &s1.Spec.Ports[0],
+							},
+						)),
+					),
+					secret: &Secret{
+						object: sec1,
+					},
+				}},
+		},
+		"insert ingressroute with tls version 1.2": {
+			objs: []interface{}{
+				ir7, s1, sec1,
+			},
+			want: []Vertex{
+				&VirtualHost{
+					Port: 80,
+					host: "foo.com",
+					routes: routemap(
+						route("/", ir7, servicemap(
+							&Service{
+								Object:      s1,
+								ServicePort: &s1.Spec.Ports[0],
+							},
+						)),
+					),
+				},
+				&SecureVirtualHost{
+					Port:            443,
+					MinProtoVersion: auth.TlsParameters_TLSv1_2,
+					host:            "foo.com",
+					routes: routemap(
+						route("/", ir7, servicemap(
+							&Service{
+								Object:      s1,
+								ServicePort: &s1.Spec.Ports[0],
+							},
+						)),
+					),
+					secret: &Secret{
+						object: sec1,
+					},
+				}},
+		},
+		"insert ingressroute with tls version 1.3": {
+			objs: []interface{}{
+				ir8, s1, sec1,
+			},
+			want: []Vertex{
+				&VirtualHost{
+					Port: 80,
+					host: "foo.com",
+					routes: routemap(
+						route("/", ir8, servicemap(
+							&Service{
+								Object:      s1,
+								ServicePort: &s1.Spec.Ports[0],
+							},
+						)),
+					),
+				},
+				&SecureVirtualHost{
+					Port:            443,
+					MinProtoVersion: auth.TlsParameters_TLSv1_3,
+					host:            "foo.com",
+					routes: routemap(
+						route("/", ir8, servicemap(
+							&Service{
+								Object:      s1,
+								ServicePort: &s1.Spec.Ports[0],
+							},
+						)),
+					),
+					secret: &Secret{
+						object: sec1,
+					},
+				}},
+		},
+		"insert ingressroute with invalid tls version": {
+			objs: []interface{}{
+				ir9, s1, sec1,
+			},
+			want: []Vertex{
+				&VirtualHost{
+					Port: 80,
+					host: "foo.com",
+					routes: routemap(
+						route("/", ir9, servicemap(
+							&Service{
+								Object:      s1,
+								ServicePort: &s1.Spec.Ports[0],
+							},
+						)),
+					),
+				},
+				&SecureVirtualHost{
+					Port:            443,
+					MinProtoVersion: auth.TlsParameters_TLSv1_1,
+					host:            "foo.com",
+					routes: routemap(
+						route("/", ir9, servicemap(
+							&Service{
+								Object:      s1,
+								ServicePort: &s1.Spec.Ports[0],
+							},
+						)),
+					),
+					secret: &Secret{
+						object: sec1,
+					},
 				}},
 		},
 		"insert ingressroute referencing two backends, one missing": {


### PR DESCRIPTION
This finalizes the last bits to enable TLS for IngressRoutes. In addition, it adds a `minimumProtocolVersion` option to the `IngressRoute.Spec.VirtualHost.TLS` struct to allow users to define the minimumProtocolVersion as well as update the CRD valiation enum to match the supported versions. 

Fixes #467 #458 #452 

Signed-off-by: Steve Sloka <steves@heptio.com>