### PR TITLE
internal/dag: export/unexport Route fields

### DIFF
--- a/internal/contour/holdoff.go
+++ b/internal/contour/holdoff.go
@@ -33,7 +33,6 @@ const (
 // A HoldoffNotifier delays calls to OnChange in the hope of
 // coalescing rapid calls into a single update.
 type HoldoffNotifier struct {
-
 	// Notifier to be called after delay.
 	Notifier
 	*metrics.Metrics

--- a/internal/contour/route.go
+++ b/internal/contour/route.go
@@ -135,7 +135,7 @@ func (v *routeVisitor) Visit() map[string]*v2.RouteConfiguration {
 						return
 					}
 					rr := route.Route{
-						Match: prefixmatch(r.Prefix()),
+						Match: prefixmatch(r.Prefix),
 						Action: actionroute(
 							svcs,
 							r.Websocket,
@@ -181,7 +181,7 @@ func (v *routeVisitor) Visit() map[string]*v2.RouteConfiguration {
 						return
 					}
 					vhost.Routes = append(vhost.Routes, route.Route{
-						Match: prefixmatch(r.Prefix()),
+						Match: prefixmatch(r.Prefix),
 						Action: actionroute(
 							svcs,
 							r.Websocket,

--- a/internal/dag/builder.go
+++ b/internal/dag/builder.go
@@ -300,8 +300,8 @@ func (b *builder) compute() *DAG {
 		if ing.Spec.Backend != nil {
 			// handle the annoying default ingress
 			r := &Route{
-				path:         "/",
-				Object:       ing,
+				Prefix:       "/",
+				object:       ing,
 				HTTPSUpgrade: tlsRequired(ing),
 				Websocket:    wr["/"],
 				Timeout:      timeout,
@@ -322,15 +322,15 @@ func (b *builder) compute() *DAG {
 				host = "*"
 			}
 			for _, httppath := range httppaths(rule) {
-				path := httppath.Path
-				if path == "" {
-					path = "/"
+				prefix := httppath.Path
+				if prefix == "" {
+					prefix = "/"
 				}
 				r := &Route{
-					path:         path,
-					Object:       ing,
+					Prefix:       prefix,
+					object:       ing,
 					HTTPSUpgrade: tlsRequired(ing),
-					Websocket:    wr[path],
+					Websocket:    wr[prefix],
 					Timeout:      timeout,
 				}
 
@@ -502,8 +502,8 @@ func (b *builder) processIngressRoute(ir *ingressroutev1.IngressRoute, prefixMat
 			enforceTLSRoute := routeEnforceTLS(enforceTLS, route.PermitInsecure)
 
 			r := &Route{
-				path:         route.Match,
-				Object:       ir,
+				Prefix:       route.Match,
+				object:       ir,
 				Websocket:    route.EnableWebsockets,
 				HTTPSUpgrade: enforceTLSRoute,
 			}

--- a/internal/dag/builder_test.go
+++ b/internal/dag/builder_test.go
@@ -1639,8 +1639,8 @@ func TestDAGInsert(t *testing.T) {
 					Port: 80,
 					routes: routemap(
 						&Route{
-							path:   "/",
-							Object: i6b,
+							Prefix: "/",
+							object: i6b,
 							services: servicemap(
 								&Service{
 									Object:      s1,
@@ -1657,8 +1657,8 @@ func TestDAGInsert(t *testing.T) {
 						Port: 443,
 						routes: routemap(
 							&Route{
-								path:   "/",
-								Object: i6b,
+								Prefix: "/",
+								object: i6b,
 								services: servicemap(
 									&Service{
 										Object:      s1,
@@ -1705,8 +1705,8 @@ func TestDAGInsert(t *testing.T) {
 							},
 						)),
 						&Route{
-							path:   "/websocket",
-							Object: ir10,
+							Prefix: "/websocket",
+							object: ir10,
 							services: servicemap(
 								&Service{
 									Object:      s1,
@@ -1746,8 +1746,8 @@ func TestDAGInsert(t *testing.T) {
 					Port: 80,
 					routes: routemap(
 						&Route{
-							path:   "/",
-							Object: ir6,
+							Prefix: "/",
+							object: ir6,
 							services: servicemap(
 								&Service{
 									Object:      s1,
@@ -1765,8 +1765,8 @@ func TestDAGInsert(t *testing.T) {
 						Port: 443,
 						routes: routemap(
 							&Route{
-								path:   "/",
-								Object: ir6,
+								Prefix: "/",
+								object: ir6,
 								services: servicemap(
 									&Service{
 										Object:      s1,
@@ -1791,8 +1791,8 @@ func TestDAGInsert(t *testing.T) {
 					Port: 80,
 					routes: routemap(
 						&Route{
-							path:   "/",
-							Object: ir14,
+							Prefix: "/",
+							object: ir14,
 							services: servicemap(
 								&Service{
 									Object:      s1,
@@ -1809,8 +1809,8 @@ func TestDAGInsert(t *testing.T) {
 						Port: 443,
 						routes: routemap(
 							&Route{
-								path:   "/",
-								Object: ir14,
+								Prefix: "/",
+								object: ir14,
 								services: servicemap(
 									&Service{
 										Object:      s1,
@@ -1834,8 +1834,8 @@ func TestDAGInsert(t *testing.T) {
 					Port: 80,
 					routes: routemap(
 						&Route{
-							path:   "/",
-							Object: ir7,
+							Prefix: "/",
+							object: ir7,
 							services: servicemap(
 								&Service{
 									Object:      s1,
@@ -1852,8 +1852,8 @@ func TestDAGInsert(t *testing.T) {
 						Port: 443,
 						routes: routemap(
 							&Route{
-								path:   "/",
-								Object: ir7,
+								Prefix: "/",
+								object: ir7,
 								services: servicemap(
 									&Service{
 										Object:      s1,
@@ -1879,8 +1879,8 @@ func TestDAGInsert(t *testing.T) {
 					Host: "foo.com",
 					Port: 80,
 					routes: routemap(&Route{
-						path:   "/",
-						Object: ir8,
+						Prefix: "/",
+						object: ir8,
 						services: servicemap(
 							&Service{
 								Object:      s1,
@@ -1896,8 +1896,8 @@ func TestDAGInsert(t *testing.T) {
 						Port: 443,
 						routes: routemap(
 							&Route{
-								path:   "/",
-								Object: ir8,
+								Prefix: "/",
+								object: ir8,
 								services: servicemap(
 									&Service{
 										Object:      s1,
@@ -1924,8 +1924,8 @@ func TestDAGInsert(t *testing.T) {
 					Port: 80,
 					routes: routemap(
 						&Route{
-							path:   "/",
-							Object: ir9,
+							Prefix: "/",
+							object: ir9,
 							services: servicemap(
 								&Service{
 									Object:      s1,
@@ -1941,8 +1941,8 @@ func TestDAGInsert(t *testing.T) {
 						Port: 443,
 						routes: routemap(
 							&Route{
-								path:   "/",
-								Object: ir9,
+								Prefix: "/",
+								object: ir9,
 								services: servicemap(
 									&Service{
 										Object:      s1,
@@ -2054,8 +2054,8 @@ func TestDAGInsert(t *testing.T) {
 							},
 						)),
 						&Route{
-							path:   "/ws1",
-							Object: i11,
+							Prefix: "/ws1",
+							object: i11,
 							services: servicemap(
 								&Service{
 									Object:      s1,
@@ -2079,8 +2079,8 @@ func TestDAGInsert(t *testing.T) {
 					Port: 80,
 					routes: routemap(
 						&Route{
-							path:   "/",
-							Object: i12a,
+							Prefix: "/",
+							object: i12a,
 							services: servicemap(
 								&Service{
 									Object:      s1,
@@ -2104,8 +2104,8 @@ func TestDAGInsert(t *testing.T) {
 					Port: 80,
 					routes: routemap(
 						&Route{
-							path:   "/",
-							Object: i12b,
+							Prefix: "/",
+							object: i12b,
 							services: servicemap(
 								&Service{
 									Object:      s1,
@@ -2129,8 +2129,8 @@ func TestDAGInsert(t *testing.T) {
 					Port: 80,
 					routes: routemap(
 						&Route{
-							path:   "/",
-							Object: i12c,
+							Prefix: "/",
+							object: i12c,
 							services: servicemap(
 								&Service{
 									Object:      s1,
@@ -2178,8 +2178,8 @@ func TestDAGInsert(t *testing.T) {
 					Port: 80,
 					routes: routemap(
 						&Route{
-							path:   "/",
-							Object: i13a,
+							Prefix: "/",
+							object: i13a,
 							services: servicemap(
 								&Service{
 									Object:      s13a,
@@ -2202,8 +2202,8 @@ func TestDAGInsert(t *testing.T) {
 						Port: 443,
 						routes: routemap(
 							&Route{
-								path:   "/",
-								Object: i13a,
+								Prefix: "/",
+								object: i13a,
 								services: servicemap(
 									&Service{
 										Object:      s13a,
@@ -3258,7 +3258,7 @@ func TestDAGIngressRouteCycle(t *testing.T) {
 	want[hostport{host: "example.com", port: 80}] = &VirtualHost{
 		Host:   "example.com",
 		Port:   80,
-		routes: routemap(&Route{path: "/finance", Object: ir2}),
+		routes: routemap(&Route{Prefix: "/finance", object: ir2}),
 	}
 
 	opts := []cmp.Option{
@@ -4273,15 +4273,15 @@ func TestEnforceRoute(t *testing.T) {
 func routemap(routes ...*Route) map[string]*Route {
 	m := make(map[string]*Route)
 	for _, r := range routes {
-		m[r.path] = r
+		m[r.Prefix] = r
 	}
 	return m
 }
 
-func route(path string, obj interface{}, services ...map[servicemeta]*Service) *Route {
+func route(prefix string, obj interface{}, services ...map[servicemeta]*Service) *Route {
 	r := Route{
-		path:   path,
-		Object: obj,
+		Prefix: prefix,
+		object: obj,
 	}
 	switch len(services) {
 	case 0:

--- a/internal/dag/dag.go
+++ b/internal/dag/dag.go
@@ -49,8 +49,8 @@ func (d *DAG) Statuses() []Status {
 }
 
 type Route struct {
-	path     string
-	Object   interface{} // one of Ingress or IngressRoute
+	Prefix   string
+	object   interface{} // one of Ingress or IngressRoute
 	services map[servicemeta]*Service
 
 	// Should this route generate a 301 upgrade if accessed
@@ -67,8 +67,6 @@ type Route struct {
 	// TODO(dfc) should this move to service?
 	Timeout time.Duration
 }
-
-func (r *Route) Prefix() string { return r.path }
 
 func (r *Route) addService(s *Service, hc *ingressroutev1.HealthCheck, lbStrat string) {
 	if r.services == nil {
@@ -100,7 +98,7 @@ func (v *VirtualHost) addRoute(route *Route) {
 	if v.routes == nil {
 		v.routes = make(map[string]*Route)
 	}
-	v.routes[route.path] = route
+	v.routes[route.Prefix] = route
 }
 
 func (v *VirtualHost) Visit(f func(Vertex)) {

--- a/internal/debug/dot.go
+++ b/internal/debug/dot.go
@@ -51,7 +51,7 @@ func (c *ctx) writeVertex(v dag.Vertex) {
 	case *dag.SecureVirtualHost:
 		fmt.Fprintf(c.w, `"%p" [shape=record, label="{https://%s:%d}"]`+"\n", v, v.Host, v.Port)
 	case *dag.Route:
-		fmt.Fprintf(c.w, `"%p" [shape=record, label="{prefix|%s}"]`+"\n", v, v.Prefix())
+		fmt.Fprintf(c.w, `"%p" [shape=record, label="{prefix|%s}"]`+"\n", v, v.Prefix)
 	}
 }
 

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -149,7 +149,6 @@ func (m *Metrics) SetDAGRebuiltMetric(timestamp int64) {
 
 // SetIngressRouteMetric sets metric values for a set of IngressRoutes
 func (m *Metrics) SetIngressRouteMetric(metrics IngressRouteMetric) {
-
 	// Process metrics
 	for meta, value := range metrics.Total {
 		m.ingressRouteTotalGauge.WithLabelValues(meta.Namespace).Set(float64(value))


### PR DESCRIPTION
Export Route.path and rename it to Route.Prefix. This removes the
Prefix() accessor and makes it clear that all routes are keyed on
prefixes.

Unexport Route.Object as its rarely accessed outside builder_test and
matches the other variations in Secret.

Signed-off-by: Dave Cheney <dave@cheney.net>