### PR TITLE
Gopkg.toml: upgrade to gogo/protobuf 1.1.1

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -93,7 +93,7 @@
   version = "v1.0.0"
 
 [[projects]]
-  digest = "1:0a3f6a0c68ab8f3d455f8892295503b179e571b7fefe47cc6c556405d1f83411"
+  digest = "1:6e73003ecd35f4487a5e88270d3ca0a81bc80dc88053ac7e4dcfec5fba30d918"
   name = "github.com/gogo/protobuf"
   packages = [
     "gogoproto",
@@ -104,8 +104,8 @@
     "types",
   ]
   pruneopts = ""
-  revision = "1adfc126b41513cc696b209667c8656ea7aac67c"
-  version = "v1.0.0"
+  revision = "636bf0302bc95575d69441b25a2603156ffdddf1"
+  version = "v1.1.1"
 
 [[projects]]
   branch = "master"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -40,7 +40,3 @@ ignored = [
 [[constraint]]
   name = "github.com/envoyproxy/go-control-plane"
   version = "=v0.4"
-
-[[constraint]]
-  name = "github.com/gogo/protobuf"
-  version = "=1.0.0"

--- a/internal/contour/annotations_test.go
+++ b/internal/contour/annotations_test.go
@@ -103,9 +103,8 @@ func TestParseAnnotationUInt32(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			got := parseAnnotationUInt32(tc.a, annotationRequestTimeout)
-			full := types.UInt32Value{Value: tc.want}
 
-			if ((got == nil) != tc.isNil) || (got != nil && *got != full) {
+			if ((got == nil) != tc.isNil) || (got != nil && got.Value != tc.want) {
 				t.Fatalf("parseAnnotationUInt32(%q): want: %v, isNil: %v, got: %v", tc.a, tc.want, tc.isNil, got)
 			}
 		})

--- a/internal/dag/annotations_test.go
+++ b/internal/dag/annotations_test.go
@@ -20,7 +20,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/gogo/protobuf/types"
 	"k8s.io/api/extensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -98,9 +97,7 @@ func TestParseAnnotationUInt32(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			got := parseAnnotationUInt32(tc.a, annotationRequestTimeout)
-			full := types.UInt32Value{Value: tc.want}
-
-			if ((got == nil) != tc.isNil) || (got != nil && *got != full) {
+			if ((got == nil) != tc.isNil) || (got != nil && got.Value != tc.want) {
 				t.Fatalf("parseAnnotationUInt32(%q): want: %v, isNil: %v, got: %v", tc.a, tc.want, tc.isNil, got)
 			}
 		})


### PR DESCRIPTION
Updates #653 

This is required for the v0.5 of go-control-plane. The upgrade breaks a
few tests where it wasn't copacetic to compare proto types by value.

Signed-off-by: Dave Cheney <dave@cheney.net>