### PR TITLE
Update the dns policy to match recommendation

### DIFF
--- a/deployment/ds-hostnet-split/03-envoy.yaml
+++ b/deployment/ds-hostnet-split/03-envoy.yaml
@@ -48,7 +48,7 @@ spec:
         volumeMounts:
           - name: contour-config
             mountPath: /config
-      dnsPolicy: ClusterFirst
+      dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
       initContainers:
       - args:


### PR DESCRIPTION
Fixes #686 by updating the dns policy to match recommendation for pods are running with hostNetork: true

Signed-off-by: Steve Sloka <steve@stevesloka.com>