### PR TITLE
internal/dag,contour,e2e: reimplement retry-on feature

### DIFF
--- a/internal/contour/route.go
+++ b/internal/contour/route.go
@@ -256,6 +256,12 @@ func actionroute(r *dag.Route, services []*dag.Service) *route.Route_Route {
 		rr.Route.UseWebsocket = &types.BoolValue{Value: true}
 	}
 
+	if r.RetryOn != "" {
+		rr.Route.RetryPolicy = &route.RouteAction_RetryPolicy{
+			RetryOn: r.RetryOn,
+		}
+	}
+
 	switch timeout := r.Timeout; timeout {
 	case 0:
 		// no timeout specified, do nothing

--- a/internal/contour/route.go
+++ b/internal/contour/route.go
@@ -260,6 +260,13 @@ func actionroute(r *dag.Route, services []*dag.Service) *route.Route_Route {
 		rr.Route.RetryPolicy = &route.RouteAction_RetryPolicy{
 			RetryOn: r.RetryOn,
 		}
+		if r.NumRetries > 0 {
+			rr.Route.RetryPolicy.NumRetries = &types.UInt32Value{Value: uint32(r.NumRetries)}
+		}
+		if r.PerTryTimeout > 0 {
+			timeout := r.PerTryTimeout
+			rr.Route.RetryPolicy.PerTryTimeout = &timeout
+		}
 	}
 
 	switch timeout := r.Timeout; timeout {

--- a/internal/e2e/rds_test.go
+++ b/internal/e2e/rds_test.go
@@ -1846,13 +1846,8 @@ func TestRouteWithTLS_InsecurePaths(t *testing.T) {
 	}, streamRDS(t, cc))
 }
 
-// issue 665, suport for retry-on, num-retries, and per-try-timeout annotations.
+// issue 665, support for retry-on, num-retries, and per-try-timeout annotations.
 func TestRouteRetryAnnotations(t *testing.T) {
-	const (
-		durationInfinite  = time.Duration(0)
-		duration10Minutes = 10 * time.Minute
-	)
-
 	rh, cc, done := setup(t)
 	defer done()
 

--- a/internal/e2e/rds_test.go
+++ b/internal/e2e/rds_test.go
@@ -1846,6 +1846,55 @@ func TestRouteWithTLS_InsecurePaths(t *testing.T) {
 	}, streamRDS(t, cc))
 }
 
+// issue 665, suport for retry-on, num-retries, and per-try-timeout annotations.
+func TestRouteRetryAnnotations(t *testing.T) {
+	const (
+		durationInfinite  = time.Duration(0)
+		duration10Minutes = 10 * time.Minute
+	)
+
+	rh, cc, done := setup(t)
+	defer done()
+
+	s1 := &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "backend",
+			Namespace: "default",
+		},
+		Spec: v1.ServiceSpec{
+			Ports: []v1.ServicePort{{
+				Protocol:   "TCP",
+				Port:       80,
+				TargetPort: intstr.FromInt(8080),
+			}},
+		},
+	}
+	rh.OnAdd(s1)
+
+	i1 := &v1beta1.Ingress{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "hello", Namespace: "default",
+			Annotations: map[string]string{
+				"contour.heptio.com/retry-on":        "50x,gateway-error",
+				"contour.heptio.com/num-retries":     "7",
+				"contour.heptio.com/per-try-timeout": "120ms",
+			},
+		},
+		Spec: v1beta1.IngressSpec{
+			Backend: backend("backend", intstr.FromInt(80)),
+		},
+	}
+	rh.OnAdd(i1)
+	assertRDS(t, cc, []route.VirtualHost{{
+		Name:    "*",
+		Domains: []string{"*"},
+		Routes: []route.Route{{
+			Match:  prefixmatch("/"), // match all
+			Action: routeretry("default/backend/80", "50x,gateway-error", 7, 120*time.Millisecond),
+		}},
+	}}, nil)
+}
+
 func assertRDS(t *testing.T, cc *grpc.ClientConn, ingress_http, ingress_https []route.VirtualHost) {
 	t.Helper()
 	assertEqual(t, &v2.DiscoveryResponse{
@@ -1955,4 +2004,18 @@ func redirecthttps() *route.Route_Redirect {
 			HttpsRedirect: true,
 		},
 	}
+}
+
+func routeretry(cluster string, retryOn string, numRetries uint32, perTryTimeout time.Duration) *route.Route_Route {
+	r := routecluster(cluster)
+	r.Route.RetryPolicy = &route.RouteAction_RetryPolicy{
+		RetryOn: retryOn,
+	}
+	if numRetries > 0 {
+		r.Route.RetryPolicy.NumRetries = &types.UInt32Value{Value: numRetries}
+	}
+	if perTryTimeout > 0 {
+		r.Route.RetryPolicy.PerTryTimeout = &perTryTimeout
+	}
+	return r
 }


### PR DESCRIPTION
Fixes #665 

Reimplement that retry-on, num-retries, and per-try-timeout support added in Contour 0.4 by @cmaloney and lost after Contour 0.5 when the dag was introduced.

Also add some tests so we can't loose this support again.