### PR TITLE
internal/dag: Enforce TLS

### DIFF
--- a/apis/contour/v1beta1/ingressroute.go
+++ b/apis/contour/v1beta1/ingressroute.go
@@ -36,8 +36,6 @@ type VirtualHost struct {
 	// are described in fqdn and aliases, the tls.secretName secret must contain a
 	// matching certificate
 	TLS *TLS `json:"tls"`
-	// If set to true, this virtual host will only be accessible via HTTPS.
-	HTTPSOnly bool `json:"httpsOnly"`
 }
 
 // TLS describes tls properties. The CNI names that will be matched on
@@ -60,6 +58,9 @@ type Route struct {
 	Delegate `json:"delegate"`
 	// Enables websocket support for the route
 	EnableWebsockets bool `json:"enableWebsockets"`
+	// Allow this path to respond to insecure requests over HTTP which are normally
+	// not permitted when a `virtualhost.tls` block is present.
+	PermitInsecure bool `json:"permitInsecure"`
 }
 
 // Service defines an upstream to proxy traffic to

--- a/design/ingressroute-design.md
+++ b/design/ingressroute-design.md
@@ -94,6 +94,8 @@ spec:
     service:
     - name: google-static
       port: 9000
+    # If enforceTLS is specified, allows any request to this path to serve insecure requests
+    permitInsecure: true
   - match: /finance
     # delegate delegates the matching route to another IngressRoute object.
     # This delegates the responsibility for /finance to the IngressRoute matching the delegate parameters
@@ -167,13 +169,6 @@ The following list are the options available to choose from:
 - **Random:** The random load balancer selects a random healthy host
 
 More documentation on Envoy's lb support can be found here: [https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/load_balancing.html](https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/load_balancing.html)
-
-### TLS
-
-- **minimumProtocolVersion**: Define the minimum TLS version a vhost should negotiate. Allowed values:
-  - 1.3
-  - 1.2
-  - 1.1 (Default)
 
 ### Healthcheck
 
@@ -315,6 +310,20 @@ TLS configuration, certificates, and cipher suites, remain similar in form to th
 However, because the `spec.virtualhost.tls` is present only in root objects, there is no ambiguity as to which IngressRoute holds the canonical TLS information. (This cannot be said for the current Ingress object).
 This also implies that the IngressRoute root and the TLS Secret must live in the same namespace.
 However as mentioned above, the entire routespace (/ onwards) can be delegated to another namespace, which allows operators to define virtual hosts and their TLS configuration in one namespace, and delegate the operation of those virtual hosts to another namespace.
+
+Since defining a TLS section of a root IngressRoute tells Contour that it should set up a TLS listener and serve the provided TLS certificate/key, it's inherent that all requests be served over TLS. 
+This results in any request to an insecure endpoint will receive a 301 http status code informing the client to redirect to the secure endpoint. No additional parameters need to be set for this functionality other than specifying TLS on the IngressRoute.
+
+Additionally, it may be necessary to serve specific routes over an insecure endpoint. 
+An example would be the challenges sent from LetsEncyrpt. Specific routes can set the permitInsecure parameter which will let that route serve insecure or secure traffic (Meaning no 301 redirects).
+
+### Parameters
+
+- **secretName**: Name of secret containing certificate and key used to terminate TLS connections.
+- **minimumProtocolVersion**: Define the minimum TLS version a vhost should negotiate. Allowed values:
+  - 1.3
+  - 1.2
+  - 1.1 (Default)
 
 # Example Use-Cases
 

--- a/internal/contour/route_test.go
+++ b/internal/contour/route_test.go
@@ -334,8 +334,12 @@ func TestRouteVisit(t *testing.T) {
 						Name:    "www.example.com",
 						Domains: []string{"www.example.com", "www.example.com:80"},
 						Routes: []route.Route{{
-							Match:  prefixmatch("/"),
-							Action: routeroute("default/backend/8080"),
+							Match: prefixmatch("/"),
+							Action: &route.Route_Redirect{
+								Redirect: &route.RedirectAction{
+									HttpsRedirect: true,
+								},
+							},
 						}},
 					}},
 				},

