### PR TITLE
deployment: remove Aliases from CRD printer

### DIFF
--- a/deployment/common/common.yaml
+++ b/deployment/common/common.yaml
@@ -27,10 +27,6 @@ spec:
       type: string
       description: Fully qualified domain name
       JSONPath: .spec.virtualhost.fqdn
-    - name: Aliases
-      type: string
-      description: Fully qualified domain name
-      JSONPath: .spec.virtualhost.aliases
     - name: TLS Secret
       type: string
       description: Secret with TLS credentials

--- a/deployment/render/daemonset-rbac.yaml
+++ b/deployment/render/daemonset-rbac.yaml
@@ -30,10 +30,6 @@ spec:
       type: string
       description: Fully qualified domain name
       JSONPath: .spec.virtualhost.fqdn
-    - name: Aliases
-      type: string
-      description: Fully qualified domain name
-      JSONPath: .spec.virtualhost.aliases
     - name: TLS Secret
       type: string
       description: Secret with TLS credentials

--- a/deployment/render/deployment-rbac.yaml
+++ b/deployment/render/deployment-rbac.yaml
@@ -30,10 +30,6 @@ spec:
       type: string
       description: Fully qualified domain name
       JSONPath: .spec.virtualhost.fqdn
-    - name: Aliases
-      type: string
-      description: Fully qualified domain name
-      JSONPath: .spec.virtualhost.aliases
     - name: TLS Secret
       type: string
       description: Secret with TLS credentials


### PR DESCRIPTION
The aliases field has been removed from the IngressRoute CRD. This PR removes Aliases from the CRD "additional printer columns".