### PR TITLE
internal/contour: include healthcheck params in cluster name

### DIFF
--- a/internal/contour/cluster.go
+++ b/internal/contour/cluster.go
@@ -181,6 +181,22 @@ func (v *clusterVisitor) edscluster(svc *dag.Service) {
 // clustername returns the name of the CDS cluster for this service.
 func clustername(s *dag.Service) string {
 	buf := s.LoadBalancerStrategy
+	if hc := s.HealthCheck; hc != nil {
+		if hc.TimeoutSeconds > 0 {
+			buf += (time.Duration(hc.TimeoutSeconds) * time.Second).String()
+		}
+		if hc.IntervalSeconds > 0 {
+			buf += (time.Duration(hc.IntervalSeconds) * time.Second).String()
+		}
+		if hc.UnhealthyThresholdCount > 0 {
+			buf += strconv.Itoa(int(hc.UnhealthyThresholdCount))
+		}
+		if hc.HealthyThresholdCount > 0 {
+			buf += strconv.Itoa(int(hc.HealthyThresholdCount))
+		}
+		buf += hc.Path
+	}
+
 	hash := sha1.Sum([]byte(buf))
 	return hashname(60, s.Namespace(), s.Name(), strconv.Itoa(int(s.Port)), fmt.Sprintf("%x", hash[:5]))
 }

--- a/internal/contour/cluster_test.go
+++ b/internal/contour/cluster_test.go
@@ -306,7 +306,7 @@ func TestClusterVisit(t *testing.T) {
 			},
 			want: clustermap(
 				&v2.Cluster{
-					Name: "default/backend/80/da39a3ee5e",
+					Name: "default/backend/80/c184349821",
 					Type: v2.Cluster_EDS,
 					EdsClusterConfig: &v2.Cluster_EdsClusterConfig{
 						EdsConfig:   apiconfigsource("contour"), // hard coded by initconfig
@@ -375,7 +375,7 @@ func TestClusterVisit(t *testing.T) {
 			},
 			want: clustermap(
 				&v2.Cluster{
-					Name: "default/backend/80/da39a3ee5e",
+					Name: "default/backend/80/7f8051653a",
 					Type: v2.Cluster_EDS,
 					EdsClusterConfig: &v2.Cluster_EdsClusterConfig{
 						EdsConfig:   apiconfigsource("contour"), // hard coded by initconfig

--- a/internal/dag/builder_test.go
+++ b/internal/dag/builder_test.go
@@ -3200,10 +3200,11 @@ func TestBuilderLookupService(t *testing.T) {
 
 	tests := map[string]struct {
 		meta
-		port     intstr.IntOrString
-		weight   int
-		strategy string
-		want     *Service
+		port        intstr.IntOrString
+		weight      int
+		strategy    string
+		healthcheck *ingressroutev1.HealthCheck
+		want        *Service
 	}{
 		"lookup service by port number": {
 			meta: meta{name: "service1", namespace: "default"},
@@ -3248,7 +3249,7 @@ func TestBuilderLookupService(t *testing.T) {
 					},
 				},
 			}
-			got := b.lookupService(tc.meta, tc.port, tc.weight, tc.strategy)
+			got := b.lookupService(tc.meta, tc.port, tc.weight, tc.strategy, tc.healthcheck)
 			if diff := cmp.Diff(tc.want, got); diff != "" {
 				t.Fatal(diff)
 			}

--- a/internal/dag/dag.go
+++ b/internal/dag/dag.go
@@ -80,11 +80,10 @@ type Route struct {
 	PerTryTimeout time.Duration
 }
 
-func (r *Route) addService(s *Service, hc *ingressroutev1.HealthCheck) {
+func (r *Route) addService(s *Service) {
 	if r.services == nil {
 		r.services = make(map[servicemeta]*Service)
 	}
-	s.HealthCheck = hc
 	r.services[s.toMeta()] = s
 }
 
@@ -186,20 +185,22 @@ func (s *Service) Namespace() string  { return s.Object.Namespace }
 func (s *Service) Visit(func(Vertex)) {}
 
 type servicemeta struct {
-	name      string
-	namespace string
-	port      int32
-	weight    int
-	strategy  string
+	name        string
+	namespace   string
+	port        int32
+	weight      int
+	strategy    string
+	healthcheck string // %#v of *ingressroutev1.HealthCheck
 }
 
 func (s *Service) toMeta() servicemeta {
 	return servicemeta{
-		name:      s.Object.Name,
-		namespace: s.Object.Namespace,
-		port:      s.Port,
-		weight:    s.Weight,
-		strategy:  s.LoadBalancerStrategy,
+		name:        s.Object.Name,
+		namespace:   s.Object.Namespace,
+		port:        s.Port,
+		weight:      s.Weight,
+		strategy:    s.LoadBalancerStrategy,
+		healthcheck: healthcheckToString(s.HealthCheck),
 	}
 }
 


### PR DESCRIPTION
Fixes #581

Update CDS and RDS's clustername helper to include healthcheck params in
the name of the cluster. This matches the change to the dag where the
healthcheck params are used as part of the servicemeta map key.

Signed-off-by: Dave Cheney <dave@cheney.net>