### PR TITLE
internal/contour: Implement prometheus metric for last DAG rebuilt timestamp

### DIFF
--- a/design/ingressroute-design.md
+++ b/design/ingressroute-design.md
@@ -374,6 +374,7 @@ Metrics are essential to any system. Contour will expose a `/metrics` Prometheus
 - **contour_ingressroute_invalid_total (gauge):**  Number of `Invalid` IngressRoute objects
   - namespace
   - vhost
+- **contour_ingressroute_dagrebuild_timestamp (gauge):** Timestamp of the last DAG rebuild
 
 ## Envoy Metrics
 

--- a/docs/prometheus.md
+++ b/docs/prometheus.md
@@ -45,3 +45,21 @@ Prometheus needs a configuration block that looks like this:
 The main difference from the [official Prometheus Kubernetes sample config](https://github.com/prometheus/prometheus/blob/master/documentation/examples/prometheus-kubernetes.yml)
 is the added interpretation of the `__meta_kubernetes_pod_annotation_prometheus_io_format` label, because Envoy
 currently requires a [`format=prometheus` url parameter to return the stats in Prometheus format.](https://github.com/envoyproxy/envoy/issues/2182)
+
+## Metrics
+
+Metrics are essential to any system. Contour will expose a `/metrics` Prometheus endpoint with the following metrics:
+
+- **contour_ingressroute_total (gauge):** Total number of IngressRoutes objects that exist regardless of status (i.e. Valid / Invalid / Orphaned, etc). This metric should match the sum of `Orphaned` + `Valid` + `Invalid` IngressRoutes.
+  - namespace
+- **contour_ingressroute_orphaned_total (gauge):**  Number of `Orphaned` IngressRoute objects which have no root delegating to them
+  - namespace
+- **contour_ingressroute_root_total (gauge):**  Number of `Root` IngressRoute objects (Note: There will only be a single `Root` IngressRoute per vhost)
+  - namespace
+- **contour_ingressroute_valid_total (gauge):**  Number of `Valid` IngressRoute objects
+  - namespace
+  - vhost
+- **contour_ingressroute_invalid_total (gauge):**  Number of `Invalid` IngressRoute objects
+  - namespace
+  - vhost
+- **contour_ingressroute_dagrebuild_timestamp (gauge):** Timestamp of the last DAG rebuild

--- a/internal/contour/holdoff.go
+++ b/internal/contour/holdoff.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/heptio/contour/internal/dag"
+	"github.com/heptio/contour/internal/metrics"
 	"github.com/sirupsen/logrus"
 )
 
@@ -35,6 +36,7 @@ type HoldoffNotifier struct {
 
 	// Notifier to be called after delay.
 	Notifier
+	*metrics.Metrics
 
 	logrus.FieldLogger
 
@@ -55,6 +57,7 @@ func (hn *HoldoffNotifier) OnChange(builder *dag.Builder) {
 		hn.WithField("last update", since).Info("forcing update")
 		hn.Notifier.OnChange(builder)
 		hn.last = time.Now()
+		hn.Metrics.SetDAGRebuiltMetric(hn.last.Unix())
 		return
 	}
 
@@ -65,5 +68,6 @@ func (hn *HoldoffNotifier) OnChange(builder *dag.Builder) {
 		hn.WithField("last update", time.Since(hn.last)).Info("performing delayed update")
 		hn.Notifier.OnChange(builder)
 		hn.last = time.Now()
+		hn.Metrics.SetDAGRebuiltMetric(hn.last.Unix())
 	})
 }

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -24,11 +24,12 @@ import (
 
 // Metrics provide Prometheus metrics for the app
 type Metrics struct {
-	ingressRouteTotalGauge     *prometheus.GaugeVec
-	ingressRouteRootTotalGauge *prometheus.GaugeVec
-	ingressRouteInvalidGauge   *prometheus.GaugeVec
-	ingressRouteValidGauge     *prometheus.GaugeVec
-	ingressRouteOrphanedGauge  *prometheus.GaugeVec
+	ingressRouteTotalGauge      *prometheus.GaugeVec
+	ingressRouteRootTotalGauge  *prometheus.GaugeVec
+	ingressRouteInvalidGauge    *prometheus.GaugeVec
+	ingressRouteValidGauge      *prometheus.GaugeVec
+	ingressRouteOrphanedGauge   *prometheus.GaugeVec
+	ingressRouteDAGRebuildGauge *prometheus.GaugeVec
 
 	CacheHandlerOnUpdateSummary prometheus.Summary
 	ResourceEventHandlerSummary *prometheus.SummaryVec
@@ -49,11 +50,12 @@ type Meta struct {
 }
 
 const (
-	IngressRouteTotalGauge     = "contour_ingressroute_total"
-	IngressRouteRootTotalGauge = "contour_ingressroute_root_total"
-	IngressRouteInvalidGauge   = "contour_ingressroute_invalid_total"
-	IngressRouteValidGauge     = "contour_ingressroute_valid_total"
-	IngressRouteOrphanedGauge  = "contour_ingressroute_orphaned_total"
+	IngressRouteTotalGauge      = "contour_ingressroute_total"
+	IngressRouteRootTotalGauge  = "contour_ingressroute_root_total"
+	IngressRouteInvalidGauge    = "contour_ingressroute_invalid_total"
+	IngressRouteValidGauge      = "contour_ingressroute_valid_total"
+	IngressRouteOrphanedGauge   = "contour_ingressroute_orphaned_total"
+	IngressRouteDAGRebuildGauge = "contour_ingressroute_dagrebuild_timestamp"
 
 	cacheHandlerOnUpdateSummary = "contour_cachehandler_onupdate_duration_seconds"
 	resourceEventHandlerSummary = "contour_resourceeventhandler_duration_seconds"
@@ -98,6 +100,13 @@ func NewMetrics(registry *prometheus.Registry) *Metrics {
 			},
 			[]string{"namespace"},
 		),
+		ingressRouteDAGRebuildGauge: prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Name: IngressRouteDAGRebuildGauge,
+				Help: "Timestamp of the last DAG rebuild",
+			},
+			[]string{},
+		),
 		CacheHandlerOnUpdateSummary: prometheus.NewSummary(prometheus.SummaryOpts{
 			Name:       cacheHandlerOnUpdateSummary,
 			Help:       "Histogram for the runtime of xDS cache regeneration",
@@ -123,9 +132,15 @@ func (m *Metrics) register(registry *prometheus.Registry) {
 		m.ingressRouteInvalidGauge,
 		m.ingressRouteValidGauge,
 		m.ingressRouteOrphanedGauge,
+		m.ingressRouteDAGRebuildGauge,
 		m.CacheHandlerOnUpdateSummary,
 		m.ResourceEventHandlerSummary,
 	)
+}
+
+// SetDAGRebuiltMetric records the last time the DAG was rebuilt
+func (m *Metrics) SetDAGRebuiltMetric(timestamp int64) {
+	m.ingressRouteDAGRebuildGauge.WithLabelValues().Set(float64(timestamp))
 }
 
 // SetIngressRouteMetric takes


### PR DESCRIPTION
Fixes #591 by adding a Prometheus metric which records the last time the DAG was rebuilt. 

Did a quick test with Grafana and could visualize like this (as an example):
![screen shot 2018-08-16 at 4 13 46 pm](https://user-images.githubusercontent.com/1048184/44233231-44a76e80-a171-11e8-9c09-6910b95776c6.png)


Signed-off-by: Steve Sloka <steves@heptio.com>