### PR TITLE
internal/dag: assign routes to SecureVirtualHost speculatively

### DIFF
--- a/internal/dag/builder.go
+++ b/internal/dag/builder.go
@@ -516,10 +516,7 @@ func (b *builder) processIngressRoute(ir *ingressroutev1.IngressRoute, prefixMat
 			if httpAllowed {
 				b.lookupVirtualHost(host, 80, aliases...).routes[r.path] = r
 			}
-
-			if hst := b.lookupSecureVirtualHost(host, 443, aliases...); hst.secret != nil {
-				b.lookupSecureVirtualHost(host, 443, aliases...).routes[r.path] = r
-			}
+			b.lookupSecureVirtualHost(host, 443, aliases...).routes[r.path] = r
 			continue
 		}
 


### PR DESCRIPTION
Always assign routes to a SecureVirtualHost sepeculatively. Later,
during builder.DAG, we filter out SecureVirtualHosts that do not have a
secret assigned.

Signed-off-by: Dave Cheney <dave@cheney.net>