### PR TITLE
Add the equivalent of 'kubernetes.io/ingress.allow-http: false' to IngressRoute

### DIFF
--- a/apis/contour/v1beta1/ingressroute.go
+++ b/apis/contour/v1beta1/ingressroute.go
@@ -40,7 +40,7 @@ type VirtualHost struct {
 	// matching certificate
 	TLS *TLS `json:"tls"`
 	// If set to false, this virtual host will only be accessible via HTTPS.
-	AllowHTTP *bool `json:"allowHttp"`
+	HTTPAllowed *bool `json:"httpAllowed"`
 }
 
 // TLS describes tls properties. The CNI names that will be matched on

--- a/apis/contour/v1beta1/ingressroute.go
+++ b/apis/contour/v1beta1/ingressroute.go
@@ -39,6 +39,8 @@ type VirtualHost struct {
 	// are described in fqdn and aliases, the tls.secretName secret must contain a
 	// matching certificate
 	TLS *TLS `json:"tls"`
+	// If set to false, this virtual host will only be accessible via HTTPS.
+	AllowHTTP *bool `json:"allowHttp"`
 }
 
 // TLS describes tls properties. The CNI names that will be matched on

--- a/apis/contour/v1beta1/zz_generated.deepcopy.go
+++ b/apis/contour/v1beta1/zz_generated.deepcopy.go
@@ -247,8 +247,8 @@ func (in *VirtualHost) DeepCopyInto(out *VirtualHost) {
 			**out = **in
 		}
 	}
