### PR TITLE
internal/contour: update route vistor for cluster name change

### DIFF
--- a/internal/contour/cluster_test.go
+++ b/internal/contour/cluster_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/gogo/protobuf/types"
 	"github.com/google/go-cmp/cmp"
 	ingressroutev1 "github.com/heptio/contour/apis/contour/v1beta1"
-	"github.com/heptio/contour/internal/dag"
 	"github.com/heptio/contour/internal/metrics"
 	"github.com/prometheus/client_golang/prometheus"
 	"k8s.io/api/core/v1"
@@ -907,62 +906,4 @@ func clustermap(clusters ...*v2.Cluster) map[string]*v2.Cluster {
 
 func duration(d time.Duration) *time.Duration {
 	return &d
-}
-
-func TestServiceName(t *testing.T) {
-	tests := map[string]struct {
-		service *dag.Service
-		want    string
-	}{
-		"named service": {
-			service: &dag.Service{
-				Object: &v1.Service{
-					ObjectMeta: metav1.ObjectMeta{
-						Namespace: "default",
-						Name:      "kuard",
-					},
-				},
-				ServicePort: &v1.ServicePort{
-					Name: "http",
-				},
-			},
-			want: "default/kuard/http",
-		},
-		"named service w/ lb strategy": {
-			service: &dag.Service{
-				Object: &v1.Service{
-					ObjectMeta: metav1.ObjectMeta{
-						Namespace: "default",
-						Name:      "kuard",
-					},
-				},
-				ServicePort: &v1.ServicePort{
-					Name: "http",
-				},
-				LoadBalancerStrategy: "Random", // ignored by servicename
-			},
-			want: "default/kuard/http",
-		},
-		"unnamed service": {
-			service: &dag.Service{
-				Object: &v1.Service{
-					ObjectMeta: metav1.ObjectMeta{
-						Namespace: "default",
-						Name:      "kuard",
-					},
-				},
-				ServicePort: &v1.ServicePort{},
-			},
-			want: "default/kuard",
-		},
-	}
-
-	for name, tc := range tests {
-		t.Run(name, func(t *testing.T) {
-			got := servicename(tc.service)
-			if diff := cmp.Diff(tc.want, got); diff != "" {
-				t.Fatal(diff)
-			}
-		})
-	}
 }

--- a/internal/contour/endpointstranslator.go
+++ b/internal/contour/endpointstranslator.go
@@ -122,7 +122,7 @@ func (e *EndpointsTranslator) recomputeClusterLoadAssignment(oldep, newep *v1.En
 			portname := p.Name
 			cla, ok := clas[portname]
 			if !ok {
-				cla = clusterloadassignment(clustername(newep.ObjectMeta, portname))
+				cla = clusterloadassignment(servicename(newep.ObjectMeta, portname))
 				clas[portname] = cla
 			}
 			for _, a := range s.Addresses {
@@ -148,16 +148,16 @@ func (e *EndpointsTranslator) recomputeClusterLoadAssignment(oldep, newep *v1.En
 			portname := p.Name
 			if _, ok := clas[portname]; !ok {
 				// port is not present in the list added / updated, so remove it
-				e.Remove(clustername(oldep.ObjectMeta, portname))
+				e.Remove(servicename(oldep.ObjectMeta, portname))
 			}
 		}
 	}
 }
 
-// clustername returns the name of the cluster this meta and port
+// servicename returns the name of the cluster this meta and port
 // refers to. The CDS name of the cluster may include additional suffixes
 // but these are not known to EDS.
-func clustername(meta metav1.ObjectMeta, portname string) string {
+func servicename(meta metav1.ObjectMeta, portname string) string {
 	name := []string{
 		meta.Namespace,
 		meta.Name,

--- a/internal/contour/route.go
+++ b/internal/contour/route.go
@@ -17,7 +17,6 @@ import (
 	"crypto/sha256"
 	"fmt"
 	"sort"
-	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -290,7 +289,7 @@ func weightedclusters(services []*dag.Service) *route.WeightedCluster {
 	for _, svc := range services {
 		total += svc.Weight
 		wc.Clusters = append(wc.Clusters, &route.WeightedCluster_ClusterWeight{
-			Name:   hashname(60, svc.Namespace(), svc.Name(), strconv.Itoa(int(svc.Port))),
+			Name:   clustername(svc),
 			Weight: &types.UInt32Value{Value: uint32(svc.Weight)},
 		})
 	}

--- a/internal/contour/route_test.go
+++ b/internal/contour/route_test.go
@@ -89,7 +89,7 @@ func TestRouteVisit(t *testing.T) {
 						Domains: []string{"*"},
 						Routes: []route.Route{{
 							Match:  prefixmatch("/"),
-							Action: routeroute("default/kuard/8080"),
+							Action: routeroute("default/kuard/8080/da39a3ee5e"),
 						}},
 					}},
 				},
@@ -142,7 +142,7 @@ func TestRouteVisit(t *testing.T) {
 						Domains: []string{"www.example.com", "www.example.com:80"},
 						Routes: []route.Route{{
 							Match:  prefixmatch("/"),
-							Action: routeroute("default/backend/80"),
+							Action: routeroute("default/backend/80/da39a3ee5e"),
 						}},
 					}},
 				},
@@ -198,7 +198,7 @@ func TestRouteVisit(t *testing.T) {
 						Domains: []string{"*"},
 						Routes: []route.Route{{
 							Match:  prefixmatch("/"),
-							Action: routeroute("default/kuard/8080"),
+							Action: routeroute("default/kuard/8080/da39a3ee5e"),
 						}},
 					}},
 				},
