### PR TITLE
Makefile: add an unconvert target

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 vendor/
 .vs/
 .idea/
+.DS_Store

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ PROJECT = contour
 REGISTRY ?= gcr.io/heptio-images
 IMAGE := $(REGISTRY)/$(PROJECT)
 SRCDIRS := ./cmd ./internal ./apis
-PKGS := $(shell go list ./cmd/... ./internal/... | grep -v generated)
+PKGS := $(shell go list ./cmd/... ./internal/...)
 
 GIT_REF = $(shell git rev-parse --short=8 --verify HEAD)
 VERSION ?= $(GIT_REF)
@@ -16,7 +16,7 @@ test-race: | test
 vet: | test
 	go vet ./...
 
-check: test test-race vet gofmt staticcheck unused misspell
+check: test test-race vet gofmt staticcheck unused misspell unconvert
 	@echo Checking rendered files are up to date
 	@(cd deployment && bash render.sh && git diff --exit-code . || (echo "rendered files are out of date" && exit 1))
 
@@ -56,6 +56,10 @@ misspell:
 errcheck:
 	@go get github.com/kisielk/errcheck
 	errcheck $(PKGS)
+
+unconvert:
+	@go get github.com/mdempsky/unconvert
+	unconvert -v $(PKGS)
 
 render:
 	@echo Rendering deployment files...

--- a/internal/contour/route_test.go
+++ b/internal/contour/route_test.go
@@ -32,10 +32,7 @@ import (
 )
 
 func TestRouteVisit(t *testing.T) {
-	var (
-		infinity     = time.Duration(0)
-		nintyseconds = time.Duration(90 * time.Second)
-	)
+	var infinity = pduration(0)
 
 	tests := map[string]struct {
 		*RouteCache
@@ -613,7 +610,7 @@ func TestRouteVisit(t *testing.T) {
 						Domains: []string{"*"},
 						Routes: []route.Route{{
 							Match:  prefixmatch("/"),
-							Action: routetimeout("default/kuard/8080/da39a3ee5e", &infinity),
+							Action: routetimeout("default/kuard/8080/da39a3ee5e", infinity),
 						}},
 					}},
 				},
@@ -661,7 +658,7 @@ func TestRouteVisit(t *testing.T) {
 						Domains: []string{"*"},
 						Routes: []route.Route{{
 							Match:  prefixmatch("/"),
-							Action: routetimeout("default/kuard/8080/da39a3ee5e", &infinity),
+							Action: routetimeout("default/kuard/8080/da39a3ee5e", infinity),
 						}},
 					}},
 				},
@@ -709,7 +706,7 @@ func TestRouteVisit(t *testing.T) {
 						Domains: []string{"*"},
 						Routes: []route.Route{{
 							Match:  prefixmatch("/"),
-							Action: routetimeout("default/kuard/8080/da39a3ee5e", &nintyseconds),
+							Action: routetimeout("default/kuard/8080/da39a3ee5e", pduration(90*time.Second)),
 						}},
 					}},
 				},


### PR DESCRIPTION
Add unconvert to make check. Unconvert spots places in the code where
explicit conversions are unnecessary.

Signed-off-by: Dave Cheney <dave@cheney.net>