### PR TITLE
all: update to Envoy 1.7.0

### DIFF
--- a/deployment/common/common.yaml
+++ b/deployment/common/common.yaml
@@ -89,7 +89,7 @@ spec:
                   pattern: ^\/.*$
                 intervalSeconds:
                   type: integer
-                timeoutSeconds: 
+                timeoutSeconds:
                   type: integer
                 unhealthyThresholdCount:
                   type: integer
@@ -126,7 +126,7 @@ spec:
                         name:
                           type: string
                           pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$ # DNS-1123
-                        port: 
+                        port:
                           type: integer
                         weight:
                           type: integer
@@ -148,7 +148,7 @@ spec:
                               pattern: ^\/.*$
                             intervalSeconds:
                               type: integer
-                            timeoutSeconds: 
+                            timeoutSeconds:
                               type: integer
                             unhealthyThresholdCount:
                               type: integer

--- a/deployment/deployment-grpc-v2/02-contour.yaml
+++ b/deployment/deployment-grpc-v2/02-contour.yaml
@@ -26,7 +26,7 @@ spec:
         name: contour
         command: ["contour"]
         args: ["serve", "--incluster"]
-      - image: docker.io/envoyproxy/envoy-alpine:v1.6.0
+      - image: docker.io/envoyproxy/envoy-alpine:v1.7.0
         name: envoy
         ports:
         - containerPort: 8080

--- a/deployment/ds-grpc-v2/02-contour.yaml
+++ b/deployment/ds-grpc-v2/02-contour.yaml
@@ -27,7 +27,7 @@ spec:
         name: contour
         command: ["contour"]
         args: ["serve", "--incluster"]
-      - image: docker.io/envoyproxy/envoy-alpine:v1.6.0
+      - image: docker.io/envoyproxy/envoy-alpine:v1.7.0
         name: envoy
         ports:
         - containerPort: 8080

--- a/deployment/ds-hostnet-split/03-envoy.yaml
+++ b/deployment/ds-hostnet-split/03-envoy.yaml
@@ -33,7 +33,7 @@ spec:
         - node0
         command:
         - envoy
-        image: docker.io/envoyproxy/envoy-alpine:v1.6.0
+        image: docker.io/envoyproxy/envoy-alpine:v1.7.0
         imagePullPolicy: IfNotPresent
         name: envoy
         ports:
@@ -67,7 +67,7 @@ spec:
         volumeMounts:
         - name: contour-config
           mountPath: /config
-      automountServiceAccountToken: false   
+      automountServiceAccountToken: false
       volumes:
         - name: contour-config
           emptyDir: {}

--- a/deployment/ds-hostnet/02-contour.yaml
+++ b/deployment/ds-hostnet/02-contour.yaml
@@ -31,7 +31,7 @@ spec:
         name: contour
         command: ["contour"]
         args: ["serve", "--incluster"]
-      - image: docker.io/envoyproxy/envoy-alpine:v1.6.0
+      - image: docker.io/envoyproxy/envoy-alpine:v1.7.0
         name: envoy
         ports:
         - containerPort: 8080

--- a/deployment/render/daemonset-rbac.yaml
+++ b/deployment/render/daemonset-rbac.yaml
@@ -92,7 +92,7 @@ spec:
                   pattern: ^\/.*$
                 intervalSeconds:
                   type: integer
-                timeoutSeconds: 
+                timeoutSeconds:
                   type: integer
                 unhealthyThresholdCount:
                   type: integer
@@ -129,7 +129,7 @@ spec:
                         name:
                           type: string
                           pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$ # DNS-1123
-                        port: 
+                        port:
                           type: integer
                         weight:
                           type: integer
@@ -151,7 +151,7 @@ spec:
                               pattern: ^\/.*$
                             intervalSeconds:
                               type: integer
-                            timeoutSeconds: 
+                            timeoutSeconds:
                               type: integer
                             unhealthyThresholdCount:
                               type: integer
@@ -187,7 +187,7 @@ spec:
         name: contour
         command: ["contour"]
         args: ["serve", "--incluster"]
-      - image: docker.io/envoyproxy/envoy-alpine:v1.6.0
+      - image: docker.io/envoyproxy/envoy-alpine:v1.7.0
         name: envoy
         ports:
         - containerPort: 8080

--- a/deployment/render/deployment-rbac.yaml
+++ b/deployment/render/deployment-rbac.yaml
@@ -92,7 +92,7 @@ spec:
                   pattern: ^\/.*$
                 intervalSeconds:
                   type: integer
-                timeoutSeconds: 
+                timeoutSeconds:
                   type: integer
                 unhealthyThresholdCount:
                   type: integer
@@ -129,7 +129,7 @@ spec:
                         name:
                           type: string
                           pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$ # DNS-1123
-                        port: 
+                        port:
                           type: integer
                         weight:
                           type: integer
@@ -151,7 +151,7 @@ spec:
                               pattern: ^\/.*$
                             intervalSeconds:
                               type: integer
-                            timeoutSeconds: 
+                            timeoutSeconds:
                               type: integer
                             unhealthyThresholdCount:
                               type: integer
@@ -186,7 +186,7 @@ spec:
         name: contour
         command: ["contour"]
         args: ["serve", "--incluster"]
