### PR TITLE
internal/dag: set all delegate routes orphaned initially

### DIFF
--- a/internal/dag/builder.go
+++ b/internal/dag/builder.go
@@ -348,12 +348,8 @@ func (b *builder) compute() *DAG {
 	// process ingressroute documents
 	for _, ir := range b.validIngressRoutes() {
 		if ir.Spec.VirtualHost == nil {
-			// delegate ingress route. mark as orphaned if we haven't reached it before.
-			// TODO(dfc) this check is redundant, the name and namespace of the ingressroute
-			// is globally unique.
-			if !b.orphaned[meta{name: ir.Name, namespace: ir.Namespace}] {
-				b.setOrphaned(ir.Name, ir.Namespace)
-			}
+			// mark delegate ingressroute orphaned.
+			b.setOrphaned(ir)
 			continue
 		}
 
@@ -463,12 +459,13 @@ func (b *builder) setStatus(st Status) {
 	b.statuses = append(b.statuses, st)
 }
 
-// setOrphaned marks namespace/name combination as orphaned.
-func (b *builder) setOrphaned(name, namespace string) {
+// setOrphaned records an ingressroute as orphaned.
+func (b *builder) setOrphaned(ir *ingressroutev1.IngressRoute) {
 	if b.orphaned == nil {
 		b.orphaned = make(map[meta]bool)
 	}
-	b.orphaned[meta{name: name, namespace: namespace}] = true
+	m := meta{name: ir.Name, namespace: ir.Namespace}
+	b.orphaned[m] = true
 }
 
 // rootAllowed returns true if the ingressroute lives in a permitted root namespace.


### PR DESCRIPTION
Address TODO from #629

The arguments to builder.setOrphaned already identify an ingressroute
uniquely by name and namespace, so there is no need to check if we've
already set the orphaned status bit as we will only ever encounter this
ingressroute once.

Also, as the orphaned bit is only set in a single pass over the set
of ingressroutes we don't need to check if we're setting a bit that was
previously unset -- the logic is simply, if you're a delegate
ingressroute, you are orphaned until proven otherwise.

Lastly, pass the ingressroute, not its name and namespace to
setOrphaned, this makes it harder to transpose the name and namespace
parameters (not that i've done that, several times).

Signed-off-by: Dave Cheney <dave@cheney.net>