### PR TITLE
internal/contour: add clustername test

### DIFF
--- a/internal/contour/cluster.go
+++ b/internal/contour/cluster.go
@@ -198,7 +198,9 @@ func clustername(s *dag.Service) string {
 	}
 
 	hash := sha1.Sum([]byte(buf))
-	return hashname(60, s.Namespace(), s.Name(), strconv.Itoa(int(s.Port)), fmt.Sprintf("%x", hash[:5]))
+	ns := s.Namespace()
+	name := s.Name()
+	return hashname(60, ns, name, strconv.Itoa(int(s.Port)), fmt.Sprintf("%x", hash[:5]))
 }
 
 func edslbstrategy(lbStrategy string) v2.Cluster_LbPolicy {

--- a/internal/contour/cluster_test.go
+++ b/internal/contour/cluster_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/gogo/protobuf/types"
 	"github.com/google/go-cmp/cmp"
 	ingressroutev1 "github.com/heptio/contour/apis/contour/v1beta1"
+	"github.com/heptio/contour/internal/dag"
 	"github.com/heptio/contour/internal/metrics"
 	"github.com/prometheus/client_golang/prometheus"
 	"k8s.io/api/core/v1"
@@ -868,6 +869,67 @@ func TestClusterVisit(t *testing.T) {
 				Visitable:    reh.Build(),
 			}
 			got := v.Visit()
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Fatal(diff)
+			}
+		})
+	}
+}
+
+func TestClustername(t *testing.T) {
+	tests := map[string]struct {
+		service *dag.Service
+		want    string
+	}{
+		"simple": {
+			service: &dag.Service{
+				Object: service("default", "backend"),
+				ServicePort: &v1.ServicePort{
+					Name:       "http",
+					Protocol:   "TCP",
+					Port:       80,
+					TargetPort: intstr.FromInt(6502),
+				},
+			},
+			want: "default/backend/80/da39a3ee5e",
+		},
+		"far too long": {
+			service: &dag.Service{
+				Object: service("it-is-a-truth-universally-acknowledged-that-a-single-man-in-possession-of-a-good-fortune", "must-be-in-want-of-a-wife"),
+				ServicePort: &v1.ServicePort{
+					Name:       "http",
+					Protocol:   "TCP",
+					Port:       9999,
+					TargetPort: intstr.FromString("http-alt"),
+				},
+			},
+			want: "it-is-a--dea8b0/must-be--dea8b0/9999/da39a3ee5e",
+		},
+		"various healthcheck params": {
+			service: &dag.Service{
+				Object: service("default", "backend"),
+				ServicePort: &v1.ServicePort{
+					Name:       "http",
+					Protocol:   "TCP",
+					Port:       80,
+					TargetPort: intstr.FromInt(6502),
+				},
+				LoadBalancerStrategy: "Maglev",
+				HealthCheck: &ingressroutev1.HealthCheck{
+					Path:                    "/healthz",
+					IntervalSeconds:         5,
+					TimeoutSeconds:          30,
+					UnhealthyThresholdCount: 3,
+					HealthyThresholdCount:   1,
+				},
+			},
+			want: "default/backend/80/32737eb011",
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := clustername(tc.service)
 			if diff := cmp.Diff(tc.want, got); diff != "" {
 				t.Fatal(diff)
 			}


### PR DESCRIPTION
Updates #684

Add some tests to lock in the behaviour of clustername.

Signed-off-by: Dave Cheney <dave@cheney.net>