### PR TITLE
internal/dag: switch from httpAllowed to httpsOnly

### DIFF
--- a/apis/contour/v1beta1/ingressroute.go
+++ b/apis/contour/v1beta1/ingressroute.go
@@ -39,8 +39,8 @@ type VirtualHost struct {
 	// are described in fqdn and aliases, the tls.secretName secret must contain a
 	// matching certificate
 	TLS *TLS `json:"tls"`
-	// If set to false, this virtual host will only be accessible via HTTPS.
-	HTTPAllowed *bool `json:"httpAllowed"`
+	// If set to true, this virtual host will only be accessible via HTTPS.
+	HTTPSOnly bool `json:"httpsOnly"`
 }
 
 // TLS describes tls properties. The CNI names that will be matched on

--- a/apis/contour/v1beta1/zz_generated.deepcopy.go
+++ b/apis/contour/v1beta1/zz_generated.deepcopy.go
@@ -247,15 +247,6 @@ func (in *VirtualHost) DeepCopyInto(out *VirtualHost) {
 			**out = **in
 		}
 	}
-	if in.HTTPAllowed != nil {
-		in, out := &in.HTTPAllowed, &out.HTTPAllowed
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(bool)
-			**out = **in
-		}
-	}
 	return
 }
 

--- a/docs/ingressroute.md
+++ b/docs/ingressroute.md
@@ -268,7 +268,7 @@ The TLS **Minimum Protocol Version** a vhost should negotiate can be specified b
 
 #### Disable HTTP
 
-IngressRoutes support disabling HTTP at the VHost level, so that the listener is only exposed over HTTPS. This is achieved by setting the `httpAllowed` field to `false`. If not set, this field defaults to `true`.
+IngressRoutes support disabling HTTP at the VHost level, so that the listener is only exposed over HTTPS. This is achieved by setting the `httpsOnly` field to `true`.
 
 This functionality is equivalent to the `kubernetes.io/ingress.allow-http: false` annotation supported in the Ingress resource.
 
@@ -280,7 +280,7 @@ metadata:
 spec: 
   virtualhost:
     fqdn: foo-basic.bar.com
-    httpAllowed: false
+    httpsOnly: true
   routes: 
     - match: /
       services: 

--- a/internal/dag/builder.go
+++ b/internal/dag/builder.go
@@ -389,7 +389,7 @@ func (b *builder) compute() *DAG {
 			}
 		}
 
-		b.processIngressRoute(ir, "", nil, host, ir.Spec.VirtualHost.HTTPAllowed == nil || *ir.Spec.VirtualHost.HTTPAllowed)
+		b.processIngressRoute(ir, "", nil, host, ir.Spec.VirtualHost.HTTPSOnly)
 	}
 
 	return b.DAG()
@@ -481,7 +481,7 @@ func (b *builder) rootAllowed(ir *ingressroutev1.IngressRoute) bool {
 	return false
 }
 
-func (b *builder) processIngressRoute(ir *ingressroutev1.IngressRoute, prefixMatch string, visited []*ingressroutev1.IngressRoute, host string, httpAllowed bool) {
+func (b *builder) processIngressRoute(ir *ingressroutev1.IngressRoute, prefixMatch string, visited []*ingressroutev1.IngressRoute, host string, httpsOnly bool) {
 	visited = append(visited, ir)
 
 	for _, route := range ir.Spec.Routes {
@@ -516,7 +516,7 @@ func (b *builder) processIngressRoute(ir *ingressroutev1.IngressRoute, prefixMat
 				}
 			}
 
-			if httpAllowed {
+			if !httpsOnly {
 				b.lookupVirtualHost(host, 80).addRoute(r)
 			}
 			b.lookupSecureVirtualHost(host, 443).addRoute(r)
@@ -554,7 +554,7 @@ func (b *builder) processIngressRoute(ir *ingressroutev1.IngressRoute, prefixMat
 			}
 
 			// follow the link and process the target ingress route
-			b.processIngressRoute(dest, route.Match, visited, host, httpAllowed)
+			b.processIngressRoute(dest, route.Match, visited, host, httpsOnly)
 		}
 	}
 	b.setStatus(Status{Object: ir, Status: StatusValid, Description: "valid IngressRoute", Vhost: host})

--- a/internal/dag/builder_test.go
+++ b/internal/dag/builder_test.go
@@ -820,7 +820,6 @@ func TestDAGInsert(t *testing.T) {
 	}
 
 	// ir12 disables HTTP access
-	f := false
 	ir12 := &ingressroutev1.IngressRoute{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "disable-http",
@@ -828,8 +827,8 @@ func TestDAGInsert(t *testing.T) {
 		},
 		Spec: ingressroutev1.IngressRouteSpec{
 			VirtualHost: &ingressroutev1.VirtualHost{
-				Fqdn:        "disable-http.com",
-				HTTPAllowed: &f,
+				Fqdn:      "disable-http.com",
+				HTTPSOnly: true,
 			},
 			Routes: []ingressroutev1.Route{{
 				Match: "/foo",

--- a/internal/e2e/lds_test.go
+++ b/internal/e2e/lds_test.go
@@ -891,7 +891,6 @@ func TestIngressRouteHTTPNotAllowed(t *testing.T) {
 	}, streamLDS(t, cc))
 
 	// ir1 is an ingressroute that does not allow HTTP access
-	f := false
 	ir1 := &ingressroutev1.IngressRoute{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "simple",
@@ -899,8 +898,8 @@ func TestIngressRouteHTTPNotAllowed(t *testing.T) {
 		},
 		Spec: ingressroutev1.IngressRouteSpec{
 			VirtualHost: &ingressroutev1.VirtualHost{
-				Fqdn:        "example.com",
-				HTTPAllowed: &f,
+				Fqdn:      "example.com",
+				HTTPSOnly: true,
 			},
 			Routes: []ingressroutev1.Route{{
 				Match: "/",


### PR DESCRIPTION
Fixes #627

Invert the logic of spec.virtualhost.httpAllowed: false to
spec.virtualhost.httpsOnly true. This makes the zero value of the field
default to false, meaning http and https permitted, without indirecting
via a *bool.