### PR TITLE
internal/dag: rename dag.Builder to dag.KubernetesCache

### DIFF
--- a/internal/contour/cachehandler.go
+++ b/internal/contour/cachehandler.go
@@ -42,7 +42,7 @@ type statusable interface {
 func (ch *CacheHandler) OnChange(b *dag.Builder) {
 	timer := prometheus.NewTimer(ch.CacheHandlerOnUpdateSummary)
 	defer timer.ObserveDuration()
-	dag := b.Compute()
+	dag := b.Build()
 	ch.setIngressRouteStatus(dag)
 	ch.updateListeners(dag)
 	ch.updateRoutes(dag)

--- a/internal/contour/cachehandler_test.go
+++ b/internal/contour/cachehandler_test.go
@@ -521,12 +521,15 @@ func TestIngressRouteMetrics(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			var b dag.Builder
-			b.IngressRouteRootNamespaces = tc.rootNamespaces
+			b := dag.Builder{
+				KubernetesCache: dag.KubernetesCache{
+					IngressRouteRootNamespaces: tc.rootNamespaces,
+				},
+			}
 			for _, o := range tc.objs {
 				b.Insert(o)
 			}
-			dag := b.Compute()
+			dag := b.Build()
 			gotMetrics := calculateIngressRouteMetric(dag)
 			if !reflect.DeepEqual(tc.want.Root, gotMetrics.Root) {
 				t.Fatalf("(metrics-Root) expected to find: %v but got: %v", tc.want.Root, gotMetrics.Root)

--- a/internal/contour/cluster_test.go
+++ b/internal/contour/cluster_test.go
@@ -752,7 +752,7 @@ func TestClusterVisit(t *testing.T) {
 			}
 			v := clusterVisitor{
 				ClusterCache: new(ClusterCache),
-				Visitable:    reh.Compute(),
+				Visitable:    reh.Build(),
 			}
 			got := v.Visit()
 			if !reflect.DeepEqual(tc.want, got) {

--- a/internal/contour/listener_test.go
+++ b/internal/contour/listener_test.go
@@ -431,7 +431,7 @@ func TestListenerVisit(t *testing.T) {
 			}
 			v := listenerVisitor{
 				ListenerCache: lc,
-				Visitable:     reh.Compute(),
+				Visitable:     reh.Build(),
 			}
 			got := v.Visit()
 			if !reflect.DeepEqual(tc.want, got) {

--- a/internal/contour/route_test.go
+++ b/internal/contour/route_test.go
@@ -1274,7 +1274,7 @@ func TestRouteVisit(t *testing.T) {
 			}
 			v := routeVisitor{
 				RouteCache: rc,
-				Visitable:  reh.Compute(),
+				Visitable:  reh.Build(),
 			}
 			got := v.Visit()
 			if !reflect.DeepEqual(tc.want, got) {

--- a/internal/dag/builder_test.go
+++ b/internal/dag/builder_test.go
@@ -2194,7 +2194,7 @@ func TestDAGInsert(t *testing.T) {
 			for _, o := range tc.objs {
 				b.Insert(o)
 			}
-			dag := b.Compute()
+			dag := b.Build()
 
 			got := make(map[hostport]Vertex)
 			dag.Visit(func(v Vertex) {
@@ -2914,7 +2914,7 @@ func TestDAGRemove(t *testing.T) {
 			for _, o := range tc.remove {
 				b.Remove(o)
 			}
-			dag := b.Compute()
+			dag := b.Build()
 
 			got := make(map[hostport]Vertex)
 			dag.Visit(func(v Vertex) {
@@ -3101,7 +3101,7 @@ func TestDAGIngressRouteCycle(t *testing.T) {
 	var b Builder
 	b.Insert(ir2)
 	b.Insert(ir1)
-	dag := b.Compute()
+	dag := b.Build()
 
 	got := make(map[hostport]*VirtualHost)
 	dag.Visit(func(v Vertex) {
@@ -3144,7 +3144,7 @@ func TestDAGIngressRouteCycleSelfEdge(t *testing.T) {
 
 	var b Builder
 	b.Insert(ir1)
-	dag := b.Compute()
+	dag := b.Build()
 
 	got := make(map[hostport]*VirtualHost)
 	dag.Visit(func(v Vertex) {
@@ -3182,7 +3182,7 @@ func TestDAGIngressRouteDelegatesToNonExistent(t *testing.T) {
 
 	var b Builder
 	b.Insert(ir1)
-	dag := b.Compute()
+	dag := b.Build()
 
 	got := make(map[hostport]*VirtualHost)
 	dag.Visit(func(v Vertex) {
@@ -3235,7 +3235,7 @@ func TestDAGIngressRouteDelegatePrefixDoesntMatch(t *testing.T) {
 	var b Builder
 	b.Insert(ir2)
 	b.Insert(ir1)
-	dag := b.Compute()
+	dag := b.Build()
 
 	got := make(map[hostport]*VirtualHost)
 	dag.Visit(func(v Vertex) {
@@ -3337,12 +3337,15 @@ func TestDAGRootNamespaces(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			var b Builder
-			b.IngressRouteRootNamespaces = tc.rootNamespaces
+			b := Builder{
+				KubernetesCache: KubernetesCache{
+					IngressRouteRootNamespaces: tc.rootNamespaces,
+				},
+			}
 			for _, o := range tc.objs {
 				b.Insert(o)
 			}
-			dag := b.Compute()
+			dag := b.Build()
 
 			var count int
 			dag.Visit(func(v Vertex) {
@@ -3400,7 +3403,7 @@ func TestDAGIngressRouteDelegatePrefixMatchesStringPrefixButNotPathPrefix(t *tes
 	var b Builder
 	b.Insert(ir2)
 	b.Insert(ir1)
-	dag := b.Compute()
+	dag := b.Build()
 
 	got := make(map[hostport]*VirtualHost)
 	dag.Visit(func(v Vertex) {
@@ -3853,12 +3856,15 @@ func TestDAGIngressRouteStatus(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			var b Builder
-			b.IngressRouteRootNamespaces = []string{"roots"}
+			b := Builder{
+				KubernetesCache: KubernetesCache{
+					IngressRouteRootNamespaces: []string{"roots"},
+				},
+			}
 			for _, o := range tc.objs {
 				b.Insert(o)
 			}
-			got := b.Compute().Statuses()
+			got := b.Build().Statuses()
 			if len(tc.want) != len(got) {
 				t.Fatalf("expected %d statuses, but got %d", len(tc.want), len(got))
 			}
@@ -3974,7 +3980,7 @@ func TestDAGIngressRouteUniqueFQDNs(t *testing.T) {
 			for _, o := range tc.objs {
 				b.Insert(o)
 			}
-			dag := b.Compute()
+			dag := b.Build()
 
 			got := make(map[hostport]Vertex)
 			dag.Visit(func(v Vertex) {

--- a/internal/debug/debug.go
+++ b/internal/debug/debug.go
@@ -50,10 +50,10 @@ func registerProfile(mux *http.ServeMux) {
 	mux.Handle("/debug/pprof/threadcreate", pprof.Handler("threadcreate"))
 }
 
-func registerDotWriter(mux *http.ServeMux, builder *dag.Builder) {
+func registerDotWriter(mux *http.ServeMux, b *dag.Builder) {
 	mux.HandleFunc("/debug/dag", func(w http.ResponseWriter, r *http.Request) {
 		dw := &dotWriter{
-			Builder: builder,
+			Builder: b,
 		}
 		dw.writeDot(w)
 	})

--- a/internal/debug/dot.go
+++ b/internal/debug/dot.go
@@ -85,7 +85,7 @@ func (dw *dotWriter) writeDot(w io.Writer) {
 		})
 	}
 
-	dw.Builder.Compute().Visit(visit)
+	dw.Builder.Build().Visit(visit)
 
 	fmt.Fprintln(w, "}")
 }


### PR DESCRIPTION
Updates #581 

Rename the current dag.Builder to dag.KubernetesCache. This violates the
tenet that the dag shouldn't know much about where k8s object come from,
but in return we free up the dag.Builder type to become a per build
invocation context.

Signed-off-by: Dave Cheney <dave@cheney.net>