### PR TITLE
internal/contour: include lbstrategy in cluster name

### DIFF
--- a/internal/contour/cluster_test.go
+++ b/internal/contour/cluster_test.go
@@ -14,7 +14,6 @@
 package contour
 
 import (
-	"reflect"
 	"testing"
 	"time"
 
@@ -23,7 +22,9 @@ import (
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 	envoy_type "github.com/envoyproxy/go-control-plane/envoy/type"
 	"github.com/gogo/protobuf/types"
+	"github.com/google/go-cmp/cmp"
 	ingressroutev1 "github.com/heptio/contour/apis/contour/v1beta1"
+	"github.com/heptio/contour/internal/dag"
 	"github.com/heptio/contour/internal/metrics"
 	"github.com/prometheus/client_golang/prometheus"
 	"k8s.io/api/core/v1"
@@ -65,7 +66,7 @@ func TestClusterVisit(t *testing.T) {
 			},
 			want: clustermap(
 				&v2.Cluster{
-					Name: "default/kuard/443",
+					Name: "default/kuard/443/da39a3ee5e",
 					Type: v2.Cluster_EDS,
 					EdsClusterConfig: &v2.Cluster_EdsClusterConfig{
 						EdsConfig:   apiconfigsource("contour"), // hard coded by initconfig
@@ -105,7 +106,7 @@ func TestClusterVisit(t *testing.T) {
 			},
 			want: clustermap(
 				&v2.Cluster{
-					Name: "default/kuard/443",
+					Name: "default/kuard/443/da39a3ee5e",
 					Type: v2.Cluster_EDS,
 					EdsClusterConfig: &v2.Cluster_EdsClusterConfig{
 						EdsConfig:   apiconfigsource("contour"), // hard coded by initconfig
@@ -149,7 +150,7 @@ func TestClusterVisit(t *testing.T) {
 			},
 			want: clustermap(
 				&v2.Cluster{
-					Name: "default/kuard/80",
+					Name: "default/kuard/80/da39a3ee5e",
 					Type: v2.Cluster_EDS,
 					EdsClusterConfig: &v2.Cluster_EdsClusterConfig{
 						EdsConfig:   apiconfigsource("contour"), // hard coded by initconfig
@@ -191,7 +192,7 @@ func TestClusterVisit(t *testing.T) {
 			},
 			want: clustermap(
 				&v2.Cluster{
-					Name: "beurocratic-company-test-domain-1/tiny-cog-depa-81582b/443",
+					Name: "beurocra-7fe4b4/tiny-cog-7fe4b4/443/da39a3ee5e",
 					Type: v2.Cluster_EDS,
 					EdsClusterConfig: &v2.Cluster_EdsClusterConfig{
 						EdsConfig:   apiconfigsource("contour"), // hard coded by initconfig
@@ -243,7 +244,7 @@ func TestClusterVisit(t *testing.T) {
 			},
 			want: clustermap(
 				&v2.Cluster{
-					Name: "default/backend/80",
+					Name: "default/backend/80/da39a3ee5e",
 					Type: v2.Cluster_EDS,
 					EdsClusterConfig: &v2.Cluster_EdsClusterConfig{
 						EdsConfig:   apiconfigsource("contour"), // hard coded by initconfig
@@ -258,7 +259,7 @@ func TestClusterVisit(t *testing.T) {
 					},
 				},
 				&v2.Cluster{
-					Name: "default/backend/8080",
+					Name: "default/backend/8080/da39a3ee5e",
 					Type: v2.Cluster_EDS,
 					EdsClusterConfig: &v2.Cluster_EdsClusterConfig{
 						EdsConfig:   apiconfigsource("contour"), // hard coded by initconfig
@@ -306,7 +307,7 @@ func TestClusterVisit(t *testing.T) {
 			},
 			want: clustermap(
 				&v2.Cluster{
-					Name: "default/backend/80",
+					Name: "default/backend/80/da39a3ee5e",
 					Type: v2.Cluster_EDS,
 					EdsClusterConfig: &v2.Cluster_EdsClusterConfig{
 						EdsConfig:   apiconfigsource("contour"), // hard coded by initconfig
@@ -375,7 +376,7 @@ func TestClusterVisit(t *testing.T) {
 			},
 			want: clustermap(
 				&v2.Cluster{
-					Name: "default/backend/80",
+					Name: "default/backend/80/da39a3ee5e",
 					Type: v2.Cluster_EDS,
 					EdsClusterConfig: &v2.Cluster_EdsClusterConfig{
 						EdsConfig:   apiconfigsource("contour"), // hard coded by initconfig
@@ -437,7 +438,7 @@ func TestClusterVisit(t *testing.T) {
 			},
 			want: clustermap(
 				&v2.Cluster{
-					Name: "default/backend/80",
+					Name: "default/backend/80/f3b72af6a9",
 					Type: v2.Cluster_EDS,
 					EdsClusterConfig: &v2.Cluster_EdsClusterConfig{
 						EdsConfig:   apiconfigsource("contour"), // hard coded by initconfig
@@ -483,7 +484,7 @@ func TestClusterVisit(t *testing.T) {
 			},
 			want: clustermap(
 				&v2.Cluster{
-					Name: "default/backend/80",
+					Name: "default/backend/80/8bf87fefba",
 					Type: v2.Cluster_EDS,
 					EdsClusterConfig: &v2.Cluster_EdsClusterConfig{
 						EdsConfig:   apiconfigsource("contour"), // hard coded by initconfig
@@ -529,7 +530,7 @@ func TestClusterVisit(t *testing.T) {
 			},
 			want: clustermap(
 				&v2.Cluster{
-					Name: "default/backend/80",
+					Name: "default/backend/80/40633a6ca9",
 					Type: v2.Cluster_EDS,
 					EdsClusterConfig: &v2.Cluster_EdsClusterConfig{
 						EdsConfig:   apiconfigsource("contour"), // hard coded by initconfig
@@ -575,7 +576,7 @@ func TestClusterVisit(t *testing.T) {
 			},
 			want: clustermap(
 				&v2.Cluster{
-					Name: "default/backend/80",
+					Name: "default/backend/80/843e4ded8f",
 					Type: v2.Cluster_EDS,
 					EdsClusterConfig: &v2.Cluster_EdsClusterConfig{
 						EdsConfig:   apiconfigsource("contour"), // hard coded by initconfig
@@ -621,7 +622,7 @@ func TestClusterVisit(t *testing.T) {
 			},
 			want: clustermap(
 				&v2.Cluster{
-					Name: "default/backend/80",
+					Name: "default/backend/80/58d888c08a",
 					Type: v2.Cluster_EDS,
 					EdsClusterConfig: &v2.Cluster_EdsClusterConfig{
 						EdsConfig:   apiconfigsource("contour"), // hard coded by initconfig
@@ -637,6 +638,75 @@ func TestClusterVisit(t *testing.T) {
 				},
 			),
 		},
+		"ingressroute with differing lb algorithms": {
+			objs: []interface{}{
+				&ingressroutev1.IngressRoute{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "simple",
+						Namespace: "default",
+					},
+					Spec: ingressroutev1.IngressRouteSpec{
+						VirtualHost: &ingressroutev1.VirtualHost{
+							Fqdn: "www.example.com",
+						},
+						Routes: []ingressroutev1.Route{{
+							Match: "/a",
+							Services: []ingressroutev1.Service{{
+								Name:     "backend",
+								Port:     80,
+								Strategy: "Random",
+							}},
+						}, {
+							Match: "/b",
+							Services: []ingressroutev1.Service{{
+								Name:     "backend",
+								Port:     80,
+								Strategy: "Maglev",
+							}},
+						}},
+					},
+				},
+				service("default", "backend", v1.ServicePort{
+					Name:       "http",
+					Protocol:   "TCP",
+					Port:       80,
+					TargetPort: intstr.FromInt(6502),
+				}),
+			},
+			want: clustermap(
+				&v2.Cluster{
+					Name: "default/backend/80/58d888c08a",
+					Type: v2.Cluster_EDS,
+					EdsClusterConfig: &v2.Cluster_EdsClusterConfig{
+						EdsConfig:   apiconfigsource("contour"), // hard coded by initconfig
+						ServiceName: "default/backend/http",
+					},
+					ConnectTimeout: 250 * time.Millisecond,
+					LbPolicy:       v2.Cluster_RANDOM,
+					CommonLbConfig: &v2.Cluster_CommonLbConfig{
+						HealthyPanicThreshold: &envoy_type.Percent{ // Disable HealthyPanicThreshold
+							Value: 0,
+						},
+					},
+				},
+				&v2.Cluster{
+					Name: "default/backend/80/843e4ded8f",
+					Type: v2.Cluster_EDS,
+					EdsClusterConfig: &v2.Cluster_EdsClusterConfig{
+						EdsConfig:   apiconfigsource("contour"), // hard coded by initconfig
+						ServiceName: "default/backend/http",
+					},
+					ConnectTimeout: 250 * time.Millisecond,
+					LbPolicy:       v2.Cluster_MAGLEV,
+					CommonLbConfig: &v2.Cluster_CommonLbConfig{
+						HealthyPanicThreshold: &envoy_type.Percent{ // Disable HealthyPanicThreshold
+							Value: 0,
+						},
+					},
+				},
+			),
+		},
+
 		"ingressroute with unknown lb algorithm": {
 			objs: []interface{}{
 				&ingressroutev1.IngressRoute{
@@ -667,7 +737,7 @@ func TestClusterVisit(t *testing.T) {
 			},
 			want: clustermap(
 				&v2.Cluster{
-					Name: "default/backend/80",
+					Name: "default/backend/80/86d7a9c129",
 					Type: v2.Cluster_EDS,
 					EdsClusterConfig: &v2.Cluster_EdsClusterConfig{
 						EdsConfig:   apiconfigsource("contour"), // hard coded by initconfig
@@ -715,7 +785,7 @@ func TestClusterVisit(t *testing.T) {
 			},
 			want: clustermap(
 				&v2.Cluster{
-					Name: "default/kuard/80",
+					Name: "default/kuard/80/da39a3ee5e",
 					Type: v2.Cluster_EDS,
 					EdsClusterConfig: &v2.Cluster_EdsClusterConfig{
 						EdsConfig:   apiconfigsource("contour"), // hard coded by initconfig
@@ -768,7 +838,7 @@ func TestClusterVisit(t *testing.T) {
 			},
 			want: clustermap(
 				&v2.Cluster{
-					Name: "default/kuard/443",
+					Name: "default/kuard/443/da39a3ee5e",
 					Type: v2.Cluster_EDS,
 					EdsClusterConfig: &v2.Cluster_EdsClusterConfig{
 						EdsConfig:   apiconfigsource("contour"), // hard coded by initconfig
@@ -799,8 +869,8 @@ func TestClusterVisit(t *testing.T) {
 				Visitable:    reh.Build(),
 			}
 			got := v.Visit()
-			if !reflect.DeepEqual(tc.want, got) {
-				t.Fatalf("expected:\n%+v\ngot:\n%+v", tc.want, got)
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Fatal(diff)
 			}
 		})
 	}
@@ -841,28 +911,57 @@ func duration(d time.Duration) *time.Duration {
 
 func TestServiceName(t *testing.T) {
 	tests := map[string]struct {
-		name, namespace string
-		portname        string
-		want            string
+		service *dag.Service
+		want    string
 	}{
 		"named service": {
-			namespace: "default",
-			name:      "kuard",
-			portname:  "http",
-			want:      "default/kuard/http",
+			service: &dag.Service{
+				Object: &v1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+						Name:      "kuard",
+					},
+				},
+				ServicePort: &v1.ServicePort{
+					Name: "http",
+				},
+			},
+			want: "default/kuard/http",
+		},
+		"named service w/ lb strategy": {
+			service: &dag.Service{
+				Object: &v1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+						Name:      "kuard",
+					},
+				},
+				ServicePort: &v1.ServicePort{
+					Name: "http",
+				},
+				LoadBalancerStrategy: "Random", // ignored by servicename
+			},
+			want: "default/kuard/http",
 		},
 		"unnamed service": {
-			namespace: "default",
-			name:      "kuard",
-			want:      "default/kuard",
+			service: &dag.Service{
+				Object: &v1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+						Name:      "kuard",
+					},
+				},
+				ServicePort: &v1.ServicePort{},
+			},
+			want: "default/kuard",
 		},
 	}
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			got := servicename(tc.namespace, tc.name, tc.portname)
-			if got != tc.want {
-				t.Fatalf("servicename(%s/%s, %q): want %q, got %q", tc.namespace, tc.name, tc.portname, tc.want, got)
+			got := servicename(tc.service)
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Fatal(diff)
 			}
 		})
 	}

--- a/internal/contour/endpointstranslator.go
+++ b/internal/contour/endpointstranslator.go
@@ -14,11 +14,14 @@
 package contour
 
 import (
+	"strings"
+
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2/endpoint"
 	"github.com/sirupsen/logrus"
 	"k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	_cache "k8s.io/client-go/tools/cache"
 )
 
@@ -119,7 +122,7 @@ func (e *EndpointsTranslator) recomputeClusterLoadAssignment(oldep, newep *v1.En
 			portname := p.Name
 			cla, ok := clas[portname]
 			if !ok {
-				cla = clusterloadassignment(servicename(newep.ObjectMeta.Namespace, newep.ObjectMeta.Name, portname))
+				cla = clusterloadassignment(clustername(newep.ObjectMeta, portname))
 				clas[portname] = cla
 			}
 			for _, a := range s.Addresses {
@@ -145,10 +148,25 @@ func (e *EndpointsTranslator) recomputeClusterLoadAssignment(oldep, newep *v1.En
 			portname := p.Name
 			if _, ok := clas[portname]; !ok {
 				// port is not present in the list added / updated, so remove it
-				e.Remove(servicename(oldep.ObjectMeta.Namespace, oldep.Name, portname))
+				e.Remove(clustername(oldep.ObjectMeta, portname))
 			}
 		}
 	}
+}
+
+// clustername returns the name of the cluster this meta and port
+// refers to. The CDS name of the cluster may include additional suffixes
+// but these are not known to EDS.
+func clustername(meta metav1.ObjectMeta, portname string) string {
+	name := []string{
+		meta.Namespace,
+		meta.Name,
+		portname,
+	}
+	if portname == "" {
+		name = name[:2]
+	}
+	return strings.Join(name, "/")
 }
 
 func clusterloadassignment(name string, lbendpoints ...endpoint.LbEndpoint) *v2.ClusterLoadAssignment {

--- a/internal/dag/builder_test.go
+++ b/internal/dag/builder_test.go
@@ -3200,9 +3200,10 @@ func TestBuilderLookupService(t *testing.T) {
 
 	tests := map[string]struct {
 		meta
-		port   intstr.IntOrString
-		weight int
-		want   *Service
+		port     intstr.IntOrString
+		weight   int
+		strategy string
+		want     *Service
 	}{
 		"lookup service by port number": {
 			meta: meta{name: "service1", namespace: "default"},
@@ -3247,7 +3248,7 @@ func TestBuilderLookupService(t *testing.T) {
 					},
 				},
 			}
-			got := b.lookupService(tc.meta, tc.port, tc.weight)
+			got := b.lookupService(tc.meta, tc.port, tc.weight, tc.strategy)
 			if diff := cmp.Diff(tc.want, got); diff != "" {
 				t.Fatal(diff)
 			}

--- a/internal/dag/dag.go
+++ b/internal/dag/dag.go
@@ -80,12 +80,11 @@ type Route struct {
 	PerTryTimeout time.Duration
 }
 
-func (r *Route) addService(s *Service, hc *ingressroutev1.HealthCheck, lbStrat string) {
+func (r *Route) addService(s *Service, hc *ingressroutev1.HealthCheck) {
 	if r.services == nil {
 		r.services = make(map[servicemeta]*Service)
 	}
 	s.HealthCheck = hc
-	s.LoadBalancerStrategy = lbStrat
 	r.services[s.toMeta()] = s
 }
 
@@ -191,6 +190,7 @@ type servicemeta struct {
 	namespace string
 	port      int32
 	weight    int
+	strategy  string
 }
 
 func (s *Service) toMeta() servicemeta {
@@ -199,6 +199,7 @@ func (s *Service) toMeta() servicemeta {
 		namespace: s.Object.Namespace,
 		port:      s.Port,
 		weight:    s.Weight,
+		strategy:  s.LoadBalancerStrategy,
 	}
 }
 

--- a/internal/e2e/cds_test.go
+++ b/internal/e2e/cds_test.go
@@ -65,7 +65,7 @@ func TestClusterLongServiceName(t *testing.T) {
 	assertEqual(t, &v2.DiscoveryResponse{
 		VersionInfo: "0",
 		Resources: []types.Any{
-			any(t, cluster("default/kbujbkuhdod66-172bef/8080", "default/kbujbkuhdod66gjdmwmijz8xzgsx1nkfbrloezdjiulquzk4x3p0nnvpzi8r")),
+			any(t, cluster("default/kbujbkuh-c83ceb/8080/da39a3ee5e", "default/kbujbkuhdod66gjdmwmijz8xzgsx1nkfbrloezdjiulquzk4x3p0nnvpzi8r")),
 		},
 		TypeUrl: clusterType,
 		Nonce:   "0",
@@ -127,7 +127,7 @@ func TestClusterAddUpdateDelete(t *testing.T) {
 	assertEqual(t, &v2.DiscoveryResponse{
 		VersionInfo: "0",
 		Resources: []types.Any{
-			any(t, cluster("default/kuard/80", "default/kuard")),
+			any(t, cluster("default/kuard/80/da39a3ee5e", "default/kuard")),
 		},
 		TypeUrl: clusterType,
 		Nonce:   "0",
@@ -148,7 +148,7 @@ func TestClusterAddUpdateDelete(t *testing.T) {
 	assertEqual(t, &v2.DiscoveryResponse{
 		VersionInfo: "0",
 		Resources: []types.Any{
-			any(t, cluster("default/kuard/80", "default/kuard/http")),
+			any(t, cluster("default/kuard/80/da39a3ee5e", "default/kuard/http")),
 		},
 		TypeUrl: clusterType,
 		Nonce:   "0",
@@ -179,8 +179,8 @@ func TestClusterAddUpdateDelete(t *testing.T) {
 	assertEqual(t, &v2.DiscoveryResponse{
 		VersionInfo: "0",
 		Resources: []types.Any{
-			any(t, cluster("default/kuard/443", "default/kuard/https")),
-			any(t, cluster("default/kuard/80", "default/kuard/http")),
+			any(t, cluster("default/kuard/443/da39a3ee5e", "default/kuard/https")),
+			any(t, cluster("default/kuard/80/da39a3ee5e", "default/kuard/http")),
 		},
 		TypeUrl: clusterType,
 		Nonce:   "0",
@@ -204,7 +204,7 @@ func TestClusterAddUpdateDelete(t *testing.T) {
 	assertEqual(t, &v2.DiscoveryResponse{
 		VersionInfo: "0",
 		Resources: []types.Any{
-			any(t, cluster("default/kuard/443", "default/kuard/https")),
+			any(t, cluster("default/kuard/443/da39a3ee5e", "default/kuard/https")),
 		},
 		TypeUrl: clusterType,
 		Nonce:   "0",
@@ -264,8 +264,8 @@ func TestClusterRenameUpdateDelete(t *testing.T) {
 	assertEqual(t, &v2.DiscoveryResponse{
 		VersionInfo: "0",
 		Resources: []types.Any{
-			any(t, cluster("default/kuard/443", "default/kuard/https")),
-			any(t, cluster("default/kuard/80", "default/kuard/http")),
+			any(t, cluster("default/kuard/443/da39a3ee5e", "default/kuard/https")),
+			any(t, cluster("default/kuard/80/da39a3ee5e", "default/kuard/http")),
 		},
 		TypeUrl: clusterType,
 		Nonce:   "0",
@@ -284,7 +284,7 @@ func TestClusterRenameUpdateDelete(t *testing.T) {
 	assertEqual(t, &v2.DiscoveryResponse{
 		VersionInfo: "0",
 		Resources: []types.Any{
-			any(t, cluster("default/kuard/443", "default/kuard")),
+			any(t, cluster("default/kuard/443/da39a3ee5e", "default/kuard")),
 		},
 		TypeUrl: clusterType,
 		Nonce:   "0",
@@ -295,8 +295,8 @@ func TestClusterRenameUpdateDelete(t *testing.T) {
 	assertEqual(t, &v2.DiscoveryResponse{
 		VersionInfo: "0",
 		Resources: []types.Any{
-			any(t, cluster("default/kuard/443", "default/kuard/https")),
-			any(t, cluster("default/kuard/80", "default/kuard/http")),
+			any(t, cluster("default/kuard/443/da39a3ee5e", "default/kuard/https")),
+			any(t, cluster("default/kuard/80/da39a3ee5e", "default/kuard/http")),
 		},
 		TypeUrl: clusterType,
 		Nonce:   "0",
@@ -343,7 +343,7 @@ func TestIssue243(t *testing.T) {
 		assertEqual(t, &v2.DiscoveryResponse{
 			VersionInfo: "0",
 			Resources: []types.Any{
-				any(t, cluster("default/kuard/80", "default/kuard")),
+				any(t, cluster("default/kuard/80/da39a3ee5e", "default/kuard")),
 			},
 			TypeUrl: clusterType,
 			Nonce:   "0",
@@ -386,7 +386,7 @@ func TestIssue247(t *testing.T) {
 	assertEqual(t, &v2.DiscoveryResponse{
 		VersionInfo: "0",
 		Resources: []types.Any{
-			any(t, cluster("default/kuard/80", "default/kuard")),
+			any(t, cluster("default/kuard/80/da39a3ee5e", "default/kuard")),
 		},
 		TypeUrl: clusterType,
 		Nonce:   "0",
@@ -446,8 +446,8 @@ func TestCDSResourceFiltering(t *testing.T) {
 		VersionInfo: "0",
 		Resources: []types.Any{
 			// note, resources are sorted by Cluster.Name
-			any(t, cluster("default/httpbin/8080", "default/httpbin")),
-			any(t, cluster("default/kuard/80", "default/kuard")),
+			any(t, cluster("default/httpbin/8080/da39a3ee5e", "default/httpbin")),
+			any(t, cluster("default/kuard/80/da39a3ee5e", "default/kuard")),
 		},
 		TypeUrl: clusterType,
 		Nonce:   "0",
@@ -457,11 +457,11 @@ func TestCDSResourceFiltering(t *testing.T) {
 	assertEqual(t, &v2.DiscoveryResponse{
 		VersionInfo: "0",
 		Resources: []types.Any{
-			any(t, cluster("default/kuard/80", "default/kuard")),
+			any(t, cluster("default/kuard/80/da39a3ee5e", "default/kuard")),
 		},
 		TypeUrl: clusterType,
 		Nonce:   "0",
-	}, streamCDS(t, cc, "default/kuard/80"))
+	}, streamCDS(t, cc, "default/kuard/80/da39a3ee5e"))
 
 	// assert a non matching filter returns no results
 	// note: streamCDS would stall at this point.
@@ -512,7 +512,7 @@ func TestClusterCircuitbreakerAnnotations(t *testing.T) {
 		VersionInfo: "0",
 		Resources: []types.Any{
 			any(t, &v2.Cluster{
-				Name: "default/kuard/8080",
+				Name: "default/kuard/8080/da39a3ee5e",
 				Type: v2.Cluster_EDS,
 				EdsClusterConfig: &v2.Cluster_EdsClusterConfig{
 					EdsConfig:   apiconfigsource("contour"), // hard coded by initconfig
@@ -561,7 +561,7 @@ func TestClusterCircuitbreakerAnnotations(t *testing.T) {
 		VersionInfo: "0",
 		Resources: []types.Any{
 			any(t, &v2.Cluster{
-				Name: "default/kuard/8080",
+				Name: "default/kuard/8080/da39a3ee5e",
 				Type: v2.Cluster_EDS,
 				EdsClusterConfig: &v2.Cluster_EdsClusterConfig{
 					EdsConfig:   apiconfigsource("contour"), // hard coded by initconfig
@@ -634,7 +634,91 @@ func TestClusterPerServiceParameters(t *testing.T) {
 	assertEqual(t, &v2.DiscoveryResponse{
 		VersionInfo: "0",
 		Resources: []types.Any{
-			any(t, cluster("default/kuard/80", "default/kuard")),
+			any(t, cluster("default/kuard/80/da39a3ee5e", "default/kuard")),
+		},
+		TypeUrl: clusterType,
+		Nonce:   "0",
+	}, streamCDS(t, cc))
+}
+
+// issue 581, different load balancer parameters should
+// generate multiple cds entries.
+func TestClusterLoadBalancerStrategyPerRoute(t *testing.T) {
+	rh, cc, done := setup(t)
+	defer done()
+
+	rh.OnAdd(&v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "kuard",
+			Namespace: "default",
+		},
+		Spec: v1.ServiceSpec{
+			Ports: []v1.ServicePort{{
+				Protocol:   "TCP",
+				Port:       80,
+				TargetPort: intstr.FromInt(8080),
+			}},
+		},
+	})
+
+	rh.OnAdd(&ingressroutev1.IngressRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "simple",
+			Namespace: "default",
+		},
+		Spec: ingressroutev1.IngressRouteSpec{
+			VirtualHost: &ingressroutev1.VirtualHost{Fqdn: "www.example.com"},
+			Routes: []ingressroutev1.Route{{
+				Match: "/a",
+				Services: []ingressroutev1.Service{{
+					Name:     "kuard",
+					Port:     80,
+					Strategy: "Random",
+				}},
+			}, {
+				Match: "/b",
+				Services: []ingressroutev1.Service{{
+					Name:     "kuard",
+					Port:     80,
+					Strategy: "Maglev",
+				}},
+			}},
+		},
+	})
+
+	assertEqual(t, &v2.DiscoveryResponse{
+		VersionInfo: "0",
+		Resources: []types.Any{
+			any(t, &v2.Cluster{
+				Name: "default/kuard/80/58d888c08a",
+				Type: v2.Cluster_EDS,
+				EdsClusterConfig: &v2.Cluster_EdsClusterConfig{
+					EdsConfig:   apiconfigsource("contour"), // hard coded by initconfig
+					ServiceName: "default/kuard",
+				},
+				ConnectTimeout: 250 * time.Millisecond,
+				LbPolicy:       v2.Cluster_RANDOM,
+				CommonLbConfig: &v2.Cluster_CommonLbConfig{
+					HealthyPanicThreshold: &envoy_type.Percent{ // Disable HealthyPanicThreshold
+						Value: 0,
+					},
+				},
+			}),
+			any(t, &v2.Cluster{
+				Name: "default/kuard/80/843e4ded8f",
+				Type: v2.Cluster_EDS,
+				EdsClusterConfig: &v2.Cluster_EdsClusterConfig{
+					EdsConfig:   apiconfigsource("contour"), // hard coded by initconfig
+					ServiceName: "default/kuard",
+				},
+				ConnectTimeout: 250 * time.Millisecond,
+				LbPolicy:       v2.Cluster_MAGLEV,
+				CommonLbConfig: &v2.Cluster_CommonLbConfig{
+					HealthyPanicThreshold: &envoy_type.Percent{ // Disable HealthyPanicThreshold
+						Value: 0,
+					},
+				},
+			}),
 		},
 		TypeUrl: clusterType,
 		Nonce:   "0",


### PR DESCRIPTION
Updates #581

This PR alters the way the CDS cluster name is computed to include a
hash of the service's parameters. This this way, services with differing
parameters will have different CDS entries.

These CDS entries share the same EDS backends, as they share the same
Cluster.ServiceName identifier.

At the moment only load balancing strategy is included in the parameter
hash. The next PR will include the other components of the health check
strategy.

Signed-off-by: Dave Cheney <dave@cheney.net>