### PR TITLE
Makefile: add a gosimple target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ test-race: | test
 vet: | test
 	go vet ./...
 
-check: test test-race vet gofmt staticcheck unused misspell unconvert
+check: test test-race vet gofmt staticcheck unused misspell unconvert gosimple
 	@echo Checking rendered files are up to date
 	@(cd deployment && bash render.sh && git diff --exit-code . || (echo "rendered files are out of date" && exit 1))
 
@@ -60,6 +60,14 @@ errcheck:
 unconvert:
 	@go get github.com/mdempsky/unconvert
 	unconvert -v $(PKGS)
+
+gosimple:
+	@go get honnef.co/go/tools/cmd/gosimple
+	gosimple $(PKGS)
+
+unparam:
+	@go get mvdan.cc/unparam
+	unparam ./...
 
 render:
 	@echo Rendering deployment files...

--- a/internal/dag/builder.go
+++ b/internal/dag/builder.go
@@ -602,13 +602,7 @@ func (b *builder) processIngressRoute(ir *ingressroutev1.IngressRoute, prefixMat
 
 // routeEnforceTLS determines if the route should redirect the user to a secure TLS listener
 func routeEnforceTLS(enforceTLS, permitInsecure bool) bool {
-	if enforceTLS {
-		if permitInsecure {
-			return false
-		}
-		return true
-	}
-	return false
+	return enforceTLS && !permitInsecure
 }
 
 // httppaths returns a slice of HTTPIngressPath values for a given IngressRule.


### PR DESCRIPTION
Add gosimple target to make check. This helps spot overcomplicated logic
expressions.

This PR also adds a make unparam check, but it is disabled at the
moment.

Signed-off-by: Dave Cheney <dave@cheney.net>