-	if in.AllowHTTP != nil {
-		in, out := &in.AllowHTTP, &out.AllowHTTP
+	if in.HTTPAllowed != nil {
+		in, out := &in.HTTPAllowed, &out.HTTPAllowed
 		if *in == nil {
 			*out = nil
 		} else {

--- a/apis/contour/v1beta1/zz_generated.deepcopy.go
+++ b/apis/contour/v1beta1/zz_generated.deepcopy.go
@@ -247,6 +247,15 @@ func (in *VirtualHost) DeepCopyInto(out *VirtualHost) {
 			**out = **in
 		}
 	}
+	if in.AllowHTTP != nil {
+		in, out := &in.AllowHTTP, &out.AllowHTTP
+		if *in == nil {
+			*out = nil
+		} else {
+			*out = new(bool)
+			**out = **in
+		}
+	}
 	return
 }
 

--- a/docs/ingressroute.md
+++ b/docs/ingressroute.md
@@ -216,7 +216,7 @@ spec:
           port: 80
 ```
 
-##### TLS
+#### TLS
 
 IngressRoutes follow a similar pattern to Ingress for configuring TLS credentials.
 
@@ -265,6 +265,28 @@ The TLS **Minimum Protocol Version** a vhost should negotiate can be specified b
   - 1.3
   - 1.2
   - 1.1 (Default)
+
+#### Disable HTTP
+
+IngressRoutes support disabling HTTP at the VHost level, so that the listener is only exposed over HTTPS. This is achieved by setting the `httpAllowed` field to `false`. If not set, this field defaults to `true`.
+
+This functionality is equivalent to the `kubernetes.io/ingress.allow-http: false` annotation supported in the Ingress resource.
+
+```yaml
+apiVersion: contour.heptio.com/v1beta1
+kind: IngressRoute
+metadata: 
+  name: disableHttp
+spec: 
+  virtualhost:
+    fqdn: foo-basic.bar.com
+    httpAllowed: false
+  routes: 
+    - match: /
+      services: 
+        - name: s1
+          port: 80
+```
 
 ### Routing
 

--- a/internal/dag/builder.go
+++ b/internal/dag/builder.go
@@ -390,7 +390,7 @@ func (b *builder) compute() *DAG {
 			}
 		}
 
-		b.processIngressRoute(ir, "", nil, host, ir.Spec.VirtualHost.Aliases, ir.Spec.VirtualHost.AllowHTTP == nil || *ir.Spec.VirtualHost.AllowHTTP)
+		b.processIngressRoute(ir, "", nil, host, ir.Spec.VirtualHost.Aliases, ir.Spec.VirtualHost.HTTPAllowed == nil || *ir.Spec.VirtualHost.HTTPAllowed)
 	}
 
 	return b.DAG()

--- a/internal/dag/builder.go
+++ b/internal/dag/builder.go
@@ -390,7 +390,7 @@ func (b *builder) compute() *DAG {
 			}
 		}
 
-		b.processIngressRoute(ir, "", nil, host, ir.Spec.VirtualHost.Aliases)
+		b.processIngressRoute(ir, "", nil, host, ir.Spec.VirtualHost.Aliases, ir.Spec.VirtualHost.AllowHTTP == nil || *ir.Spec.VirtualHost.AllowHTTP)
 	}
 
 	return b.DAG()
@@ -478,7 +478,7 @@ func (b *builder) rootAllowed(ir *ingressroutev1.IngressRoute) bool {
 	return false
 }
 
-func (b *builder) processIngressRoute(ir *ingressroutev1.IngressRoute, prefixMatch string, visited []*ingressroutev1.IngressRoute, host string, aliases []string) {
+func (b *builder) processIngressRoute(ir *ingressroutev1.IngressRoute, prefixMatch string, visited []*ingressroutev1.IngressRoute, host string, aliases []string, httpAllowed bool) {
 	visited = append(visited, ir)
 
 	for _, route := range ir.Spec.Routes {
@@ -512,7 +512,10 @@ func (b *builder) processIngressRoute(ir *ingressroutev1.IngressRoute, prefixMat
 					r.addService(svc, s.HealthCheck, s.Strategy, s.Weight)
 				}
 			}
-			b.lookupVirtualHost(host, 80, aliases...).routes[r.path] = r
+
+			if httpAllowed {
+				b.lookupVirtualHost(host, 80, aliases...).routes[r.path] = r
+			}
 
 			if hst := b.lookupSecureVirtualHost(host, 443, aliases...); hst.secret != nil {
 				b.lookupSecureVirtualHost(host, 443, aliases...).routes[r.path] = r
@@ -551,7 +554,7 @@ func (b *builder) processIngressRoute(ir *ingressroutev1.IngressRoute, prefixMat
 			}
 
 			// follow the link and process the target ingress route
-			b.processIngressRoute(dest, route.Match, visited, host, aliases)
+			b.processIngressRoute(dest, route.Match, visited, host, aliases, httpAllowed)
 		}
 	}
 	b.setStatus(Status{Object: ir, Status: StatusValid, Description: "valid IngressRoute", Vhost: host})

--- a/internal/dag/builder_test.go
+++ b/internal/dag/builder_test.go
@@ -828,8 +828,8 @@ func TestDAGInsert(t *testing.T) {
 		},
 		Spec: ingressroutev1.IngressRouteSpec{
 			VirtualHost: &ingressroutev1.VirtualHost{
-				Fqdn:      "disable-http.com",
-				AllowHTTP: &f,
+				Fqdn:        "disable-http.com",
+				HTTPAllowed: &f,
 			},
 			Routes: []ingressroutev1.Route{{
 				Match: "/foo",

--- a/internal/e2e/lds_test.go
+++ b/internal/e2e/lds_test.go
@@ -899,8 +899,8 @@ func TestIngressRouteHTTPNotAllowed(t *testing.T) {
 		},
 		Spec: ingressroutev1.IngressRouteSpec{
 			VirtualHost: &ingressroutev1.VirtualHost{
-				Fqdn:      "example.com",
-				AllowHTTP: &f,
+				Fqdn:        "example.com",
+				HTTPAllowed: &f,
 			},
 			Routes: []ingressroutev1.Route{{
 				Match: "/",

--- a/internal/e2e/lds_test.go
+++ b/internal/e2e/lds_test.go
@@ -873,6 +873,57 @@ func TestLDSIngressRouteOutsideRootNamespaces(t *testing.T) {
 	}, streamLDS(t, cc))
 }
 
+func TestIngressRouteHTTPNotAllowed(t *testing.T) {
+	rh, cc, done := setup(t, func(reh *contour.ResourceEventHandler) {
+		reh.IngressRouteRootNamespaces = []string{"roots"}
+		reh.Notifier.(*contour.CacheHandler).IngressRouteStatus = &k8s.IngressRouteStatus{
+			Client: fake.NewSimpleClientset(),
+		}
+	})
+	defer done()
+
+	// assert that there are no active listeners
+	assertEqual(t, &v2.DiscoveryResponse{
+		VersionInfo: "0",
+		Resources:   []types.Any{},
+		TypeUrl:     listenerType,
+		Nonce:       "0",
+	}, streamLDS(t, cc))
+
+	// ir1 is an ingressroute that does not allow HTTP access
+	f := false
+	ir1 := &ingressroutev1.IngressRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "simple",
+			Namespace: "default",
+		},
+		Spec: ingressroutev1.IngressRouteSpec{
+			VirtualHost: &ingressroutev1.VirtualHost{
+				Fqdn:      "example.com",
+				AllowHTTP: &f,
+			},
+			Routes: []ingressroutev1.Route{{
+				Match: "/",
+				Services: []ingressroutev1.Service{{
+					Name: "kuard",
+					Port: 8080,
+				}},
+			}},
+		},
+	}
+
+	// add ingressroute
+	rh.OnAdd(ir1)
+
+	// assert that there are no active listeners
+	assertEqual(t, &v2.DiscoveryResponse{
+		VersionInfo: "0",
+		Resources:   []types.Any{},
+		TypeUrl:     listenerType,
+		Nonce:       "0",
+	}, streamLDS(t, cc))
+}
+
 func streamLDS(t *testing.T, cc *grpc.ClientConn, rn ...string) *v2.DiscoveryResponse {
 	t.Helper()
 	rds := v2.NewListenerDiscoveryServiceClient(cc)


### PR DESCRIPTION
Fixes #455 

Adds a new field to the IngressRoute to control whether HTTP is allowed on a given VirtualHost:

```
spec:
  virtualhost:
    fqdn: "example.com"
    allowHttp: false
```

Update (Aug 10, 2018): renamed the `allowHttp` field to `httpAllowed`:

```
spec:
  virtualhost:
    fqdn: "example.com"
    httpAllowed: false
```