### PR TITLE
internal/dag: make route weights part of the service's cache properties

### DIFF
--- a/internal/dag/dag.go
+++ b/internal/dag/dag.go
@@ -51,7 +51,7 @@ func (d *DAG) Statuses() []Status {
 type Route struct {
 	path     string
 	Object   interface{} // one of Ingress or IngressRoute
-	services map[portmeta]*Service
+	services map[servicemeta]*Service
 
 	// Should this route generate a 301 upgrade if accessed
 	// over HTTP?
@@ -70,13 +70,12 @@ type Route struct {
 
 func (r *Route) Prefix() string { return r.path }
 
-func (r *Route) addService(s *Service, hc *ingressroutev1.HealthCheck, lbStrat string, weight int) {
+func (r *Route) addService(s *Service, hc *ingressroutev1.HealthCheck, lbStrat string) {
 	if r.services == nil {
-		r.services = make(map[portmeta]*Service)
+		r.services = make(map[servicemeta]*Service)
 	}
 	s.HealthCheck = hc
 	s.LoadBalancerStrategy = lbStrat
-	s.Weight = weight
 	r.services[s.toMeta()] = s
 }
 
@@ -201,17 +200,19 @@ func (s *Service) Name() string       { return s.Object.Name }
 func (s *Service) Namespace() string  { return s.Object.Namespace }
 func (s *Service) Visit(func(Vertex)) {}
 
-type portmeta struct {
+type servicemeta struct {
 	name      string
 	namespace string
 	port      int32
+	weight    int
 }
 
-func (s *Service) toMeta() portmeta {
-	return portmeta{
+func (s *Service) toMeta() servicemeta {
+	return servicemeta{
 		name:      s.Object.Name,
 		namespace: s.Object.Namespace,
 		port:      s.Port,
+		weight:    s.Weight,
 	}
 }
 

--- a/internal/e2e/cds_test.go
+++ b/internal/e2e/cds_test.go
@@ -587,7 +587,7 @@ func TestClusterCircuitbreakerAnnotations(t *testing.T) {
 }
 
 // issue 581, different service parameters should generate
-// separate cds entries.
+// a single CDS entry if they differ only in weight.
 func TestClusterPerServiceParameters(t *testing.T) {
 	rh, cc, done := setup(t)
 	defer done()

--- a/internal/e2e/cds_test.go
+++ b/internal/e2e/cds_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 	envoy_type "github.com/envoyproxy/go-control-plane/envoy/type"
 	"github.com/gogo/protobuf/types"
+	ingressroutev1 "github.com/heptio/contour/apis/contour/v1beta1"
 	"google.golang.org/grpc"
 	"k8s.io/api/core/v1"
 	"k8s.io/api/extensions/v1beta1"
@@ -579,6 +580,61 @@ func TestClusterCircuitbreakerAnnotations(t *testing.T) {
 					},
 				},
 			}),
+		},
+		TypeUrl: clusterType,
+		Nonce:   "0",
+	}, streamCDS(t, cc))
+}
+
+// issue 581, different service parameters should generate
+// separate cds entries.
+func TestClusterPerServiceParameters(t *testing.T) {
+	rh, cc, done := setup(t)
+	defer done()
+
+	rh.OnAdd(&v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "kuard",
+			Namespace: "default",
+		},
+		Spec: v1.ServiceSpec{
+			Ports: []v1.ServicePort{{
+				Protocol:   "TCP",
+				Port:       80,
+				TargetPort: intstr.FromInt(8080),
+			}},
+		},
+	})
+
+	rh.OnAdd(&ingressroutev1.IngressRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "simple",
+			Namespace: "default",
+		},
+		Spec: ingressroutev1.IngressRouteSpec{
+			VirtualHost: &ingressroutev1.VirtualHost{Fqdn: "www.example.com"},
+			Routes: []ingressroutev1.Route{{
+				Match: "/a",
+				Services: []ingressroutev1.Service{{
+					Name:   "kuard",
+					Port:   80,
+					Weight: 90,
+				}},
+			}, {
+				Match: "/b",
+				Services: []ingressroutev1.Service{{
+					Name:   "kuard",
+					Port:   80,
+					Weight: 60,
+				}},
+			}},
+		},
+	})
+
+	assertEqual(t, &v2.DiscoveryResponse{
+		VersionInfo: "0",
+		Resources: []types.Any{
+			any(t, cluster("default/kuard/80", "default/kuard")),
 		},
 		TypeUrl: clusterType,
 		Nonce:   "0",


### PR DESCRIPTION
Updates #581 

Move service weight assignment from Route.addService to builder.lookupService. This means services with different route weightings are considered different from the POV of the DAG -- each call to lookupService with a different weight will result in a new service entry in the builder's cache.

However, this does not affect the name of the CDS entry as service weights are a property of RDS, not CDS.

This resolves one form of ambiguity related to #581; services reachable by multiple routes or present multiple times in the same route, both with differing weights, will now behave properly.