### PR TITLE
Fix examples for the IngressRoute documentation

### DIFF
--- a/docs/ingressroute.md
+++ b/docs/ingressroute.md
@@ -242,28 +242,6 @@ The TLS **Minimum Protocol Version** a vhost should negotiate can be specified b
   - 1.2
   - 1.1 (Default)
 
-#### Disable HTTP
-
-IngressRoutes support disabling HTTP at the VHost level, so that the listener is only exposed over HTTPS. This is achieved by setting the `httpsOnly` field to `true`.
-
-This functionality is equivalent to the `kubernetes.io/ingress.allow-http: false` annotation supported in the Ingress resource.
-
-```yaml
-apiVersion: contour.heptio.com/v1beta1
-kind: IngressRoute
-metadata:
-  name: disableHttp
-spec:
-  virtualhost:
-    fqdn: foo-basic.bar.com
-    httpsOnly: true
-  routes:
-    - match: /
-      services:
-        - name: s1
-          port: 80
-```
-
 ### Routing
 
 Each route entry in an IngressRoute must start with a prefix match.
@@ -519,6 +497,26 @@ spec:
       enableWebsockets: true # Setting this to true enables websocket for all paths that match /websocket
       services:
         - name: chat-app
+          port: 80
+```
+
+#### Permit Insecure
+
+IngressRoutes support allowing HTTP alongside HTTPS. This way, the path responds to insecure requests over HTTP which are normally not permitted when a `virtualhost.tls` block is present.
+
+```yaml
+apiVersion: contour.heptio.com/v1beta1
+kind: IngressRoute
+metadata:
+  name: permit-insecure
+spec:
+  virtualhost:
+    fqdn: foo-basic.bar.com
+  routes:
+    - match: /
+      permitInsecure: true
+      services:
+        - name: s1
           port: 80
 ```
 

--- a/docs/ingressroute.md
+++ b/docs/ingressroute.md
@@ -291,6 +291,7 @@ spec:
         - name: s1
           port: 80
     - match: /blog # matches `multi-path.bar.com/blog` or `multi-path.bar.com/blog/*`
+      services:
         - name: s2
           port: 80
 ```

--- a/docs/ingressroute.md
+++ b/docs/ingressroute.md
@@ -42,14 +42,14 @@ Implementing similar behavior using an IngressRoute looks like this:
 # ingressroute.yaml
 apiVersion: contour.heptio.com/v1beta1
 kind: IngressRoute
-metadata: 
+metadata:
   name: basic
-spec: 
+spec:
   virtualhost:
     fqdn: foo-basic.bar.com
-  routes: 
+  routes:
     - match: /
-      services: 
+      services:
         - name: s1
           port: 80
 ```
@@ -59,10 +59,10 @@ spec:
 **Line 6-7**: The presence of the `virtualhost` field indicates that this is a root IngressRoute that is the top level entry point for this domain.
 The `fqdn` field specifies the fully qualified domain name that will be used to match against `Host:` HTTP headers.
 
-**Lines 8-9**: IngressRoutes must have one or more `routes`, each of which must have a path to match against (e.g. `/blog`) and then one or more `services` which will handle the HTTP traffic. 
+**Lines 8-9**: IngressRoutes must have one or more `routes`, each of which must have a path to match against (e.g. `/blog`) and then one or more `services` which will handle the HTTP traffic.
 
 **Lines 10-12**: The `services` field is an array of named Service & Port combinations that will be used for this IngressRoute path.
-Ingress HTTP traffic will be sent directly to the Endpoints corresponding to the Service. 
+Ingress HTTP traffic will be sent directly to the Endpoints corresponding to the Service.
 
 ## Interacting with IngressRoutes
 
@@ -165,29 +165,29 @@ must be represented by two different IngressRoute objects:
 # ingressroute-name.yaml
 apiVersion: contour.heptio.com/v1beta1
 kind: IngressRoute
-metadata: 
+metadata:
   name: name-example-foo
   namespace: default
-spec: 
+spec:
   virtualhost:
     fqdn: foo1.bar.com
-  routes: 
+  routes:
     - match: /
-      services: 
+      services:
         - name: s1
           port: 80
 ---
 apiVersion: contour.heptio.com/v1beta1
 kind: IngressRoute
-metadata: 
+metadata:
   name: name-example-bar
   namespace: default
-spec: 
+spec:
   virtualhost:
     fqdn: bar1.bar.com
-  routes: 
+  routes:
     - match: /
-      services: 
+      services:
         - name: s2
           port: 80
 ```
@@ -222,17 +222,17 @@ The IngressRoute can be configured to use this secret using `tls.secretName` pro
 # tls.ingressroute.yaml
 apiVersion: contour.heptio.com/v1beta1
 kind: IngressRoute
-metadata: 
+metadata:
   name: tls-example
   namespace: default
-spec: 
+spec:
   virtualhost:
     fqdn: foo2.bar.com
     tls:
       secretName: testsecret
-  routes: 
+  routes:
     - match: /
-      services: 
+      services:
         - name: s1
           port: 80
 ```
@@ -251,15 +251,15 @@ This functionality is equivalent to the `kubernetes.io/ingress.allow-http: false
 ```yaml
 apiVersion: contour.heptio.com/v1beta1
 kind: IngressRoute
-metadata: 
+metadata:
   name: disableHttp
-spec: 
+spec:
   virtualhost:
     fqdn: foo-basic.bar.com
     httpsOnly: true
-  routes: 
+  routes:
     - match: /
-      services: 
+      services:
         - name: s1
           port: 80
 ```
@@ -279,15 +279,15 @@ All other requests to the host `multi-path.bar.com` will be routed to the Servic
 # multiple-paths.ingressroute.yaml
 apiVersion: contour.heptio.com/v1beta1
 kind: IngressRoute
-metadata: 
+metadata:
   name: multiple-paths
   namespace: default
-spec: 
+spec:
   virtualhost:
     fqdn: multi-path.bar.com
-  routes: 
+  routes:
     - match: / # matches everything else
-      services: 
+      services:
         - name: s1
           port: 80
     - match: /blog # matches `multi-path.bar.com/blog` or `multi-path.bar.com/blog/*`
@@ -304,15 +304,15 @@ One of the key IngressRoute features is the ability to support multiple services
 # multiple-upstreams.ingressroute.yaml
 apiVersion: contour.heptio.com/v1beta1
 kind: IngressRoute
-metadata: 
+metadata:
   name: multiple-upstreams
   namespace: default
-spec: 
+spec:
   virtualhost:
     fqdn: multi.bar.com
-  routes: 
+  routes:
     - match: /
-      services: 
+      services:
         - name: s1
           port: 80
         - name: s2
@@ -331,15 +331,15 @@ This is commonly used for canary testing of new versions of an application when 
 # weight-shfiting.ingressroute.yaml
 apiVersion: contour.heptio.com/v1beta1
 kind: IngressRoute
-metadata: 
+metadata:
   name: weight-shifting
   namespace: default
-spec: 
+spec:
   virtualhost:
     fqdn: weights.bar.com
-  routes: 
+  routes:
     - match: /
-      services: 
+      services:
         - name: s1
           port: 80
           weight: 10
@@ -376,15 +376,15 @@ Service `s1-strategy` does not have an explicit strategy defined so it will use 
 # lb-strategy.ingressroute.yaml
 apiVersion: contour.heptio.com/v1beta1
 kind: IngressRoute
-metadata: 
+metadata:
   name: lb-strategy
   namespace: default
-spec: 
+spec:
   virtualhost:
     fqdn: strategy.bar.com
-  routes: 
+  routes:
     - match: /
-      services: 
+      services:
         - name: s1-strategy
           port: 80
         - name: s2-strategy
@@ -404,16 +404,16 @@ Service `s3-def-strategy` will have requests distributed randomly.
 # default-lb-strategy.ingressroute.yaml
 apiVersion: contour.heptio.com/v1beta1
 kind: IngressRoute
-metadata: 
+metadata:
   name: default-lb-strategy
   namespace: default
-spec: 
+spec:
   virtualhost:
     fqdn: default-strategy.bar.com
   strategy: WeightedLeastRequest # Default LB algorithm to be applied to services
-  routes: 
+  routes:
     - match: /
-      services: 
+      services:
         - name: s1-def-strategy
           port: 80
         - name: s2-def-strategy
@@ -437,13 +437,13 @@ It is important to note that these are health checks which Envoy implements and 
 # health-checks.ingressroute.yaml
 apiVersion: contour.heptio.com/v1beta1
 kind: IngressRoute
-metadata: 
+metadata:
   name: health-check
   namespace: default
-spec: 
+spec:
   virtualhost:
     fqdn: health.bar.com
-  routes: 
+  routes:
     - match: /
       services:
         - name: s1-health
@@ -476,7 +476,7 @@ You may still override this default on a per-Service basis.
 # default-health-checks.ingressroute.yaml
 apiVersion: contour.heptio.com/v1beta1
 kind: IngressRoute
-metadata: 
+metadata:
   name: health-check
   namespace: default
 spec:
@@ -490,7 +490,7 @@ spec:
     healthyThresholdCount: 5
   routes:
     - match: /
-      services: 
+      services:
         - name: s1-def-health
           port: 80
         - name: s2-def-health
@@ -504,7 +504,7 @@ WebSocket support can be enabled on specific routes using the `EnableWebsockets`
 ```yaml
 apiVersion: contour.heptio.com/v1beta1
 kind: IngressRoute
-metadata: 
+metadata:
   name: chat
   namespace: default
 spec:
@@ -512,7 +512,7 @@ spec:
     fqdn: chat.example.com
   routes:
     - match: /
-      services: 
+      services:
         - name: chat-app
           port: 80
     - match: /websocket
@@ -552,7 +552,7 @@ kind: IngressRoute
 metadata:
   name: delegation-root
   namespace: default
-spec: 
+spec:
   virtualhost:
     fqdn: root.bar.com
   routes:
@@ -561,17 +561,17 @@ spec:
         - name: s1
           port: 80
     # delegate the path, `/service2` to the IngressRoute object in this namespace with the name `service2`
-    - match: /service2 
+    - match: /service2
       delegate:
         name: service2
 ---
 # service2.ingressroute.yaml
 apiVersion: contour.heptio.com/v1beta1
 kind: IngressRoute
-metadata: 
+metadata:
   name: service2
   namespace: default
-spec: 
+spec:
   routes:
     - match: /service2
       services:
@@ -642,19 +642,19 @@ In this example, the root IngressRoute has delegated configuration of paths matc
 # root.ingressroute.yaml
 apiVersion: contour.heptio.com/v1beta1
 kind: IngressRoute
-metadata: 
+metadata:
   name: namespace-delegation-root
   namespace: default
-spec: 
+spec:
   virtualhost:
     fqdn: ns-root.bar.com
-  routes: 
+  routes:
     - match: /
-      services: 
+      services:
         - name: s1
           port: 80
 # delegate the subpath, `/blog` to the IngressRoute object in the marketing namespace with the name `blog`
-    - match: /blog 
+    - match: /blog
       delegate:
         name: blog
         namespace: marketing
@@ -662,13 +662,13 @@ spec:
 # blog.ingressroute.yaml
 apiVersion: contour.heptio.com/v1beta1
 kind: IngressRoute
-metadata: 
+metadata:
   name: blog
   namespace: marketing
-spec: 
-  routes: 
+spec:
+  routes:
     - match: /blog
-      services: 
+      services:
         - name: s2
           port: 80
 ```
@@ -688,7 +688,7 @@ This restricted mode is enabled in Contour by specifying a command line flag, `-
 
 IngressRoutes with a defined `virtualhost` field that are not in one of the allowed root namespaces will be flagged as `invalid` and will be ignored by Contour.
 
-> **NOTE: The restricted root namespace feature is only supported for IngressRoute CRDs.  
+> **NOTE: The restricted root namespace feature is only supported for IngressRoute CRDs.
 > `--ingressroute-root-namespaces` does not affect the operation of `v1beta1.Ingress` objects**
 
 ## Status Reporting


### PR DESCRIPTION
This example was missing the `services:` key, which would cause failure
when trying to submit the example to a kubernetes cluster. The change
is on [line 294](https://github.com/heptio/contour/compare/master...jelmersnoeck:correct-yaml-spec?expand=1#diff-d1dacc562d1dac587ae8c3e7aa565e6bR294).

It also [sets a valid name](https://github.com/heptio/contour/compare/master...jelmersnoeck:correct-yaml-spec?expand=1#diff-d1dacc562d1dac587ae8c3e7aa565e6bR255) for the Disable HTTP example. The `disableHttp`
name contains a capitalized character which isn't allowed by the 
validation regex:

`[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*`

I'm not sure if this is desired - I couldn't find a guideline for this - but I've
also added a commit (https://github.com/heptio/contour/commit/c5fd114fdae7eaf42c8f10ec6e331d6a3e86d65d) which removes trailing whitespaces from
the documentation file. If this is not desired, I can remove this commit.