### PR TITLE
internal/dag: add websocket support to ingressroute

### DIFF
--- a/apis/contour/v1beta1/ingressroute.go
+++ b/apis/contour/v1beta1/ingressroute.go
@@ -53,9 +53,12 @@ type TLS struct {
 type Route struct {
 	// Match defines the prefix match
 	Match string `json:"match"`
-	// Service are the services to proxy traffic
+	// Services are the services to proxy traffic
 	Services []Service `json:"services"`
+	// Delegate specifies that this route should be delegated to another IngressRoute
 	Delegate `json:"delegate"`
+	// Enables websocket support for the route
+	EnableWebsockets bool `json:"enableWebsockets"`
 }
 
 // Service defines an upstream to proxy traffic to
@@ -73,7 +76,7 @@ type Service struct {
 	Strategy string `json:"strategy"`
 }
 
-// Delegate allows for passing delgating VHosts to other IngressRoutes
+// Delegate allows for delegating VHosts to other IngressRoutes
 type Delegate struct {
 	// Name of the IngressRoute
 	Name string `json:"name"`

--- a/docs/ingressroute.md
+++ b/docs/ingressroute.md
@@ -493,6 +493,31 @@ spec:
           port: 80
 ```
 
+#### WebSocket Support
+
+WebSocket support can be enabled on specific routes using the `EnableWebsockets` field:
+
+```yaml
+apiVersion: contour.heptio.com/v1beta1
+kind: IngressRoute
+metadata: 
+  name: chat
+  namespace: default
+spec:
+  virtualhost:
+    fqdn: chat.example.com
+  routes:
+    - match: /
+      services: 
+        - name: chat-app
+          port: 80
+    - match: /websocket
+      enableWebsockets: true # Setting this to true enables websocket for all paths that match /websocket
+      services:
+        - name: chat-app
+          port: 80
+```
+
 ## IngressRoute Delegation
 
 A key feature of the IngressRoute specification is route delegation which follows the working model of DNS:

--- a/internal/dag/builder.go
+++ b/internal/dag/builder.go
@@ -439,8 +439,9 @@ func (irp *ingressRouteProcessor) process(ir *ingressroutev1.IngressRoute, prefi
 				return []Status{{Object: ir, Status: StatusInvalid, Description: fmt.Sprintf("the path prefix %q does not match the parent's path prefix %q", route.Match, prefixMatch), Vhost: host}}
 			}
 			r := &Route{
-				path:   route.Match,
-				Object: ir,
+				path:      route.Match,
+				Object:    ir,
+				Websocket: route.EnableWebsockets,
 			}
 			for _, s := range route.Services {
 				if s.Port < 1 || s.Port > 65535 {


### PR DESCRIPTION
Adds a new field to the Routes object inside the IngressRoute CRD called `EnableWebsockets`, which controls whether a client can upgrade to a websocket connection on the given route.

Fixes #595 