--- a/internal/dag/builder_test.go
+++ b/internal/dag/builder_test.go
@@ -793,27 +793,6 @@ func TestDAGInsert(t *testing.T) {
 		},
 	}
 
-	// ir12 disables HTTP access
-	ir12 := &ingressroutev1.IngressRoute{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "disable-http",
-			Namespace: "default",
-		},
-		Spec: ingressroutev1.IngressRouteSpec{
-			VirtualHost: &ingressroutev1.VirtualHost{
-				Fqdn:      "disable-http.com",
-				HTTPSOnly: true,
-			},
-			Routes: []ingressroutev1.Route{{
-				Match: "/foo",
-				Services: []ingressroutev1.Service{{
-					Name: "kuarder",
-					Port: 8080,
-				}},
-			}},
-		},
-	}
-
 	// ir13 has two routes to the same service with different
 	// weights
 	ir13 := &ingressroutev1.IngressRoute{
@@ -861,6 +840,30 @@ func TestDAGInsert(t *testing.T) {
 					Name:   "kuard",
 					Port:   8080,
 					Weight: 60,
+				}},
+			}},
+		},
+	}
+
+	// ir14 has TLS and allows insecure
+	ir14 := &ingressroutev1.IngressRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "example-com",
+			Namespace: "default",
+		},
+		Spec: ingressroutev1.IngressRouteSpec{
+			VirtualHost: &ingressroutev1.VirtualHost{
+				Fqdn: "foo.com",
+				TLS: &ingressroutev1.TLS{
+					SecretName: "secret",
+				},
+			},
+			Routes: []ingressroutev1.Route{{
+				Match:          "/",
+				PermitInsecure: true,
+				Services: []ingressroutev1.Service{{
+					Name: "kuard",
+					Port: 8080,
 				}},
 			}},
 		},
