### PR TITLE
internal/dag: avoid panic if spec.rule.paths.HTTP missing

### DIFF
--- a/internal/dag/builder.go
+++ b/internal/dag/builder.go
@@ -312,6 +312,11 @@ func (b *Builder) compute() *DAG {
 			if host == "" {
 				host = "*"
 			}
+			if rule.IngressRuleValue.HTTP == nil {
+				// HTTP can be nil as rule.IngressRuleValue's zero value contains
+				// a nil HTTP key.
+				continue
+			}
 			for n := range rule.IngressRuleValue.HTTP.Paths {
 				path := rule.IngressRuleValue.HTTP.Paths[n].Path
 				if path == "" {

--- a/internal/dag/builder_test.go
+++ b/internal/dag/builder_test.go
@@ -64,6 +64,21 @@ func TestDAGInsert(t *testing.T) {
 			}},
 		},
 	}
+
+	// i2a is missing a http key from the spec.rule.
+	// see issue 606
+	i2a := &v1beta1.Ingress{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "kuard",
+			Namespace: "default",
+		},
+		Spec: v1beta1.IngressSpec{
+			Rules: []v1beta1.IngressRule{{
+				Host: "test1.test.com",
+			}},
+		},
+	}
+
 	// i3 is similar to i2 but includes a hostname on the ingress rule
 	i3 := &v1beta1.Ingress{
 		ObjectMeta: metav1.ObjectMeta{
@@ -914,6 +929,12 @@ func TestDAGInsert(t *testing.T) {
 					),
 				},
 			},
+		},
+		"insert ingress with missing spec.rule.http key": {
+			objs: []interface{}{
+				i2a,
+			},
+			want: []Vertex{},
 		},
 		"insert ingress w/ host name and single backend": {
 			objs: []interface{}{


### PR DESCRIPTION
Fixes #606

rule.IngressRuleValue.HTTP can be nil as rule.IngressRuleValue's zero
value contains a nil HTTP field. This is possible with the following,
valid, YAML:
```
spec:
  rules:
  - host: test1.test.com
```

Signed-off-by: Dave Cheney <dave@cheney.net>