### PR TITLE
internal/contour: ignore endpoint updates if both old and new have zero endpoints

### DIFF
--- a/internal/contour/endpointstranslator.go
+++ b/internal/contour/endpointstranslator.go
@@ -69,8 +69,9 @@ func (e *EndpointsTranslator) addEndpoints(ep *v1.Endpoints) {
 }
 
 func (e *EndpointsTranslator) updateEndpoints(oldep, newep *v1.Endpoints) {
-	if len(newep.Subsets) < 1 {
-		// if there are no endpoints in this object, ignore it
+	if len(newep.Subsets) == 0 && len(oldep.Subsets) == 0 {
+		// if there are no endpoints in this object, and the old
+		// object also had zero endpoints, ignore this update
 		// to avoid sending a noop notification to watchers.
 		return
 	}

--- a/internal/contour/endpointstranslator_test.go
+++ b/internal/contour/endpointstranslator_test.go
@@ -229,6 +229,36 @@ func TestEndpointsTranslatorRecomputeClusterLoadAssignment(t *testing.T) {
 	}
 }
 
+// See #602
+func TestEndpointsTranslatorScaleToZeroEndpoints(t *testing.T) {
+	var et EndpointsTranslator
+	e1 := endpoints("default", "simple", v1.EndpointSubset{
+		Addresses: addresses("192.168.183.24"),
+		Ports:     ports(8080),
+	})
+	et.OnAdd(e1)
+
+	// Assert endpoint was added
+	want := []proto.Message{
+		clusterloadassignment("default/simple", lbendpoint("192.168.183.24", 8080)),
+	}
+	got := contents(&et)
+	if !reflect.DeepEqual(want, got) {
+		t.Fatalf("expected:\n%v\ngot:\n%v\n", want, got)
+	}
+
+	// e2 is the same as e1, but without endpoint subsets
+	e2 := endpoints("default", "simple")
+	et.OnUpdate(e1, e2)
+
+	// Assert endpoints are removed
+	want = []proto.Message{}
+	got = contents(&et)
+	if !reflect.DeepEqual(want, got) {
+		t.Fatalf("expected:\n%v\ngot:\n%v\n", want, got)
+	}
+}
+
 type clusterLoadAssignmentsByName []proto.Message
 
 func (c clusterLoadAssignmentsByName) Len() int      { return len(c) }


### PR DESCRIPTION
Fixes #602

```
Before this change, we were ignoring endpoint update events that had
zero endpoints in the updated object. This was a problem because we were
not handling the case where we went from N endpoints to zero endpoints.

With this change, we only ignore the update if we are going from zero
endpoints to zero endpoints. Otherwise, we handle the update like any
other.

Signed-off-by: Alexander Brand <alexbrand09@gmail.com>
```