@@ -264,7 +264,7 @@ func TestRouteVisit(t *testing.T) {
 						Domains: []string{"www.example.com", "www.example.com:80"},
 						Routes: []route.Route{{
 							Match:  prefixmatch("/"),
-							Action: routeroute("default/kuard/8080"),
+							Action: routeroute("default/kuard/8080/da39a3ee5e"),
 						}},
 					}},
 				},
@@ -275,7 +275,7 @@ func TestRouteVisit(t *testing.T) {
 						Domains: []string{"www.example.com", "www.example.com:443"},
 						Routes: []route.Route{{
 							Match:  prefixmatch("/"),
-							Action: routeroute("default/kuard/8080"),
+							Action: routeroute("default/kuard/8080/da39a3ee5e"),
 						}},
 					}},
 				},
@@ -350,7 +350,7 @@ func TestRouteVisit(t *testing.T) {
 						Domains: []string{"www.example.com", "www.example.com:443"},
 						Routes: []route.Route{{
 							Match:  prefixmatch("/"),
-							Action: routeroute("default/backend/8080"),
+							Action: routeroute("default/backend/8080/da39a3ee5e"),
 						}},
 					}},
 				},
@@ -419,7 +419,7 @@ func TestRouteVisit(t *testing.T) {
 						Domains: []string{"www.example.com", "www.example.com:443"},
 						Routes: []route.Route{{
 							Match:  prefixmatch("/"),
-							Action: routeroute("default/kuard/8080"),
+							Action: routeroute("default/kuard/8080/da39a3ee5e"),
 						}},
 					}},
 				},
@@ -500,7 +500,7 @@ func TestRouteVisit(t *testing.T) {
 						Domains: []string{"www.example.com", "www.example.com:443"},
 						Routes: []route.Route{{
 							Match:  prefixmatch("/"),
-							Action: routeroute("default/kuard/8080"),
+							Action: routeroute("default/kuard/8080/da39a3ee5e"),
 						}},
 					}},
 				},
@@ -562,10 +562,10 @@ func TestRouteVisit(t *testing.T) {
 						Domains: []string{"www.example.com", "www.example.com:80"},
 						Routes: []route.Route{{
 							Match:  prefixmatch("/ws1"),
-							Action: websocketroute("default/kuard/8080"),
+							Action: websocketroute("default/kuard/8080/da39a3ee5e"),
 						}, {
 							Match:  prefixmatch("/"),
-							Action: routeroute("default/kuard/8080"),
+							Action: routeroute("default/kuard/8080/da39a3ee5e"),
 						}},
 					}},
 				},
@@ -613,7 +613,7 @@ func TestRouteVisit(t *testing.T) {
 						Domains: []string{"*"},
 						Routes: []route.Route{{
 							Match:  prefixmatch("/"),
-							Action: routetimeout("default/kuard/8080", &infinity),
+							Action: routetimeout("default/kuard/8080/da39a3ee5e", &infinity),
 						}},
 					}},
 				},
@@ -661,7 +661,7 @@ func TestRouteVisit(t *testing.T) {
 						Domains: []string{"*"},
 						Routes: []route.Route{{
 							Match:  prefixmatch("/"),
-							Action: routetimeout("default/kuard/8080", &infinity),
+							Action: routetimeout("default/kuard/8080/da39a3ee5e", &infinity),
 						}},
 					}},
 				},
@@ -709,7 +709,7 @@ func TestRouteVisit(t *testing.T) {
 						Domains: []string{"*"},
 						Routes: []route.Route{{
 							Match:  prefixmatch("/"),
-							Action: routetimeout("default/kuard/8080", &nintyseconds),
+							Action: routetimeout("default/kuard/8080/da39a3ee5e", &nintyseconds),
 						}},
 					}},
 				},
@@ -765,7 +765,7 @@ func TestRouteVisit(t *testing.T) {
 						Domains: []string{"my-very-very-long-service-host-name.subdomain.boring-dept.my.company", "my-very-very-long-service-host-name.subdomain.boring-dept.my.company:80"},
 						Routes: []route.Route{{
 							Match:  prefixmatch("/"),
-							Action: routeroute("default/kuard/80"),
+							Action: routeroute("default/kuard/80/da39a3ee5e"),
 						}},
 					}},
 				},