@@ -1742,28 +1745,80 @@ func TestDAGInsert(t *testing.T) {
 					Port: 80,
 					host: "foo.com",
 					routes: routemap(
-						route("/", ir6, servicemap(
-							&Service{
-								Object:      s1,
-								ServicePort: &s1.Spec.Ports[0],
-							},
-						)),
-					),
-				},
-				&SecureVirtualHost{
-					VirtualHost: VirtualHost{
-						Port: 443,
-						host: "foo.com",
-						routes: routemap(
-							route("/", ir6, servicemap(
+						&Route{
+							path:   "/",
+							Object: ir6,
+							services: servicemap(
 								&Service{
 									Object:      s1,
 									ServicePort: &s1.Spec.Ports[0],
 								},
-							)),
-						),
-					},
+							),
+							HTTPSUpgrade: true,
+						},
+					),
+				},
+				&SecureVirtualHost{
 					MinProtoVersion: auth.TlsParameters_TLSv1_1,
+					VirtualHost: VirtualHost{
+						Port: 443,
+						host: "foo.com",
+						routes: routemap(
+							&Route{
+								path:   "/",
+								Object: ir6,
+								services: servicemap(
+									&Service{
+										Object:      s1,
+										ServicePort: &s1.Spec.Ports[0],
+									},
+								),
+								HTTPSUpgrade: true,
+							}),
+					},
+					secret: &Secret{
+						object: sec1,
+					},
+				}},
+		},
+		"insert ingressroute with TLS one insecure": {
+			objs: []interface{}{
+				ir14, s1, sec1,
+			},
+			want: []Vertex{
+				&VirtualHost{
+					Port: 80,
+					host: "foo.com",
+					routes: routemap(
+						&Route{
+							path:   "/",
+							Object: ir14,
+							services: servicemap(
+								&Service{
+									Object:      s1,
+									ServicePort: &s1.Spec.Ports[0],
+								},
+							),
+						},
+					),
+				},
+				&SecureVirtualHost{
+					MinProtoVersion: auth.TlsParameters_TLSv1_1,
+					VirtualHost: VirtualHost{
+						Port: 443,
+						host: "foo.com",
+						routes: routemap(
+							&Route{
+								path:   "/",
+								Object: ir14,
+								services: servicemap(
+									&Service{
+										Object:      s1,
+										ServicePort: &s1.Spec.Ports[0],
+									},
+								),
+							}),
+					},
 					secret: &Secret{
 						object: sec1,
 					},
@@ -1778,12 +1833,17 @@ func TestDAGInsert(t *testing.T) {
 					Port: 80,
 					host: "foo.com",
 					routes: routemap(
-						route("/", ir7, servicemap(
-							&Service{
-								Object:      s1,
-								ServicePort: &s1.Spec.Ports[0],
-							},
-						)),
+						&Route{
+							path:   "/",
+							Object: ir7,
+							services: servicemap(
+								&Service{
+									Object:      s1,
+									ServicePort: &s1.Spec.Ports[0],
+								},
+							),
+							HTTPSUpgrade: true,
+						},
 					),
 				},
 				&SecureVirtualHost{
@@ -1791,12 +1851,17 @@ func TestDAGInsert(t *testing.T) {
 						Port: 443,
 						host: "foo.com",
 						routes: routemap(
-							route("/", ir7, servicemap(
-								&Service{
-									Object:      s1,
-									ServicePort: &s1.Spec.Ports[0],
-								},
-							)),
+							&Route{
+								path:   "/",
+								Object: ir7,
+								services: servicemap(
+									&Service{
+										Object:      s1,
+										ServicePort: &s1.Spec.Ports[0],
+									},
+								),
+								HTTPSUpgrade: true,
+							},
 						),
 					},
 					MinProtoVersion: auth.TlsParameters_TLSv1_2,
@@ -1813,26 +1878,34 @@ func TestDAGInsert(t *testing.T) {
 				&VirtualHost{
 					Port: 80,
 					host: "foo.com",
-					routes: routemap(
-						route("/", ir8, servicemap(
+					routes: routemap(&Route{
+						path:   "/",
+						Object: ir8,
+						services: servicemap(
 							&Service{
 								Object:      s1,
 								ServicePort: &s1.Spec.Ports[0],
 							},
-						)),
-					),
+						),
+						HTTPSUpgrade: true,
+					}),
 				},
 				&SecureVirtualHost{
 					VirtualHost: VirtualHost{
 						Port: 443,
 						host: "foo.com",
 						routes: routemap(
-							route("/", ir8, servicemap(
-								&Service{
-									Object:      s1,
-									ServicePort: &s1.Spec.Ports[0],
-								},
-							)),
+							&Route{
+								path:   "/",
+								Object: ir8,
+								services: servicemap(
+									&Service{
+										Object:      s1,
+										ServicePort: &s1.Spec.Ports[0],
+									},
+								),
+								HTTPSUpgrade: true,
+							},
 						),
 					},
 					MinProtoVersion: auth.TlsParameters_TLSv1_3,
@@ -1850,26 +1923,34 @@ func TestDAGInsert(t *testing.T) {
 					Port: 80,
 					host: "foo.com",
 					routes: routemap(
-						route("/", ir9, servicemap(
-							&Service{
-								Object:      s1,
-								ServicePort: &s1.Spec.Ports[0],
-							},
-						)),
-					),
+						&Route{
+							path:   "/",
+							Object: ir9,
+							services: servicemap(
+								&Service{
+									Object:      s1,
+									ServicePort: &s1.Spec.Ports[0],
+								},
+							),
+							HTTPSUpgrade: true,
+						}),
 				},
 				&SecureVirtualHost{
 					VirtualHost: VirtualHost{
 						Port: 443,
 						host: "foo.com",
 						routes: routemap(
-							route("/", ir9, servicemap(
-								&Service{
-									Object:      s1,
-									ServicePort: &s1.Spec.Ports[0],
-								},
-							)),
-						),
+							&Route{
+								path:   "/",
+								Object: ir9,
+								services: servicemap(
+									&Service{
+										Object:      s1,
+										ServicePort: &s1.Spec.Ports[0],
+									},
+								),
+								HTTPSUpgrade: true,
+							}),
 					},
 					MinProtoVersion: auth.TlsParameters_TLSv1_1,
 					secret: &Secret{
@@ -2209,48 +2290,6 @@ func TestDAGInsert(t *testing.T) {
 					),
 				},
 			},
-		},
-		"insert ingressroute that does not allow HTTP": {
-			objs: []interface{}{
-				ir12, s2,
-			},
-			want: []Vertex{},
-		},
-		"insert one ingressroute that allows HTTP, and another one that does not": {
-			objs: []interface{}{
-				ir1, s1, ir12, s2,
-			},
-			want: []Vertex{
-				&VirtualHost{
-					Port: 80,
-					host: "example.com",
-					routes: routemap(
-						route("/", ir1, servicemap(
-							&Service{
-								Object:      s1,
-								ServicePort: &s1.Spec.Ports[0],
-							},
-						)),
-					),
-				}},
-		},
-		"insert one ingressroute that does not allow HTTP, and another one that does": {
-			objs: []interface{}{
-				ir12, s2, ir1, s1,
-			},
-			want: []Vertex{
-				&VirtualHost{
-					Port: 80,
-					host: "example.com",
-					routes: routemap(
-						route("/", ir1, servicemap(
-							&Service{
-								Object:      s1,
-								ServicePort: &s1.Spec.Ports[0],
-							},
-						)),
-					),
-				}},
 		},
 		"insert ingressroute with two routes to the same service": {
 			objs: []interface{}{
@@ -4188,6 +4227,43 @@ func TestHttpPaths(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			got := httppaths(tc.rule)
+			if !reflect.DeepEqual(tc.want, got) {
+				t.Fatalf("expected:\n%v\ngot:\n%v", tc.want, got)
+			}
+		})
+	}
+}
+func TestEnforceRoute(t *testing.T) {
+	tests := map[string]struct {
+		tlsEnabled     bool
+		permitInsecure bool
+		want           bool
+	}{
+		"tls not enabled": {
+			tlsEnabled:     false,
+			permitInsecure: false,
+			want:           false,
+		},
+		"tls enabled": {
+			tlsEnabled:     true,
+			permitInsecure: false,
+			want:           true,
+		},
+		"tls enabled but insecure requested": {
+			tlsEnabled:     true,
+			permitInsecure: true,
+			want:           false,
+		},
+		"tls not enabled but insecure requested": {
+			tlsEnabled:     false,
+			permitInsecure: true,
+			want:           false,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := routeEnforceTLS(tc.tlsEnabled, tc.permitInsecure)
 			if !reflect.DeepEqual(tc.want, got) {
 				t.Fatalf("expected:\n%v\ngot:\n%v", tc.want, got)
 			}


### PR DESCRIPTION
Fixes #456 by implementing 301 redirects when a Root IngressRoute defines a TLS section. Adds a `permitInsecure` to the Route section allowing for specific routes to server insecure traffic.

> Since defining a TLS section of a root IngressRoute tells Contour that it should set up a TLS listener and serve the provided TLS certificate/key, it's inherent that all requests be served over TLS. This results in any request to an insecure endpoint will receive a 301 http status code informing the client to redirect to the secure endpoint. No additional parameters need to be set for this functionality other than specifying TLS on the IngressRoute.
> 
> Additionally, it may be necessary to serve specific routes over an insecure endpoint. An example would be the challenges sent from LetsEncyrpt. Specific routes can set the permitInsecure parameter which will let that route serve insecure or secure traffic (Meaning no 301 redirects).