### PR TITLE
apis: Fix IngressRoute struct missing omitempty

### DIFF
--- a/apis/contour/v1beta1/ingressroute.go
+++ b/apis/contour/v1beta1/ingressroute.go
@@ -21,7 +21,7 @@ import (
 type IngressRouteSpec struct {
 	// Virtualhost appears at most once. If it is present, the object is considered
 	// to be a "root".
-	VirtualHost *VirtualHost `json:"virtualhost"`
+	VirtualHost *VirtualHost `json:"virtualhost,omitempty"`
 	// Routes are the ingress routes
 	Routes []Route `json:"routes"`
 }
@@ -35,7 +35,7 @@ type VirtualHost struct {
 	// If present describes tls properties. The CNI names that will be matched on
 	// are described in fqdn and aliases, the tls.secretName secret must contain a
 	// matching certificate
-	TLS *TLS `json:"tls"`
+	TLS *TLS `json:"tls,omitempty"`
 }
 
 // TLS describes tls properties. The CNI names that will be matched on
@@ -45,7 +45,7 @@ type TLS struct {
 	// required, the name of a secret in the current namespace
 	SecretName string `json:"secretName"`
 	// Minimum TLS version this vhost should negotiate
-	MinimumProtocolVersion string `json:"minimumProtocolVersion"`
+	MinimumProtocolVersion string `json:"minimumProtocolVersion,omitempty"`
 }
 
 // Route contains the set of routes for a virtual host
@@ -53,14 +53,14 @@ type Route struct {
 	// Match defines the prefix match
 	Match string `json:"match"`
 	// Services are the services to proxy traffic
-	Services []Service `json:"services"`
+	Services []Service `json:"services,omitempty"`
 	// Delegate specifies that this route should be delegated to another IngressRoute
-	Delegate `json:"delegate"`
+	Delegate *Delegate `json:"delegate,omitempty"`
 	// Enables websocket support for the route
-	EnableWebsockets bool `json:"enableWebsockets"`
+	EnableWebsockets bool `json:"enableWebsockets,omitempty"`
 	// Allow this path to respond to insecure requests over HTTP which are normally
 	// not permitted when a `virtualhost.tls` block is present.
-	PermitInsecure bool `json:"permitInsecure"`
+	PermitInsecure bool `json:"permitInsecure,omitempty"`
 }
 
 // Service defines an upstream to proxy traffic to
@@ -71,11 +71,11 @@ type Service struct {
 	// Port (defined as Integer) to proxy traffic to since a service can have multiple defined
 	Port int `json:"port"`
 	// Weight defines percentage of traffic to balance traffic
-	Weight int `json:"weight"`
+	Weight int `json:"weight,omitempty"`
 	// HealthCheck defines optional healthchecks on the upstream service
-	HealthCheck *HealthCheck `json:"healthCheck"`
+	HealthCheck *HealthCheck `json:"healthCheck,omitempty"`
 	// LB Algorithm to apply (see https://github.com/heptio/contour/blob/master/design/ingressroute-design.md#load-balancing)
-	Strategy string `json:"strategy"`
+	Strategy string `json:"strategy,omitempty"`
 }
 
 // Delegate allows for delegating VHosts to other IngressRoutes
@@ -83,7 +83,7 @@ type Delegate struct {
 	// Name of the IngressRoute
 	Name string `json:"name"`
 	// Namespace of the IngressRoute
-	Namespace string `json:"namespace"`
+	Namespace string `json:"namespace,omitempty"`
 }
 
 // HealthCheck defines optional healthchecks on the upstream service
@@ -93,7 +93,7 @@ type HealthCheck struct {
 	// The value of the host header in the HTTP health check request.
 	// If left empty (default value), the name "contour-envoy-healthcheck"
 	// will be used.
-	Host string `json:"host"`
+	Host string `json:"host,omitempty"`
 	// The interval (seconds) between health checks
 	IntervalSeconds int64 `json:"intervalSeconds"`
 	// The time to wait (seconds) for a health check response

--- a/internal/contour/cachehandler_test.go
+++ b/internal/contour/cachehandler_test.go
@@ -42,7 +42,7 @@ func TestIngressRouteMetrics(t *testing.T) {
 				}},
 			}, {
 				Match: "/prefix",
-				Delegate: ingressroutev1.Delegate{
+				Delegate: &ingressroutev1.Delegate{
 					Name: "delegated",
 				}},
 			},