@@ -853,7 +853,7 @@ func TestRouteVisit(t *testing.T) {
 						Domains: []string{"*"},
 						Routes: []route.Route{{
 							Match:  prefixmatch("/"),
-							Action: routeroute("default/kuard/8080"),
+							Action: routeroute("default/kuard/8080/da39a3ee5e"),
 						}},
 					}},
 				},
@@ -901,7 +901,7 @@ func TestRouteVisit(t *testing.T) {
 						Domains: []string{"*"},
 						Routes: []route.Route{{
 							Match:  prefixmatch("/"),
-							Action: routeretry("default/kuard/8080", "50x,gateway-error", 0, 0),
+							Action: routeretry("default/kuard/8080/da39a3ee5e", "50x,gateway-error", 0, 0),
 						}},
 					}},
 				},
@@ -950,7 +950,7 @@ func TestRouteVisit(t *testing.T) {
 						Domains: []string{"*"},
 						Routes: []route.Route{{
 							Match:  prefixmatch("/"),
-							Action: routeretry("default/kuard/8080", "50x,gateway-error", 7, 0),
+							Action: routeretry("default/kuard/8080/da39a3ee5e", "50x,gateway-error", 7, 0),
 						}},
 					}},
 				},
@@ -999,7 +999,7 @@ func TestRouteVisit(t *testing.T) {
 						Domains: []string{"*"},
 						Routes: []route.Route{{
 							Match:  prefixmatch("/"),
-							Action: routeretry("default/kuard/8080", "50x,gateway-error", 0, 150*time.Millisecond),
+							Action: routeretry("default/kuard/8080/da39a3ee5e", "50x,gateway-error", 0, 150*time.Millisecond),
 						}},
 					}},
 				},
@@ -1075,15 +1075,13 @@ func TestRouteVisit(t *testing.T) {
 									ClusterSpecifier: &route.RouteAction_WeightedClusters{
 										WeightedClusters: &route.WeightedCluster{
 											Clusters: []*route.WeightedCluster_ClusterWeight{{
-												Name:   "default/backend/80",
-												Weight: &types.UInt32Value{Value: uint32(1)},
+												Name:   "default/backend/80/da39a3ee5e",
+												Weight: u32(1),
 											}, {
-												Name:   "default/backendtwo/80",
-												Weight: &types.UInt32Value{Value: uint32(1)},
+												Name:   "default/backendtwo/80/da39a3ee5e",
+												Weight: u32(1),
 											}},
-											TotalWeight: &types.UInt32Value{
-												Value: uint32(2),
-											},
+											TotalWeight: u32(2),
 										},
 									},
 								},
@@ -1163,15 +1161,13 @@ func TestRouteVisit(t *testing.T) {
 									ClusterSpecifier: &route.RouteAction_WeightedClusters{
 										WeightedClusters: &route.WeightedCluster{
 											Clusters: []*route.WeightedCluster_ClusterWeight{{
-												Name:   "default/backend/80",
-												Weight: &types.UInt32Value{Value: uint32(0)},
+												Name:   "default/backend/80/da39a3ee5e",
+												Weight: u32(0),
 											}, {
-												Name:   "default/backendtwo/80",
-												Weight: &types.UInt32Value{Value: uint32(50)},
+												Name:   "default/backendtwo/80/da39a3ee5e",
+												Weight: u32(50),
 											}},
-											TotalWeight: &types.UInt32Value{
-												Value: uint32(50),
-											},
+											TotalWeight: u32(50),
 										},
 									},
 								},
@@ -1252,15 +1248,13 @@ func TestRouteVisit(t *testing.T) {
 									ClusterSpecifier: &route.RouteAction_WeightedClusters{
 										WeightedClusters: &route.WeightedCluster{
 											Clusters: []*route.WeightedCluster_ClusterWeight{{
-												Name:   "default/backend/80",
-												Weight: &types.UInt32Value{Value: uint32(22)},
+												Name:   "default/backend/80/da39a3ee5e",
+												Weight: u32(22),
 											}, {
-												Name:   "default/backendtwo/80",
-												Weight: &types.UInt32Value{Value: uint32(50)},
+												Name:   "default/backendtwo/80/da39a3ee5e",
+												Weight: u32(50),
 											}},
-											TotalWeight: &types.UInt32Value{
-												Value: uint32(72),
-											},
+											TotalWeight: u32(72),
 										},
 									},
 								},
@@ -1350,11 +1344,9 @@ func routeroute(cluster string) *route.Route_Route {
 				WeightedClusters: &route.WeightedCluster{
 					Clusters: []*route.WeightedCluster_ClusterWeight{{
 						Name:   cluster,
-						Weight: &types.UInt32Value{Value: uint32(1)},
+						Weight: u32(1),
 					}},
-					TotalWeight: &types.UInt32Value{
-						Value: uint32(1),
-					},
+					TotalWeight: u32(1),
 				},
 			},
 		},
