### PR TITLE
internal/contour: sort clusters with the same name by weight

### DIFF
--- a/internal/e2e/rds_test.go
+++ b/internal/e2e/rds_test.go
@@ -1699,8 +1699,9 @@ func TestRouteWithAServiceWeight(t *testing.T) {
 					Port:   80,
 					Weight: 90,
 				}, {
-					Name: "kuard",
-					Port: 80, Weight: 60,
+					Name:   "kuard",
+					Port:   80,
+					Weight: 60,
 				}},
 			}},
 		},
@@ -1713,8 +1714,8 @@ func TestRouteWithAServiceWeight(t *testing.T) {
 		Routes: []route.Route{{
 			Match: prefixmatch("/a"), // match all
 			Action: routeweightedcluster(
-				weightedcluster{"default/kuard/80", 90},
 				weightedcluster{"default/kuard/80", 60},
+				weightedcluster{"default/kuard/80", 90},
 			),
 		}},
 	}}, nil)


### PR DESCRIPTION
Fixes #638

Weight was added to Service in #635. Ensure that clusters with the same
name have a stable weight sorting.

Signed-off-by: Dave Cheney <dave@cheney.net>