### PR TITLE
docs: Add example showing how multiple Root IngressRoute objects 

### DIFF
--- a/deployment/example-workload/ingressroute/06-multiple-roots/delegate.ingressroute.yaml
+++ b/deployment/example-workload/ingressroute/06-multiple-roots/delegate.ingressroute.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: contour.heptio.com/v1beta1
+kind: IngressRoute
+metadata: 
+  name: main
+spec: 
+  routes: 
+    - match: /
+      services: 
+        - name: s2
+          port: 80

--- a/deployment/example-workload/ingressroute/06-multiple-roots/root.ingressroute.yaml
+++ b/deployment/example-workload/ingressroute/06-multiple-roots/root.ingressroute.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: contour.heptio.com/v1beta1
+kind: IngressRoute
+metadata: 
+  name: multiple-root
+spec:
+  virtualhost:
+    fqdn: bar.com
+  routes: 
+# delegate the subpath, `/` to the IngressRoute object in the marketing namespace with the name `main`
+    - match: /
+      delegate:
+        name: main
+---
+apiVersion: contour.heptio.com/v1beta1
+kind: IngressRoute
+metadata: 
+  name: multiple-root-www
+spec:
+  virtualhost:
+    fqdn: www.bar.com
+  routes: 
+# delegate the subpath, `/` to the IngressRoute object in the marketing namespace with the name `main`
+    - match: /
+      delegate:
+        name: main


### PR DESCRIPTION
The original IngressRoute design spec had support for an `Aliases` field. We've since removed that and this example shows how to accomplish the same functionality with multiple root IngressRoutes. 

It demonstrates how to have `bar.com`, as well as `www.bar.com`,  have the same delegate route which enables multiple FQDN's to be processed equally. 

Updates #644 

Signed-off-by: Steve Sloka <steves@heptio.com>