@@ -1379,7 +1371,7 @@ func routeretry(cluster string, retryOn string, numRetries uint32, perTryTimeout
 		RetryOn: retryOn,
 	}
 	if numRetries > 0 {
-		r.Route.RetryPolicy.NumRetries = &types.UInt32Value{Value: numRetries}
+		r.Route.RetryPolicy.NumRetries = u32(numRetries)
 	}
 	if perTryTimeout > 0 {
 		r.Route.RetryPolicy.PerTryTimeout = &perTryTimeout
@@ -1412,14 +1404,10 @@ func TestActionRoute(t *testing.T) {
 					ClusterSpecifier: &route.RouteAction_WeightedClusters{
 						WeightedClusters: &route.WeightedCluster{
 							Clusters: []*route.WeightedCluster_ClusterWeight{{
-								Name: "default/kuard/8080",
-								Weight: &types.UInt32Value{
-									Value: uint32(1),
-								}},
-							},
-							TotalWeight: &types.UInt32Value{
-								Value: uint32(1),
-							},
+								Name:   "default/kuard/8080/da39a3ee5e",
+								Weight: u32(1),
+							}},
+							TotalWeight: u32(1),
 						},
 					},
 				},
@@ -1447,14 +1435,10 @@ func TestActionRoute(t *testing.T) {
 					ClusterSpecifier: &route.RouteAction_WeightedClusters{
 						WeightedClusters: &route.WeightedCluster{
 							Clusters: []*route.WeightedCluster_ClusterWeight{{
-								Name: "default/kuard/8080",
-								Weight: &types.UInt32Value{
-									Value: uint32(1),
-								}},
-							},
-							TotalWeight: &types.UInt32Value{
-								Value: uint32(1),
-							},
+								Name:   "default/kuard/8080/da39a3ee5e",
+								Weight: u32(1),
+							}},
+							TotalWeight: u32(1),
 						},
 					},
 					Timeout: pduration(30 * time.Second),
@@ -1483,17 +1467,13 @@ func TestActionRoute(t *testing.T) {
 					ClusterSpecifier: &route.RouteAction_WeightedClusters{
 						WeightedClusters: &route.WeightedCluster{
 							Clusters: []*route.WeightedCluster_ClusterWeight{{
-								Name: "default/kuard/8080",
-								Weight: &types.UInt32Value{
-									Value: uint32(1),
-								}},
-							},
-							TotalWeight: &types.UInt32Value{
-								Value: uint32(1),
-							},
+								Name:   "default/kuard/8080/da39a3ee5e",
+								Weight: u32(1),
+							}},
+							TotalWeight: u32(1),
 						},
 					},
-					Timeout: pduration(time.Duration(0)),
+					Timeout: pduration(0),
 				},
 			},
 		},
@@ -1519,14 +1499,10 @@ func TestActionRoute(t *testing.T) {
 					ClusterSpecifier: &route.RouteAction_WeightedClusters{
 						WeightedClusters: &route.WeightedCluster{
 							Clusters: []*route.WeightedCluster_ClusterWeight{{
-								Name: "default/kuard/8080",
-								Weight: &types.UInt32Value{
-									Value: uint32(1),
-								}},
-							},
-							TotalWeight: &types.UInt32Value{
-								Value: uint32(1),
-							},
+								Name:   "default/kuard/8080/da39a3ee5e",
+								Weight: u32(1),
+							}},
+							TotalWeight: u32(1),
 						},
 					},
 					UseWebsocket: &types.BoolValue{Value: true},
@@ -1556,14 +1532,10 @@ func TestActionRoute(t *testing.T) {
 					ClusterSpecifier: &route.RouteAction_WeightedClusters{
 						WeightedClusters: &route.WeightedCluster{
 							Clusters: []*route.WeightedCluster_ClusterWeight{{
-								Name: "default/kuard/8080",
-								Weight: &types.UInt32Value{
-									Value: uint32(1),
-								}},
-							},
-							TotalWeight: &types.UInt32Value{
-								Value: uint32(1),
-							},
+								Name:   "default/kuard/8080/da39a3ee5e",
+								Weight: u32(1),
+							}},
+							TotalWeight: u32(1),
 						},
 					},
 					Timeout:      pduration(5 * time.Second),
@@ -1594,14 +1566,10 @@ func TestActionRoute(t *testing.T) {
 					ClusterSpecifier: &route.RouteAction_WeightedClusters{
 						WeightedClusters: &route.WeightedCluster{
 							Clusters: []*route.WeightedCluster_ClusterWeight{{
-								Name: "default/kuard/8080",
-								Weight: &types.UInt32Value{
-									Value: uint32(1),
-								}},
-							},
-							TotalWeight: &types.UInt32Value{
-								Value: uint32(1),
-							},
+								Name:   "default/kuard/8080/da39a3ee5e",
+								Weight: u32(1),
+							}},
+							TotalWeight: u32(1),
 						},
 					},
 				},