-      - image: docker.io/envoyproxy/envoy-alpine:v1.6.0
+      - image: docker.io/envoyproxy/envoy-alpine:v1.7.0
         name: envoy
         ports:
         - containerPort: 8080

--- a/internal/contour/cluster.go
+++ b/internal/contour/cluster.go
@@ -285,11 +285,21 @@ func edsconfig(source string, service *dag.Service) *v2.Cluster_EdsClusterConfig
 }
 
 func apiconfigsource(clusters ...string) *core.ConfigSource {
+	services := make([]*core.GrpcService, 0, len(clusters))
+	for _, c := range clusters {
+		services = append(services, &core.GrpcService{
+			TargetSpecifier: &core.GrpcService_EnvoyGrpc_{
+				EnvoyGrpc: &core.GrpcService_EnvoyGrpc{
+					ClusterName: c,
+				},
+			},
+		})
+	}
 	return &core.ConfigSource{
 		ConfigSourceSpecifier: &core.ConfigSource_ApiConfigSource{
 			ApiConfigSource: &core.ApiConfigSource{
 				ApiType:      core.ApiConfigSource_GRPC,
-				ClusterNames: clusters,
+				GrpcServices: services,
 			},
 		},
 	}

--- a/internal/contour/listener.go
+++ b/internal/contour/listener.go
@@ -280,9 +280,6 @@ func httpfilter(routename, accessLogPath string) listener.Filter {
 					"config_source": st(map[string]*types.Value{
 						"api_config_source": st(map[string]*types.Value{
 							"api_type": sv("GRPC"),
-							"cluster_names": lv(
-								sv("contour"),
-							),
 							"grpc_services": lv(
 								st(map[string]*types.Value{
 									"envoy_grpc": st(map[string]*types.Value{

--- a/internal/e2e/cds_test.go
+++ b/internal/e2e/cds_test.go
@@ -777,11 +777,21 @@ func cluster(name, servicename string) *v2.Cluster {
 }
 
 func apiconfigsource(clusters ...string) *core.ConfigSource {
+	services := make([]*core.GrpcService, 0, len(clusters))
+	for _, c := range clusters {
+		services = append(services, &core.GrpcService{
+			TargetSpecifier: &core.GrpcService_EnvoyGrpc_{
+				EnvoyGrpc: &core.GrpcService_EnvoyGrpc{
+					ClusterName: c,
+				},
+			},
+		})
+	}
 	return &core.ConfigSource{
 		ConfigSourceSpecifier: &core.ConfigSource_ApiConfigSource{
 			ApiConfigSource: &core.ApiConfigSource{
 				ApiType:      core.ApiConfigSource_GRPC,
-				ClusterNames: clusters,
+				GrpcServices: services,
 			},
 		},
 	}

--- a/internal/e2e/lds_test.go
+++ b/internal/e2e/lds_test.go
@@ -1042,8 +1042,7 @@ func httpfilter(routename string) listener.Filter {
 					ConfigSource: core.ConfigSource{
 						ConfigSourceSpecifier: &core.ConfigSource_ApiConfigSource{
 							ApiConfigSource: &core.ApiConfigSource{
-								ApiType:      core.ApiConfigSource_GRPC,
-								ClusterNames: []string{"contour"},
+								ApiType: core.ApiConfigSource_GRPC,
 								GrpcServices: []*core.GrpcService{{
 									TargetSpecifier: &core.GrpcService_EnvoyGrpc_{
 										EnvoyGrpc: &core.GrpcService_EnvoyGrpc{

--- a/internal/envoy/config.go
+++ b/internal/envoy/config.go
@@ -74,14 +74,12 @@ const yamlConfig = `dynamic_resources:
   lds_config:
     api_config_source:
       api_type: GRPC
-      cluster_names: [contour]
       grpc_services:
       - envoy_grpc:
           cluster_name: contour
   cds_config:
     api_config_source:
       api_type: GRPC
-      cluster_names: [contour]
       grpc_services:
       - envoy_grpc:
           cluster_name: contour

--- a/internal/envoy/config_test.go
+++ b/internal/envoy/config_test.go
@@ -29,14 +29,12 @@ func TestConfigWriter_WriteYAML(t *testing.T) {
   lds_config:
     api_config_source:
       api_type: GRPC
-      cluster_names: [contour]
       grpc_services:
       - envoy_grpc:
           cluster_name: contour
   cds_config:
     api_config_source:
       api_type: GRPC
-      cluster_names: [contour]
       grpc_services:
       - envoy_grpc:
           cluster_name: contour
@@ -88,14 +86,12 @@ admin:
   lds_config:
     api_config_source:
       api_type: GRPC
-      cluster_names: [contour]
       grpc_services:
       - envoy_grpc:
           cluster_name: contour
   cds_config:
     api_config_source:
       api_type: GRPC
-      cluster_names: [contour]
       grpc_services:
       - envoy_grpc:
           cluster_name: contour


### PR DESCRIPTION
Updates #443

Fix configuration generated by Contour to avoid triggering warnings
under Envoy 1.7.0.

This is _not_ backward compatible with Envoy 1.6.0.

Signed-off-by: Dave Cheney <dave@cheney.net>