### PR TITLE
Add support for Alias in IngressRoute

### DIFF
--- a/internal/contour/route.go
+++ b/internal/contour/route.go
@@ -163,9 +163,13 @@ func (v *routeVisitor) Visit() map[string]*v2.RouteConfiguration {
 			ingress_http.VirtualHosts = append(ingress_http.VirtualHosts, vhost)
 		case *dag.SecureVirtualHost:
 			hostname := vh.FQDN()
-			domains := []string{hostname}
+			aliases := vh.Aliases()
+			domains := append(aliases, hostname)
 			if hostname != "*" {
 				domains = append(domains, hostname+":443")
+				for _, a := range aliases {
+					domains = append(domains, a+":443")
+				}
 			}
 			vhost := route.VirtualHost{
 				Name:    hashname(60, hostname),

--- a/internal/contour/route.go
+++ b/internal/contour/route.go
@@ -113,9 +113,13 @@ func (v *routeVisitor) Visit() map[string]*v2.RouteConfiguration {
 		switch vh := vh.(type) {
 		case *dag.VirtualHost:
 			hostname := vh.FQDN()
-			domains := []string{hostname}
+			aliases := vh.Aliases()
+			domains := append(aliases, hostname)
 			if hostname != "*" {
 				domains = append(domains, hostname+":80")
+				for _, a := range aliases {
+					domains = append(domains, a+":80")
+				}
 			}
 			vhost := route.VirtualHost{
 				Name:    hashname(60, hostname),

--- a/internal/contour/route_test.go
+++ b/internal/contour/route_test.go
@@ -1033,6 +1033,98 @@ func TestRouteVisit(t *testing.T) {
 				},
 			},
 		},
+		"ingressroute aliases defined": {
+			objs: []interface{}{
+				&ingressroutev1.IngressRoute{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "simple",
+						Namespace: "default",
+					},
+					Spec: ingressroutev1.IngressRouteSpec{
+						VirtualHost: &ingressroutev1.VirtualHost{
+							Fqdn: "www.example.com",
+							Aliases: []string{
+								"foo.com",
+								"bar.com",
+							},
+						},
+						Routes: []ingressroutev1.Route{{
+							Match: "/",
+							Services: []ingressroutev1.Service{
+								{
+									Name: "backend",
+									Port: 80,
+								},
+								{
+									Name:   "backendtwo",
+									Port:   80,
+									Weight: 50,
+								},
+							},
+						}},
+					},
+				},
+				&v1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "backend",
+						Namespace: "default",
+					},
+					Spec: v1.ServiceSpec{
+						Ports: []v1.ServicePort{{
+							Protocol:   "TCP",
+							Port:       80,
+							TargetPort: intstr.FromInt(8080),
+						}},
+					},
+				},
+				&v1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "backendtwo",
+						Namespace: "default",
+					},
+					Spec: v1.ServiceSpec{
+						Ports: []v1.ServicePort{{
+							Protocol:   "TCP",
+							Port:       80,
+							TargetPort: intstr.FromInt(8080),
+						}},
+					},
+				},
+			},
+			want: map[string]*v2.RouteConfiguration{
+				"ingress_http": {
+					Name: "ingress_http",
+					VirtualHosts: []route.VirtualHost{{
+						Name:    "www.example.com",
+						Domains: []string{"foo.com", "bar.com", "www.example.com", "www.example.com:80", "foo.com:80", "bar.com:80"},
+						Routes: []route.Route{{
+							Match: prefixmatch("/"),
+							Action: &route.Route_Route{
+								Route: &route.RouteAction{
+									ClusterSpecifier: &route.RouteAction_WeightedClusters{
+										WeightedClusters: &route.WeightedCluster{
+											Clusters: []*route.WeightedCluster_ClusterWeight{{
+												Name:   "default/backend/80",
+												Weight: &types.UInt32Value{Value: uint32(0)},
+											}, {
+												Name:   "default/backendtwo/80",
+												Weight: &types.UInt32Value{Value: uint32(50)},
+											}},
+											TotalWeight: &types.UInt32Value{
+												Value: uint32(50),
+											},
+										},
+									},
+								},
+							},
+						}},
+					}},
+				},
+				"ingress_https": {
+					Name: "ingress_https",
+				},
+			},
+		},
 		"ingressroute all weights defined": {
 			objs: []interface{}{
 				&ingressroutev1.IngressRoute{

--- a/internal/dag/builder_test.go
+++ b/internal/dag/builder_test.go
@@ -775,6 +775,10 @@ func TestDAGInsert(t *testing.T) {
 		Spec: ingressroutev1.IngressRouteSpec{
 			VirtualHost: &ingressroutev1.VirtualHost{
 				Fqdn: "example.com",
+				Aliases: []string{
+					"foo.com",
+					"bar.com",
+				},
 			},
 			Routes: []ingressroutev1.Route{{
 				Match: "/",
@@ -908,8 +912,9 @@ func TestDAGInsert(t *testing.T) {
 			},
 			want: []Vertex{
 				&VirtualHost{
-					Port: 80,
-					host: "*",
+					Port:    80,
+					host:    "*",
+					aliases: []string{},
 					routes: routemap(
 						route("/", i1),
 					),
@@ -922,8 +927,9 @@ func TestDAGInsert(t *testing.T) {
 			},
 			want: []Vertex{
 				&VirtualHost{
-					Port: 80,
-					host: "*",
+					Port:    80,
+					host:    "*",
+					aliases: []string{},
 					routes: routemap(
 						route("/", i2),
 					),
@@ -942,8 +948,9 @@ func TestDAGInsert(t *testing.T) {
 			},
 			want: []Vertex{
 				&VirtualHost{
-					Port: 80,
-					host: "kuard.example.com",
+					Port:    80,
+					host:    "kuard.example.com",
+					aliases: []string{},
 					routes: routemap(
 						route("/", i3),
 					),
@@ -957,8 +964,9 @@ func TestDAGInsert(t *testing.T) {
 			},
 			want: []Vertex{
 				&VirtualHost{
-					Port: 80,
-					host: "*",
+					Port:    80,
+					host:    "*",
+					aliases: []string{},
 					routes: routemap(
 						route("/", i1, servicemap(
 							&Service{
@@ -977,8 +985,9 @@ func TestDAGInsert(t *testing.T) {
 			},
 			want: []Vertex{
 				&VirtualHost{
-					Port: 80,
-					host: "*",
+					Port:    80,
+					host:    "*",
+					aliases: []string{},
 					routes: routemap(
 						route("/", i1, servicemap(
 							&Service{
@@ -997,8 +1006,9 @@ func TestDAGInsert(t *testing.T) {
 			},
 			want: []Vertex{
 				&VirtualHost{
-					Port: 80,
-					host: "*",
+					Port:    80,
+					host:    "*",
+					aliases: []string{},
 					routes: routemap(
 						route("/", i1),
 					),
@@ -1012,8 +1022,9 @@ func TestDAGInsert(t *testing.T) {
 			},
 			want: []Vertex{
 				&VirtualHost{
-					Port: 80,
-					host: "*",
+					Port:    80,
+					host:    "*",
+					aliases: []string{},
 					routes: routemap(
 						route("/", i1),
 					),
@@ -1027,8 +1038,9 @@ func TestDAGInsert(t *testing.T) {
 			},
 			want: []Vertex{
 				&VirtualHost{
-					Port: 80,
-					host: "*",
+					Port:    80,
+					host:    "*",
+					aliases: []string{},
 					routes: routemap(
 						route("/", i1),
 					),
@@ -1042,8 +1054,9 @@ func TestDAGInsert(t *testing.T) {
 			},
 			want: []Vertex{
 				&VirtualHost{
-					Port: 80,
-					host: "*",
+					Port:    80,
+					host:    "*",
+					aliases: []string{},
 					routes: routemap(
 						route("/", i2),
 					),
@@ -1057,8 +1070,9 @@ func TestDAGInsert(t *testing.T) {
 			},
 			want: []Vertex{
 				&VirtualHost{
-					Port: 80,
-					host: "*",
+					Port:    80,
+					host:    "*",
+					aliases: []string{},
 					routes: routemap(
 						route("/", i2),
 					),
@@ -1072,8 +1086,9 @@ func TestDAGInsert(t *testing.T) {
 			},
 			want: []Vertex{
 				&VirtualHost{
-					Port: 80,
-					host: "*",
+					Port:    80,
+					host:    "*",
+					aliases: []string{},
 					routes: routemap(
 						route("/", i4, servicemap(
 							&Service{
@@ -1092,8 +1107,9 @@ func TestDAGInsert(t *testing.T) {
 			},
 			want: []Vertex{
 				&VirtualHost{
-					Port: 80,
-					host: "*",
+					Port:    80,
+					host:    "*",
+					aliases: []string{},
 					routes: routemap(
 						route("/", i4, servicemap(
 							&Service{
@@ -1112,8 +1128,9 @@ func TestDAGInsert(t *testing.T) {
 			},
 			want: []Vertex{
 				&VirtualHost{
-					Port: 80,
-					host: "*",
+					Port:    80,
+					host:    "*",
+					aliases: []string{},
 					routes: routemap(
 						route("/", i5, servicemap(
 							&Service{
@@ -1132,8 +1149,9 @@ func TestDAGInsert(t *testing.T) {
 			},
 			want: []Vertex{
 				&VirtualHost{
-					Port: 80,
-					host: "*",
+					Port:    80,
+					host:    "*",
+					aliases: []string{},
 					routes: routemap(
 						route("/", i5, servicemap(
 							&Service{
@@ -1158,8 +1176,9 @@ func TestDAGInsert(t *testing.T) {
 			},
 			want: []Vertex{
 				&VirtualHost{
-					Port: 80,
-					host: "*",
+					Port:    80,
+					host:    "*",
+					aliases: []string{},
 					routes: routemap(
 						route("/", i1),
 					),
@@ -1172,8 +1191,9 @@ func TestDAGInsert(t *testing.T) {
 			},
 			want: []Vertex{
 				&VirtualHost{
-					Port: 80,
-					host: "kuard.example.com",
+					Port:    80,
+					host:    "kuard.example.com",
+					aliases: []string{},
 					routes: routemap(
 						route("/", i3),
 					),
@@ -1198,8 +1218,9 @@ func TestDAGInsert(t *testing.T) {
 			},
 			want: []Vertex{
 				&VirtualHost{
-					Port: 80,
-					host: "kuard.example.com",
+					Port:    80,
+					host:    "kuard.example.com",
+					aliases: []string{},
 					routes: routemap(
 						route("/", i3),
 					),
@@ -1223,15 +1244,17 @@ func TestDAGInsert(t *testing.T) {
 			},
 			want: []Vertex{
 				&VirtualHost{
-					Port: 80,
-					host: "a.example.com",
+					Port:    80,
+					host:    "a.example.com",
+					aliases: []string{},
 					routes: routemap(
 						route("/", i6),
 					),
 				},
 				&VirtualHost{
-					Port: 80,
-					host: "b.example.com",
+					Port:    80,
+					host:    "b.example.com",
+					aliases: []string{},
 					routes: routemap(
 						route("/", i6),
 					),
@@ -1245,8 +1268,9 @@ func TestDAGInsert(t *testing.T) {
 			},
 			want: []Vertex{
 				&VirtualHost{
-					Port: 80,
-					host: "a.example.com",
+					Port:    80,
+					host:    "a.example.com",
+					aliases: []string{},
 					routes: routemap(
 						route("/", i6, servicemap(
 							&Service{
@@ -1257,8 +1281,9 @@ func TestDAGInsert(t *testing.T) {
 					),
 				},
 				&VirtualHost{
-					Port: 80,
-					host: "b.example.com",
+					Port:    80,
+					host:    "b.example.com",
+					aliases: []string{},
 					routes: routemap(
 						route("/", i6, servicemap(
 							&Service{
@@ -1277,8 +1302,9 @@ func TestDAGInsert(t *testing.T) {
 			},
 			want: []Vertex{
 				&VirtualHost{
-					Port: 80,
-					host: "a.example.com",
+					Port:    80,
+					host:    "a.example.com",
+					aliases: []string{},
 					routes: routemap(
 						route("/", i6, servicemap(
 							&Service{
@@ -1289,8 +1315,9 @@ func TestDAGInsert(t *testing.T) {
 					),
 				},
 				&VirtualHost{
-					Port: 80,
-					host: "b.example.com",
+					Port:    80,
+					host:    "b.example.com",
+					aliases: []string{},
 					routes: routemap(
 						route("/", i6, servicemap(
 							&Service{
@@ -1310,8 +1337,9 @@ func TestDAGInsert(t *testing.T) {
 			},
 			want: []Vertex{
 				&VirtualHost{
-					Port: 80,
-					host: "a.example.com",
+					Port:    80,
+					host:    "a.example.com",
+					aliases: []string{},
 					routes: routemap(
 						route("/", i6, servicemap(
 							&Service{
@@ -1322,8 +1350,9 @@ func TestDAGInsert(t *testing.T) {
 					),
 				},
 				&VirtualHost{
-					Port: 80,
-					host: "b.example.com",
+					Port:    80,
+					host:    "b.example.com",
+					aliases: []string{},
 					routes: routemap(
 						route("/", i6, servicemap(
 							&Service{
@@ -1358,8 +1387,9 @@ func TestDAGInsert(t *testing.T) {
 			},
 			want: []Vertex{
 				&VirtualHost{
-					Port: 80,
-					host: "a.example.com",
+					Port:    80,
+					host:    "a.example.com",
+					aliases: []string{},
 					routes: routemap(
 						route("/", i6, servicemap(
 							&Service{
@@ -1369,8 +1399,9 @@ func TestDAGInsert(t *testing.T) {
 						)),
 					),
 				}, &VirtualHost{
-					Port: 80,
-					host: "b.example.com",
+					Port:    80,
+					host:    "b.example.com",
+					aliases: []string{},
 					routes: routemap(
 						route("/", i6, servicemap(
 							&Service{
@@ -1403,8 +1434,9 @@ func TestDAGInsert(t *testing.T) {
 			},
 			want: []Vertex{
 				&VirtualHost{
-					Port: 80,
-					host: "b.example.com",
+					Port:    80,
+					host:    "b.example.com",
+					aliases: []string{},
 					routes: routemap(
 						route("/", i7),
 						route("/kuarder", i7),
@@ -1419,8 +1451,9 @@ func TestDAGInsert(t *testing.T) {
 			},
 			want: []Vertex{
 				&VirtualHost{
-					Port: 80,
-					host: "b.example.com",
+					Port:    80,
+					host:    "b.example.com",
+					aliases: []string{},
 					routes: routemap(
 						route("/", i7, servicemap(
 							&Service{
@@ -1444,8 +1477,9 @@ func TestDAGInsert(t *testing.T) {
 			},
 			want: []Vertex{
 				&VirtualHost{
-					Port: 80,
-					host: "b.example.com",
+					Port:    80,
+					host:    "b.example.com",
+					aliases: []string{},
 					routes: routemap(
 						route("/", i8, servicemap(
 							&Service{
@@ -1547,8 +1581,9 @@ func TestDAGInsert(t *testing.T) {
 			},
 			want: []Vertex{
 				&VirtualHost{
-					Port: 80,
-					host: "b.example.com",
+					Port:    80,
+					host:    "b.example.com",
+					aliases: []string{},
 					routes: routemap(
 						&Route{
 							path:   "/",
@@ -1625,6 +1660,23 @@ func TestDAGInsert(t *testing.T) {
 							),
 							Websocket: true,
 						},
+					),
+				}},
+		},
+		"insert ingressroute with aliases": {
+			objs: []interface{}{
+				ir6,
+			},
+			want: []Vertex{
+				&VirtualHost{
+					Port: 80,
+					host: "example.com",
+					aliases: []string{
+						"foo.com",
+						"bar.com",
+					},
+					routes: routemap(
+						route("/", ir6),
 					),
 				}},
 		},
@@ -1830,8 +1882,9 @@ func TestDAGInsert(t *testing.T) {
 			},
 			want: []Vertex{
 				&VirtualHost{
-					Port: 80,
-					host: "b.example.com",
+					Port:    80,
+					host:    "b.example.com",
+					aliases: []string{},
 					routes: routemap(
 						route("/", i10, servicemap(
 							&Service{
@@ -1866,8 +1919,9 @@ func TestDAGInsert(t *testing.T) {
 			},
 			want: []Vertex{
 				&VirtualHost{
-					Port: 80,
-					host: "*",
+					Port:    80,
+					host:    "*",
+					aliases: []string{},
 					routes: routemap(
 						route("/", i11, servicemap(
 							&Service{
@@ -1897,8 +1951,9 @@ func TestDAGInsert(t *testing.T) {
 			},
 			want: []Vertex{
 				&VirtualHost{
-					Port: 80,
-					host: "*",
+					Port:    80,
+					host:    "*",
+					aliases: []string{},
 					routes: routemap(
 						&Route{
 							path:   "/",
@@ -1922,8 +1977,9 @@ func TestDAGInsert(t *testing.T) {
 			},
 			want: []Vertex{
 				&VirtualHost{
-					Port: 80,
-					host: "*",
+					Port:    80,
+					host:    "*",
+					aliases: []string{},
 					routes: routemap(
 						&Route{
 							path:   "/",
@@ -1947,8 +2003,9 @@ func TestDAGInsert(t *testing.T) {
 			},
 			want: []Vertex{
 				&VirtualHost{
-					Port: 80,
-					host: "*",
+					Port:    80,
+					host:    "*",
+					aliases: []string{},
 					routes: routemap(
 						&Route{
 							path:   "/",
@@ -1996,8 +2053,9 @@ func TestDAGInsert(t *testing.T) {
 			},
 			want: []Vertex{
 				&VirtualHost{
-					Port: 80,
-					host: "example.com",
+					Port:    80,
+					host:    "example.com",
+					aliases: []string{},
 					routes: routemap(
 						&Route{
 							path:   "/",
@@ -2053,8 +2111,9 @@ func TestDAGInsert(t *testing.T) {
 			},
 			want: []Vertex{
 				&VirtualHost{
-					Port: 80,
-					host: "*",
+					Port:    80,
+					host:    "*",
+					aliases: []string{},
 					routes: routemap(
 						route("/", i3a, servicemap(
 							&Service{
@@ -2073,8 +2132,9 @@ func TestDAGInsert(t *testing.T) {
 			},
 			want: []Vertex{
 				&VirtualHost{
-					Port: 80,
-					host: "*",
+					Port:    80,
+					host:    "*",
+					aliases: []string{},
 					routes: routemap(
 						route("/", i3a, servicemap(
 							&Service{
@@ -2094,8 +2154,9 @@ func TestDAGInsert(t *testing.T) {
 			},
 			want: []Vertex{
 				&VirtualHost{
-					Port: 80,
-					host: "*",
+					Port:    80,
+					host:    "*",
+					aliases: []string{},
 					routes: routemap(
 						route("/", i1, servicemap(
 							&Service{
@@ -2449,8 +2510,9 @@ func TestDAGRemove(t *testing.T) {
 			},
 			want: []Vertex{
 				&VirtualHost{
-					Port: 80,
-					host: "kuard.example.com",
+					Port:    80,
+					host:    "kuard.example.com",
+					aliases: []string{},
 					routes: routemap(
 						route("/", i3),
 					),
@@ -2476,8 +2538,9 @@ func TestDAGRemove(t *testing.T) {
 			},
 			want: []Vertex{
 				&VirtualHost{
-					Port: 80,
-					host: "*",
+					Port:    80,
+					host:    "*",
+					aliases: []string{},
 					routes: routemap(
 						route("/", i1),
 					),
@@ -2493,8 +2556,9 @@ func TestDAGRemove(t *testing.T) {
 			},
 			want: []Vertex{
 				&VirtualHost{
-					Port: 80,
-					host: "*",
+					Port:    80,
+					host:    "*",
+					aliases: []string{},
 					routes: routemap(
 						route("/", i1),
 					),
@@ -2520,8 +2584,9 @@ func TestDAGRemove(t *testing.T) {
 			},
 			want: []Vertex{
 				&VirtualHost{
-					Port: 80,
-					host: "*",
+					Port:    80,
+					host:    "*",
+					aliases: []string{},
 					routes: routemap(
 						route("/", i5),
 					),
@@ -2537,8 +2602,9 @@ func TestDAGRemove(t *testing.T) {
 			},
 			want: []Vertex{
 				&VirtualHost{
-					Port: 80,
-					host: "kuard.example.com",
+					Port:    80,
+					host:    "kuard.example.com",
+					aliases: []string{},
 					routes: routemap(
 						route("/", i3),
 					),
@@ -2563,15 +2629,17 @@ func TestDAGRemove(t *testing.T) {
 			},
 			want: []Vertex{
 				&VirtualHost{
-					Port: 80,
-					host: "a.example.com",
+					Port:    80,
+					host:    "a.example.com",
+					aliases: []string{},
 					routes: routemap(
 						route("/", i6),
 					),
 				},
 				&VirtualHost{
-					Port: 80,
-					host: "b.example.com",
+					Port:    80,
+					host:    "b.example.com",
+					aliases: []string{},
 					routes: routemap(
 						route("/", i6),
 					),
@@ -2588,8 +2656,9 @@ func TestDAGRemove(t *testing.T) {
 			},
 			want: []Vertex{
 				&VirtualHost{
-					Port: 80,
-					host: "a.example.com",
+					Port:    80,
+					host:    "a.example.com",
+					aliases: []string{},
 					routes: routemap(
 						route("/", i6, servicemap(
 							&Service{
@@ -2599,8 +2668,9 @@ func TestDAGRemove(t *testing.T) {
 						)),
 					),
 				}, &VirtualHost{
-					Port: 80,
-					host: "b.example.com",
+					Port:    80,
+					host:    "b.example.com",
+					aliases: []string{},
 					routes: routemap(
 						route("/", i6, servicemap(
 							&Service{
@@ -2622,15 +2692,17 @@ func TestDAGRemove(t *testing.T) {
 			},
 			want: []Vertex{
 				&VirtualHost{
-					Port: 80,
-					host: "a.example.com",
+					Port:    80,
+					host:    "a.example.com",
+					aliases: []string{},
 					routes: routemap(
 						route("/", i6),
 					),
 				},
 				&VirtualHost{
-					Port: 80,
-					host: "b.example.com",
+					Port:    80,
+					host:    "b.example.com",
+					aliases: []string{},
 					routes: routemap(
 						route("/", i6),
 					),
@@ -2658,8 +2730,9 @@ func TestDAGRemove(t *testing.T) {
 			},
 			want: []Vertex{
 				&VirtualHost{
-					Port: 80,
-					host: "b.example.com",
+					Port:    80,
+					host:    "b.example.com",
+					aliases: []string{},
 					routes: routemap(
 						route("/", i7, servicemap(
 							&Service{

--- a/internal/dag/dag.go
+++ b/internal/dag/dag.go
@@ -93,11 +93,14 @@ type VirtualHost struct {
 	// if the VirtualHost is generated inside Contour.
 	Port int
 
-	host   string
-	routes map[string]*Route
+	host    string
+	aliases []string
+	routes  map[string]*Route
 }
 
 func (v *VirtualHost) FQDN() string { return v.host }
+
+func (v *VirtualHost) Aliases() []string { return v.aliases }
 
 func (v *VirtualHost) Visit(f func(Vertex)) {
 	for _, r := range v.routes {

--- a/internal/dag/dag.go
+++ b/internal/dag/dag.go
@@ -118,9 +118,10 @@ type SecureVirtualHost struct {
 	// TLS minimum protocol version. Defaults to auth.TlsParameters_TLS_AUTO
 	MinProtoVersion auth.TlsParameters_TlsProtocol
 
-	host   string
-	routes map[string]*Route
-	secret *Secret
+	host    string
+	aliases []string
+	routes  map[string]*Route
+	secret  *Secret
 }
 
 func (s *SecureVirtualHost) Data() map[string][]byte {
@@ -131,6 +132,9 @@ func (s *SecureVirtualHost) Data() map[string][]byte {
 }
 
 func (s *SecureVirtualHost) FQDN() string { return s.host }
+
+func (s *SecureVirtualHost) Aliases() []string { return s.aliases }
+
 func (s *SecureVirtualHost) Visit(f func(Vertex)) {
 	for _, r := range s.routes {
 		f(r)


### PR DESCRIPTION
Fixes #451 by adding support for `Aliases` inside IngressRoute documents. Any alias defined is appended to the RDS `domains` array. 

Signed-off-by: Steve Sloka <steves@heptio.com>