@@ -1631,15 +1599,15 @@ func TestActionRoute(t *testing.T) {
 					ClusterSpecifier: &route.RouteAction_WeightedClusters{
 						WeightedClusters: &route.WeightedCluster{
 							Clusters: []*route.WeightedCluster_ClusterWeight{{
-								Name:   "default/kuard/8080",
-								Weight: &types.UInt32Value{Value: 1}},
-							},
-							TotalWeight: &types.UInt32Value{Value: 1},
+								Name:   "default/kuard/8080/da39a3ee5e",
+								Weight: u32(1),
+							}},
+							TotalWeight: u32(1),
 						},
 					},
 					RetryPolicy: &route.RouteAction_RetryPolicy{
 						RetryOn:       "50x",
-						NumRetries:    &types.UInt32Value{Value: 7},
+						NumRetries:    u32(7),
 						PerTryTimeout: pduration(10 * time.Second),
 					},
 				},
@@ -1676,67 +1644,55 @@ func TestActionRoute(t *testing.T) {
 					ClusterSpecifier: &route.RouteAction_WeightedClusters{
 						WeightedClusters: &route.WeightedCluster{
 							Clusters: []*route.WeightedCluster_ClusterWeight{{
-								Name: "default/kuard/8080",
-								Weight: &types.UInt32Value{
-									Value: uint32(1),
-								}}, {
-								Name: "default/nginx/8080",
-								Weight: &types.UInt32Value{
-									Value: uint32(1),
-								}},
-							},
-							TotalWeight: &types.UInt32Value{
-								Value: uint32(2),
-							},
+								Name:   "default/kuard/8080/da39a3ee5e",
+								Weight: u32(1),
+							}, {
+								Name:   "default/nginx/8080/da39a3ee5e",
+								Weight: u32(1),
+							}},
+							TotalWeight: u32(2),
 						},
 					},
 				},
 			},
 		},
 		"multiple weighted services": {
-			services: []*dag.Service{
-				{
-					Object: &v1.Service{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "kuard",
-							Namespace: "default",
-						},
+			services: []*dag.Service{{
+				Object: &v1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "kuard",
+						Namespace: "default",
 					},
-					ServicePort: &v1.ServicePort{
-						Port: 8080,
-					},
-					Weight: 80,
 				},
-				{
-					Object: &v1.Service{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "nginx",
-							Namespace: "default",
-						},
-					},
-					ServicePort: &v1.ServicePort{
-						Port: 8080,
-					},
-					Weight: 20,
+				ServicePort: &v1.ServicePort{
+					Port: 8080,
 				},
+				Weight: 80,
+			}, {
+				Object: &v1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "nginx",
+						Namespace: "default",
+					},
+				},
+				ServicePort: &v1.ServicePort{
+					Port: 8080,
+				},
+				Weight: 20,
+			},
 			},
 			want: &route.Route_Route{
 				Route: &route.RouteAction{
 					ClusterSpecifier: &route.RouteAction_WeightedClusters{
 						WeightedClusters: &route.WeightedCluster{
 							Clusters: []*route.WeightedCluster_ClusterWeight{{
-								Name: "default/kuard/8080",
-								Weight: &types.UInt32Value{
-									Value: uint32(80),
-								}}, {
-								Name: "default/nginx/8080",
-								Weight: &types.UInt32Value{
-									Value: uint32(20),
-								}},
-							},
-							TotalWeight: &types.UInt32Value{
-								Value: uint32(100),
-							},
+								Name:   "default/kuard/8080/da39a3ee5e",
+								Weight: u32(80),
+							}, {
+								Name:   "default/nginx/8080/da39a3ee5e",
+								Weight: u32(20),
+							}},
+							TotalWeight: u32(100),
 						},
 					},
 				},
@@ -1785,22 +1741,16 @@ func TestActionRoute(t *testing.T) {
 					ClusterSpecifier: &route.RouteAction_WeightedClusters{
 						WeightedClusters: &route.WeightedCluster{
 							Clusters: []*route.WeightedCluster_ClusterWeight{{
-								Name: "default/kuard/8080",
-								Weight: &types.UInt32Value{
-									Value: uint32(80),
-								}}, {
-								Name: "default/nginx/8080",
-								Weight: &types.UInt32Value{
-									Value: uint32(20),
-								}}, {
-								Name: "default/notraffic/8080",
-								Weight: &types.UInt32Value{
-									Value: uint32(0),
-								}},
-							},
-							TotalWeight: &types.UInt32Value{
-								Value: uint32(100),
-							},
+								Name:   "default/kuard/8080/da39a3ee5e",
+								Weight: u32(80),
+							}, {
+								Name:   "default/nginx/8080/da39a3ee5e",
+								Weight: u32(20),
+							}, {
+								Name:   "default/notraffic/8080/da39a3ee5e",
+								Weight: u32(0),
+							}},
+							TotalWeight: u32(100),
 						},
 					},
 				},