@@ -139,7 +139,7 @@ func TestIngressRouteMetrics(t *testing.T) {
 			},
 			Routes: []ingressroutev1.Route{{
 				Match: "/foo",
-				Delegate: ingressroutev1.Delegate{
+				Delegate: &ingressroutev1.Delegate{
 					Name: "self",
 				},
 			}},
@@ -158,7 +158,7 @@ func TestIngressRouteMetrics(t *testing.T) {
 			},
 			Routes: []ingressroutev1.Route{{
 				Match: "/foo",
-				Delegate: ingressroutev1.Delegate{
+				Delegate: &ingressroutev1.Delegate{
 					Name: "child",
 				},
 			}},
@@ -173,7 +173,7 @@ func TestIngressRouteMetrics(t *testing.T) {
 		Spec: ingressroutev1.IngressRouteSpec{
 			Routes: []ingressroutev1.Route{{
 				Match: "/foo",
-				Delegate: ingressroutev1.Delegate{
+				Delegate: &ingressroutev1.Delegate{
 					Name: "parent",
 				},
 			}},
@@ -192,7 +192,7 @@ func TestIngressRouteMetrics(t *testing.T) {
 			},
 			Routes: []ingressroutev1.Route{{
 				Match: "/foo",
-				Delegate: ingressroutev1.Delegate{
+				Delegate: &ingressroutev1.Delegate{
 					Name: "child",
 				},
 				Services: []ingressroutev1.Service{{
@@ -215,12 +215,12 @@ func TestIngressRouteMetrics(t *testing.T) {
 			},
 			Routes: []ingressroutev1.Route{{
 				Match: "/foo",
-				Delegate: ingressroutev1.Delegate{
+				Delegate: &ingressroutev1.Delegate{
 					Name: "validChild",
 				},
 			}, {
 				Match: "/bar",
-				Delegate: ingressroutev1.Delegate{
+				Delegate: &ingressroutev1.Delegate{
 					Name: "invalidChild",
 				},
 			}},
@@ -288,7 +288,7 @@ func TestIngressRouteMetrics(t *testing.T) {
 			VirtualHost: &ingressroutev1.VirtualHost{},
 			Routes: []ingressroutev1.Route{{
 				Match: "/foo",
-				Delegate: ingressroutev1.Delegate{
+				Delegate: &ingressroutev1.Delegate{
 					Name: "validChild",
 				},
 			}},

--- a/internal/dag/builder.go
+++ b/internal/dag/builder.go
@@ -523,7 +523,7 @@ func (b *builder) processIngressRoute(ir *ingressroutev1.IngressRoute, prefixMat
 
 	for _, route := range ir.Spec.Routes {
 		// route cannot both delegate and point to services
-		if len(route.Services) > 0 && route.Delegate.Name != "" {
+		if len(route.Services) > 0 && route.Delegate != nil {
 			b.setStatus(Status{Object: ir, Status: StatusInvalid, Description: fmt.Sprintf("route %q: cannot specify services and delegate in the same route", route.Match), Vhost: host})
 			return
 		}
@@ -563,7 +563,7 @@ func (b *builder) processIngressRoute(ir *ingressroutev1.IngressRoute, prefixMat
 			continue
 		}
 
-		if isBlank(route.Delegate.Name) {
+		if route.Delegate == nil {
 			// not a delegate route
 			continue
 		}

--- a/internal/dag/builder_test.go
+++ b/internal/dag/builder_test.go
@@ -650,7 +650,7 @@ func TestDAGInsert(t *testing.T) {
 			},
 			Routes: []ingressroutev1.Route{{
 				Match: "/blog",
-				Delegate: ingressroutev1.Delegate{
+				Delegate: &ingressroutev1.Delegate{
 					Name:      "blog",
 					Namespace: "marketing",
 				},
@@ -673,7 +673,7 @@ func TestDAGInsert(t *testing.T) {
 				}},
 			}, {
 				Match: "/blog/admin",
-				Delegate: ingressroutev1.Delegate{
+				Delegate: &ingressroutev1.Delegate{
 					Name:      "marketing-admin",
 					Namespace: "operations",
 				},
@@ -2551,7 +2551,7 @@ func TestDAGIngressRouteCycle(t *testing.T) {
 			},
 			Routes: []ingressroutev1.Route{{
 				Match: "/finance",
-				Delegate: ingressroutev1.Delegate{
+				Delegate: &ingressroutev1.Delegate{
 					Name:      "finance-root",
 					Namespace: "finance",
 				},
@@ -2572,7 +2572,7 @@ func TestDAGIngressRouteCycle(t *testing.T) {
 				}},
 			}, {
 				Match: "/finance/stocks",
-				Delegate: ingressroutev1.Delegate{
+				Delegate: &ingressroutev1.Delegate{
 					Name:      "example-com",
 					Namespace: "default",
 				},
@@ -2619,7 +2619,7 @@ func TestDAGIngressRouteCycleSelfEdge(t *testing.T) {
 			},
 			Routes: []ingressroutev1.Route{{
 				Match: "/finance",
-				Delegate: ingressroutev1.Delegate{
+				Delegate: &ingressroutev1.Delegate{
 					Name:      "example-com",
 					Namespace: "default",
 				},
@@ -2660,7 +2660,7 @@ func TestDAGIngressRouteDelegatesToNonExistent(t *testing.T) {
 			},
 			Routes: []ingressroutev1.Route{{
 				Match: "/finance",
-				Delegate: ingressroutev1.Delegate{
+				Delegate: &ingressroutev1.Delegate{
 					Name:      "non-existent",
 					Namespace: "non-existent",
 				},
@@ -2701,7 +2701,7 @@ func TestDAGIngressRouteDelegatePrefixDoesntMatch(t *testing.T) {
 			},
 			Routes: []ingressroutev1.Route{{
 				Match: "/finance",
-				Delegate: ingressroutev1.Delegate{
+				Delegate: &ingressroutev1.Delegate{
 					Name:      "finance-root",
 					Namespace: "finance",
 				},
@@ -2866,7 +2866,7 @@ func TestDAGIngressRouteDelegatePrefixMatchesStringPrefixButNotPathPrefix(t *tes
 			},
 			Routes: []ingressroutev1.Route{{
 				Match: "/foo",
-				Delegate: ingressroutev1.Delegate{
+				Delegate: &ingressroutev1.Delegate{
 					Name:      "finance-root",
 					Namespace: "finance",
 				},
@@ -3022,7 +3022,7 @@ func TestDAGIngressRouteStatus(t *testing.T) {
 				}},
 			}, {
 				Match: "/prefix",
-				Delegate: ingressroutev1.Delegate{
+				Delegate: &ingressroutev1.Delegate{
 					Name: "delegated",
 				}},
 			},
@@ -3119,7 +3119,7 @@ func TestDAGIngressRouteStatus(t *testing.T) {
 			},
 			Routes: []ingressroutev1.Route{{
 				Match: "/foo",
-				Delegate: ingressroutev1.Delegate{
+				Delegate: &ingressroutev1.Delegate{
 					Name: "self",
 				},
 			}},
@@ -3138,7 +3138,7 @@ func TestDAGIngressRouteStatus(t *testing.T) {
 			},
 			Routes: []ingressroutev1.Route{{
 				Match: "/foo",
-				Delegate: ingressroutev1.Delegate{
+				Delegate: &ingressroutev1.Delegate{
 					Name: "child",
 				},
 			}},
@@ -3153,7 +3153,7 @@ func TestDAGIngressRouteStatus(t *testing.T) {
 		Spec: ingressroutev1.IngressRouteSpec{
 			Routes: []ingressroutev1.Route{{
 				Match: "/foo",
-				Delegate: ingressroutev1.Delegate{
+				Delegate: &ingressroutev1.Delegate{
 					Name: "parent",
 				},
 			}},
@@ -3172,7 +3172,7 @@ func TestDAGIngressRouteStatus(t *testing.T) {
 			},
 			Routes: []ingressroutev1.Route{{
 				Match: "/foo",
-				Delegate: ingressroutev1.Delegate{
+				Delegate: &ingressroutev1.Delegate{
 					Name: "child",
 				},
 				Services: []ingressroutev1.Service{{
@@ -3195,12 +3195,12 @@ func TestDAGIngressRouteStatus(t *testing.T) {
 			},
 			Routes: []ingressroutev1.Route{{
 				Match: "/foo",
-				Delegate: ingressroutev1.Delegate{
+				Delegate: &ingressroutev1.Delegate{
 					Name: "validChild",
 				},
 			}, {
 				Match: "/bar",
-				Delegate: ingressroutev1.Delegate{
+				Delegate: &ingressroutev1.Delegate{
 					Name: "invalidChild",
 				},
 			}},
@@ -3268,7 +3268,7 @@ func TestDAGIngressRouteStatus(t *testing.T) {
 			VirtualHost: &ingressroutev1.VirtualHost{},
 			Routes: []ingressroutev1.Route{{
 				Match: "/foo",
-				Delegate: ingressroutev1.Delegate{
+				Delegate: &ingressroutev1.Delegate{
 					Name: "validChild",
 				},
 			}},


### PR DESCRIPTION
This fixes #713 by updating the `IngressRoute` struct to add `omitempty` to json params so that any params not supplied do not throw errors when integrating with golang. 

Other change is the `Delegate` struct is now a pointer so that we can add `omitempty` and make that optional. Tests / builder.go have been updated to reflect change. 