### PR TITLE
Makefile: add errcheck target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,10 @@ misspell:
 		-error \
 		cmd/* internal/* docs/* design/* *.md
 
+errcheck:
+	@go get github.com/kisielk/errcheck
+	errcheck $(PKGS)
+
 render:
 	@echo Rendering deployment files...
 	@(cd deployment && bash render.sh)

--- a/cmd/contour/bootstrap.go
+++ b/cmd/contour/bootstrap.go
@@ -27,15 +27,14 @@ type configWriter interface {
 // writeBootstrapConfig writes a bootstrap configuration to the supplied path.
 // If the path ends in .yaml, the configuration file will be in v2 YAML format.
 func writeBootstrapConfig(config configWriter, path string) {
-	f, err := os.Create(path)
-	check(err)
 	switch filepath.Ext(path) {
 	case ".yaml":
+		f, err := os.Create(path)
+		check(err)
 		err = config.WriteYAML(f)
 		check(err)
+		check(f.Close())
 	default:
-		f.Close()
 		check(fmt.Errorf("path %s must end in .yaml", path))
 	}
-	check(f.Close())
 }

--- a/internal/e2e/e2e.go
+++ b/internal/e2e/e2e.go
@@ -17,7 +17,6 @@ package e2e
 
 import (
 	"net"
-	"sync"
 	"testing"
 
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2"
@@ -98,11 +97,9 @@ func setup(t *testing.T, opts ...func(*contour.ResourceEventHandler)) (cache.Res
 		endpointType: et,
 	})
 
-	var wg sync.WaitGroup
-	wg.Add(1)
+	done := make(chan error, 1)
 	go func() {
-		defer wg.Done()
-		srv.Serve(l)
+		done <- srv.Serve(l) // srv now owns l and will close l before returning
 	}()
 	cc, err := grpc.Dial(l.Addr().String(), grpc.WithInsecure())
 	check(t, err)
@@ -116,10 +113,10 @@ func setup(t *testing.T, opts ...func(*contour.ResourceEventHandler)) (cache.Res
 		// close client connection
 		cc.Close()
 
-		// shut down listener, stop server and wait for it to stop
-		l.Close()
+		// stop server and wait for it to stop
 		srv.Stop()
-		wg.Wait()
+
+		<-done
 	}
 }
 

--- a/internal/k8s/status_test.go
+++ b/internal/k8s/status_test.go
@@ -98,13 +98,13 @@ func TestSetStatus(t *testing.T) {
 			irs := IngressRouteStatus{
 				Client: client,
 			}
-			irs.SetStatus(tc.msg, tc.desc, tc.existing)
+			if err := irs.SetStatus(tc.msg, tc.desc, tc.existing); err != nil {
+				t.Fatal(err)
+			}
 
 			if len(client.Actions()) != len(tc.expectedVerbs) {
 				t.Fatalf("Expected verbs mismatch: want: %d, got: %d", len(tc.expectedVerbs), len(client.Actions()))
 			}
-
-			client.ContourV1beta1().IngressRoutes("default").Get("test", metav1.GetOptions{})
 
 			if tc.expectedPatch != string(gotPatchBytes) {
 				t.Fatalf("expected patch: %s, got: %s", tc.expectedPatch, string(gotPatchBytes))


### PR DESCRIPTION
Add an errcheck target for running kiselk's errcheck tool.

This check is not enabled in make check because it is too noisy; there
are legitimate cases to ignore an error and I'm not going to add helpers
to make errcheck happy, the value gained is too low.

However, for a few of the points that errcheck raises I have addressed
them by refactoring the code; this improved the cleanup handling in
internal/e2e, so win/win I say!

Signed-off-by: Dave Cheney <dave@cheney.net>