@@ -1821,3 +1771,5 @@ func TestActionRoute(t *testing.T) {
 func pduration(d time.Duration) *time.Duration {
 	return &d
 }
+
+func u32(val uint32) *types.UInt32Value { return &types.UInt32Value{Value: val} }

--- a/internal/e2e/rds_test.go
+++ b/internal/e2e/rds_test.go
@@ -106,7 +106,7 @@ func TestEditIngress(t *testing.T) {
 					Domains: []string{"*"},
 					Routes: []route.Route{{
 						Match:  prefixmatch("/"),
-						Action: routecluster("default/kuard/80"),
+						Action: routecluster("default/kuard/80/da39a3ee5e"),
 					}},
 				}},
 			}),
@@ -149,7 +149,7 @@ func TestEditIngress(t *testing.T) {
 					Domains: []string{"*"},
 					Routes: []route.Route{{
 						Match:  prefixmatch("/testing"),
-						Action: routecluster("default/kuard/80"),
+						Action: routecluster("default/kuard/80/da39a3ee5e"),
 					}},
 				}},
 			}),
@@ -228,7 +228,7 @@ func TestIngressPathRouteWithoutHost(t *testing.T) {
 					Domains: []string{"*"},
 					Routes: []route.Route{{
 						Match:  prefixmatch("/hello"),
-						Action: routecluster("default/hello/80"),
+						Action: routecluster("default/hello/80/da39a3ee5e"),
 					}},
 				}},
 			}),
@@ -308,7 +308,7 @@ func TestEditIngressInPlace(t *testing.T) {
 					Domains: []string{"hello.example.com", "hello.example.com:80"},
 					Routes: []route.Route{{
 						Match:  prefixmatch("/"),
-						Action: routecluster("default/wowie/80"),
+						Action: routecluster("default/wowie/80/da39a3ee5e"),
 					}},
 				}},
 			}),
@@ -357,10 +357,10 @@ func TestEditIngressInPlace(t *testing.T) {
 					Domains: []string{"hello.example.com", "hello.example.com:80"},
 					Routes: []route.Route{{
 						Match:  prefixmatch("/whoop"),
-						Action: routecluster("default/kerpow/9000"),
+						Action: routecluster("default/kerpow/9000/da39a3ee5e"),
 					}, {
 						Match:  prefixmatch("/"),
-						Action: routecluster("default/wowie/80"),
+						Action: routecluster("default/wowie/80/da39a3ee5e"),
 					}},
 				}},
 			}),
@@ -497,10 +497,10 @@ func TestEditIngressInPlace(t *testing.T) {
 					Domains: []string{"hello.example.com", "hello.example.com:443"},
 					Routes: []route.Route{{
 						Match:  prefixmatch("/whoop"),
-						Action: routecluster("default/kerpow/9000"),
+						Action: routecluster("default/kerpow/9000/da39a3ee5e"),
 					}, {
 						Match:  prefixmatch("/"),
-						Action: routecluster("default/wowie/80"),
+						Action: routecluster("default/wowie/80/da39a3ee5e"),
 					}},
 				}}}),
 		},
@@ -547,7 +547,7 @@ func TestRequestTimeout(t *testing.T) {
 		Domains: []string{"*"},
 		Routes: []route.Route{{
 			Match:  prefixmatch("/"), // match all
-			Action: routecluster("default/backend/80"),
+			Action: routecluster("default/backend/80/da39a3ee5e"),
 		}},
 	}}, nil)
 
@@ -568,7 +568,7 @@ func TestRequestTimeout(t *testing.T) {
 		Domains: []string{"*"},
 		Routes: []route.Route{{
 			Match:  prefixmatch("/"), // match all
-			Action: clustertimeout("default/backend/80", durationInfinite),
+			Action: clustertimeout("default/backend/80/da39a3ee5e", durationInfinite),
 		}},
 	}}, nil)
 
@@ -589,7 +589,7 @@ func TestRequestTimeout(t *testing.T) {
 		Domains: []string{"*"},
 		Routes: []route.Route{{
 			Match:  prefixmatch("/"), // match all
-			Action: clustertimeout("default/backend/80", duration10Minutes),
+			Action: clustertimeout("default/backend/80/da39a3ee5e", duration10Minutes),
 		}},
 	}}, nil)
 
@@ -610,7 +610,7 @@ func TestRequestTimeout(t *testing.T) {
 		Domains: []string{"*"},
 		Routes: []route.Route{{
 			Match:  prefixmatch("/"), // match all
-			Action: clustertimeout("default/backend/80", durationInfinite),
+			Action: clustertimeout("default/backend/80/da39a3ee5e", durationInfinite),
 		}},
 	}}, nil)
 }
@@ -721,7 +721,7 @@ func TestSSLRedirectOverlay(t *testing.T) {
 		Domains: []string{"example.com", "example.com:80"},
 		Routes: []route.Route{{
 			Match:  prefixmatch("/.well-known/acme-challenge/gVJl5NWL2owUqZekjHkt_bo3OHYC2XNDURRRgLI5JTk"),
-			Action: routecluster("nginx-ingress/challenge-service/8009"),
+			Action: routecluster("nginx-ingress/challenge-service/8009/da39a3ee5e"),
 		}, {
 			Match:  prefixmatch("/"), // match all
 			Action: redirecthttps(),
@@ -731,10 +731,10 @@ func TestSSLRedirectOverlay(t *testing.T) {
 		Domains: []string{"example.com", "example.com:443"},
 		Routes: []route.Route{{
 			Match:  prefixmatch("/.well-known/acme-challenge/gVJl5NWL2owUqZekjHkt_bo3OHYC2XNDURRRgLI5JTk"),
-			Action: routecluster("nginx-ingress/challenge-service/8009"),
+			Action: routecluster("nginx-ingress/challenge-service/8009/da39a3ee5e"),
 		}, {
 			Match:  prefixmatch("/"), // match all
-			Action: routecluster("default/app-service/8080"),
+			Action: routecluster("default/app-service/8080/da39a3ee5e"),
 		}},
 	}})
 }
@@ -794,7 +794,7 @@ func TestIssue257(t *testing.T) {
 		Domains: []string{"*"},
 		Routes: []route.Route{{
 			Match:  prefixmatch("/"), // match all
-			Action: routecluster("default/kuard/80"),
+			Action: routecluster("default/kuard/80/da39a3ee5e"),
 		}},
 	}}, nil)
 
@@ -847,7 +847,7 @@ func TestIssue257(t *testing.T) {
 		Domains: []string{"kuard.db.gd-ms.com", "kuard.db.gd-ms.com:80"},
 		Routes: []route.Route{{
 			Match:  prefixmatch("/"), // match all
-			Action: routecluster("default/kuard/80"),
+			Action: routecluster("default/kuard/80/da39a3ee5e"),
 		}},
 	}}, nil)
 }
@@ -963,7 +963,7 @@ func TestRDSFilter(t *testing.T) {
 					Domains: []string{"example.com", "example.com:80"},
 					Routes: []route.Route{{
 						Match:  prefixmatch("/.well-known/acme-challenge/gVJl5NWL2owUqZekjHkt_bo3OHYC2XNDURRRgLI5JTk"),
-						Action: routecluster("nginx-ingress/challenge-service/8009"),
+						Action: routecluster("nginx-ingress/challenge-service/8009/da39a3ee5e"),
 					}, {
 						Match:  prefixmatch("/"), // match all
 						Action: redirecthttps(),
@@ -985,10 +985,10 @@ func TestRDSFilter(t *testing.T) {
 					Domains: []string{"example.com", "example.com:443"},
 					Routes: []route.Route{{
 						Match:  prefixmatch("/.well-known/acme-challenge/gVJl5NWL2owUqZekjHkt_bo3OHYC2XNDURRRgLI5JTk"),
-						Action: routecluster("nginx-ingress/challenge-service/8009"),
+						Action: routecluster("nginx-ingress/challenge-service/8009/da39a3ee5e"),
 					}, {
 						Match:  prefixmatch("/"), // match all
-						Action: routecluster("default/app-service/8080"),
+						Action: routecluster("default/app-service/8080/da39a3ee5e"),
 					}},
 				}},
 			}),
@@ -1047,7 +1047,7 @@ func TestWebsocketIngress(t *testing.T) {
 		Domains: []string{"websocket.hello.world", "websocket.hello.world:80"},
 		Routes: []route.Route{{
 			Match:  prefixmatch("/"), // match all
-			Action: websocketroute("default/ws/80"),
+			Action: websocketroute("default/ws/80/da39a3ee5e"),
 		}},
 	}}, nil)
 }
@@ -1106,13 +1106,13 @@ func TestWebsocketIngressRoute(t *testing.T) {
 		Domains: []string{"websocket.hello.world", "websocket.hello.world:80"},
 		Routes: []route.Route{{
 			Match:  prefixmatch("/ws-2"),
-			Action: websocketroute("default/ws/80"),
+			Action: websocketroute("default/ws/80/da39a3ee5e"),
 		}, {
 			Match:  prefixmatch("/ws-1"),
-			Action: websocketroute("default/ws/80"),
+			Action: websocketroute("default/ws/80/da39a3ee5e"),
 		}, {
 			Match:  prefixmatch("/"), // match all
-			Action: routecluster("default/ws/80"),
+			Action: routecluster("default/ws/80/da39a3ee5e"),
 		}},
 	}}, nil)
 }
@@ -1207,17 +1207,17 @@ func TestDefaultBackendDoesNotOverwriteNamedHost(t *testing.T) {
 					Domains: []string{"*"},
 					Routes: []route.Route{{
 						Match:  prefixmatch("/kuard"),
-						Action: routecluster("default/kuard/8080"),
+						Action: routecluster("default/kuard/8080/da39a3ee5e"),
 					}, {
 						Match:  prefixmatch("/"),
-						Action: routecluster("default/kuard/80"),
+						Action: routecluster("default/kuard/80/da39a3ee5e"),
 					}},
 				}, {
 					Name:    "test-gui",
 					Domains: []string{"test-gui", "test-gui:80"},
 					Routes: []route.Route{{
 						Match:  prefixmatch("/"),
-						Action: routecluster("default/test-gui/80"),
+						Action: routecluster("default/test-gui/80/da39a3ee5e"),
 					}},
 				}},
 			}),
@@ -1281,7 +1281,7 @@ func TestRDSIngressRouteInsideRootNamespaces(t *testing.T) {
 					Domains: []string{"example.com", "example.com:80"},
 					Routes: []route.Route{{
 						Match:  prefixmatch("/"),
-						Action: routecluster("roots/kuard/8080"),
+						Action: routecluster("roots/kuard/8080/da39a3ee5e"),
 					}},
 				}},
 			}),
@@ -1388,7 +1388,7 @@ func TestRDSIngressClass(t *testing.T) {
 		Domains: []string{"*"},
 		Routes: []route.Route{{
 			Match:  prefixmatch("/"),
-			Action: routecluster("default/kuard/8080"),
+			Action: routecluster("default/kuard/8080/da39a3ee5e"),
 		}},
 	}}, nil)
 
@@ -1431,7 +1431,7 @@ func TestRDSIngressClass(t *testing.T) {
 		Domains: []string{"*"},
 		Routes: []route.Route{{
 			Match:  prefixmatch("/"),
-			Action: routecluster("default/kuard/8080"),
+			Action: routecluster("default/kuard/8080/da39a3ee5e"),
 		}},
 	}}, nil)
 
@@ -1564,7 +1564,7 @@ func TestRDSIngressSpecMissingHTTPKey(t *testing.T) {
 		Domains: []string{"test2.test.com", "test2.test.com:80"},
 		Routes: []route.Route{{
 			Match:  prefixmatch("/"), // match all
-			Action: routecluster("default/network-test/9001"),
+			Action: routecluster("default/network-test/9001/da39a3ee5e"),
 		}},
 	}}, nil)
 }
@@ -1611,7 +1611,7 @@ func TestRouteWithAServiceWeight(t *testing.T) {
 		Domains: []string{"test2.test.com", "test2.test.com:80"},
 		Routes: []route.Route{{
 			Match:  prefixmatch("/a"), // match all
-			Action: routeweightedcluster(weightedcluster{"default/kuard/80", 90}),
+			Action: routeweightedcluster(weightedcluster{"default/kuard/80/da39a3ee5e", 90}),
 		}},
 	}}, nil)
 
@@ -1644,8 +1644,8 @@ func TestRouteWithAServiceWeight(t *testing.T) {
 		Routes: []route.Route{{
 			Match: prefixmatch("/a"), // match all
 			Action: routeweightedcluster(
-				weightedcluster{"default/kuard/80", 60},
-				weightedcluster{"default/kuard/80", 90},
+				weightedcluster{"default/kuard/80/da39a3ee5e", 60},
+				weightedcluster{"default/kuard/80/da39a3ee5e", 90},
 			),
 		}},
 	}}, nil)
@@ -1724,7 +1724,7 @@ func TestRouteWithTLS(t *testing.T) {
 					Domains: []string{"test2.test.com", "test2.test.com:443"},
 					Routes: []route.Route{{
 						Match:  prefixmatch("/a"),
-						Action: routecluster("default/kuard/80"),
+						Action: routecluster("default/kuard/80/da39a3ee5e"),
 					}},
 				}}}),
 		},
@@ -1821,7 +1821,7 @@ func TestRouteWithTLS_InsecurePaths(t *testing.T) {
 							Action: redirecthttps(),
 						}, {
 							Match:  prefixmatch("/insecure"),
-							Action: routecluster("default/kuard/80"),
+							Action: routecluster("default/kuard/80/da39a3ee5e"),
 						},
 					},
 				}}}),
@@ -1833,10 +1833,10 @@ func TestRouteWithTLS_InsecurePaths(t *testing.T) {
 					Routes: []route.Route{
 						{
 							Match:  prefixmatch("/secure"),
-							Action: routecluster("default/svc2/80"),
+							Action: routecluster("default/svc2/80/da39a3ee5e"),
 						}, {
 							Match:  prefixmatch("/insecure"),
-							Action: routecluster("default/kuard/80"),
+							Action: routecluster("default/kuard/80/da39a3ee5e"),
 						},
 					},
 				}}}),
@@ -1885,7 +1885,7 @@ func TestRouteRetryAnnotations(t *testing.T) {
 		Domains: []string{"*"},
 		Routes: []route.Route{{
 			Match:  prefixmatch("/"), // match all
-			Action: routeretry("default/backend/80", "50x,gateway-error", 7, 120*time.Millisecond),
+			Action: routeretry("default/backend/80/da39a3ee5e", "50x,gateway-error", 7, 120*time.Millisecond),
 		}},
 	}}, nil)
 }


### PR DESCRIPTION
Updates #581

Update the RDS route visitor for the previous change to CDS
cluster name field.

Rearrange the helpers such that servicename generates the CDS cluster
name for use by EDS; the name of the field is servicename. This frees
clustername for use by the RDS and CDS visitors for generating the
canonical name of the cluster.

Signed-off-by: Dave Cheney <dave@cheney.net>