### PR TITLE
internal/contour: add envoy.listener.tls_inspector filter

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -45,7 +45,7 @@
   version = "v1.1.1"
 
 [[projects]]
-  digest = "1:7da71496e1c143cb5b690621a19e0b33558a28a46a4341070768d70803dfcee6"
+  digest = "1:64b562211e676aa8179dd0b221ffc357b6248335469609e6f2ab690faa8ed6e4"
   name = "github.com/envoyproxy/go-control-plane"
   packages = [
     "envoy/api/v2",
@@ -62,8 +62,8 @@
     "envoy/type",
   ]
   pruneopts = ""
-  revision = "c14704578b82128fab17743d91f870c406ef8d09"
-  version = "v0.4"
+  revision = "1f13d29c5def25a02b9149909472c6a9e6839551"
+  version = "v0.6.0"
 
 [[projects]]
   digest = "1:4216202f4088a73e2982df875e2f0d1401137bbc248e57391e70547af167a18a"
@@ -736,7 +736,6 @@
     "github.com/gogo/protobuf/jsonpb",
     "github.com/gogo/protobuf/proto",
     "github.com/gogo/protobuf/types",
-    "github.com/golang/glog",
     "github.com/google/go-cmp/cmp",
     "github.com/heptio/workgroup",
     "github.com/prometheus/client_golang/prometheus",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -29,7 +29,3 @@ required = [
 [[constraint]]
   name = "github.com/prometheus/client_golang"
   version = "^0.9.0-pre1"
-
-[[constraint]]
-  name = "github.com/envoyproxy/go-control-plane"
-  version = "=v0.4"

--- a/internal/contour/listener.go
+++ b/internal/contour/listener.go
@@ -219,7 +219,7 @@ func (v *listenerVisitor) Visit() map[string]*v2.Listener {
 			}
 			fc := listener.FilterChain{
 				FilterChainMatch: &listener.FilterChainMatch{
-					SniDomains: []string{vh.Host},
+					ServerNames: []string{vh.Host},
 				},
 				TlsContext: tlscontext(data, vh.MinProtoVersion, "h2", "http/1.1"),
 				Filters:    filters,

--- a/internal/contour/listener.go
+++ b/internal/contour/listener.go
@@ -23,6 +23,7 @@ import (
 	"github.com/gogo/protobuf/proto"
 	"github.com/gogo/protobuf/types"
 	"github.com/heptio/contour/internal/dag"
+	"github.com/heptio/contour/internal/envoy"
 	"k8s.io/api/core/v1"
 )
 
@@ -200,6 +201,9 @@ func (v *listenerVisitor) Visit() map[string]*v2.Listener {
 	ingress_https := v2.Listener{
 		Name:    ENVOY_HTTPS_LISTENER,
 		Address: socketaddress(v.httpsAddress(), v.httpsPort()),
+		ListenerFilters: []listener.ListenerFilter{
+			envoy.TLSInspector(),
+		},
 	}
 	filters := []listener.Filter{
 		httpfilter(ENVOY_HTTPS_LISTENER, v.httpsAccessLog()),

--- a/internal/contour/listener_test.go
+++ b/internal/contour/listener_test.go
@@ -138,7 +138,7 @@ func TestListenerVisit(t *testing.T) {
 					Address: socketaddress("0.0.0.0", 8443),
 					FilterChains: []listener.FilterChain{{
 						FilterChainMatch: &listener.FilterChainMatch{
-							SniDomains: []string{"whatever.example.com"},
+							ServerNames: []string{"whatever.example.com"},
 						},
 						TlsContext: tlscontext(secretdata("certificate", "key"), auth.TlsParameters_TLSv1_1, "h2", "http/1.1"),
 						Filters: []listener.Filter{
@@ -231,7 +231,7 @@ func TestListenerVisit(t *testing.T) {
 					Address: socketaddress("0.0.0.0", 8443),
 					FilterChains: []listener.FilterChain{{
 						FilterChainMatch: &listener.FilterChainMatch{
-							SniDomains: []string{"www.example.com"},
+							ServerNames: []string{"www.example.com"},
 						},
 						TlsContext: tlscontext(secretdata("certificate", "key"), auth.TlsParameters_TLSv1_1, "h2", "http/1.1"),
 						Filters: []listener.Filter{
@@ -296,7 +296,7 @@ func TestListenerVisit(t *testing.T) {
 					Address: socketaddress("0.0.0.0", 8443),
 					FilterChains: []listener.FilterChain{{
 						FilterChainMatch: &listener.FilterChainMatch{
-							SniDomains: []string{"www.example.com"},
+							ServerNames: []string{"www.example.com"},
 						},
 						TlsContext: tlscontext(secretdata("certificate", "key"), auth.TlsParameters_TLSv1_1, "h2", "http/1.1"),
 						Filters: []listener.Filter{
@@ -351,7 +351,7 @@ func TestListenerVisit(t *testing.T) {
 					Address: socketaddress("127.0.0.200", 9200),
 					FilterChains: []listener.FilterChain{{
 						FilterChainMatch: &listener.FilterChainMatch{
-							SniDomains: []string{"whatever.example.com"},
+							ServerNames: []string{"whatever.example.com"},
 						},
 						TlsContext: tlscontext(secretdata("certificate", "key"), auth.TlsParameters_TLSv1_1, "h2", "http/1.1"),
 						Filters: []listener.Filter{
@@ -403,7 +403,7 @@ func TestListenerVisit(t *testing.T) {
 					Address: socketaddress("0.0.0.0", 8443),
 					FilterChains: []listener.FilterChain{{
 						FilterChainMatch: &listener.FilterChainMatch{
-							SniDomains: []string{"whatever.example.com"},
+							ServerNames: []string{"whatever.example.com"},
 						},
 						TlsContext: tlscontext(secretdata("certificate", "key"), auth.TlsParameters_TLSv1_1, "h2", "http/1.1"),
 						Filters: []listener.Filter{

--- a/internal/contour/listener_test.go
+++ b/internal/contour/listener_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2/listener"
 	"github.com/gogo/protobuf/types"
 	ingressroutev1 "github.com/heptio/contour/apis/contour/v1beta1"
+	"github.com/heptio/contour/internal/envoy"
 	"github.com/heptio/contour/internal/metrics"
 	"github.com/prometheus/client_golang/prometheus"
 	"k8s.io/api/core/v1"
@@ -145,6 +146,9 @@ func TestListenerVisit(t *testing.T) {
 							httpfilter(ENVOY_HTTPS_LISTENER, DEFAULT_HTTPS_ACCESS_LOG),
 						},
 					}},
+					ListenerFilters: []listener.ListenerFilter{
+						envoy.TLSInspector(),
+					},
 				},
 			},
 		},
@@ -238,6 +242,9 @@ func TestListenerVisit(t *testing.T) {
 							httpfilter(ENVOY_HTTPS_LISTENER, DEFAULT_HTTPS_ACCESS_LOG),
 						},
 					}},
+					ListenerFilters: []listener.ListenerFilter{
+						envoy.TLSInspector(),
+					},
 				},
 			},
 		},
@@ -303,6 +310,9 @@ func TestListenerVisit(t *testing.T) {
 							httpfilter(ENVOY_HTTPS_LISTENER, DEFAULT_HTTPS_ACCESS_LOG),
 						},
 					}},
+					ListenerFilters: []listener.ListenerFilter{
+						envoy.TLSInspector(),
+					},
 				},
 			},
 		},
@@ -358,6 +368,9 @@ func TestListenerVisit(t *testing.T) {
 							httpfilter(ENVOY_HTTPS_LISTENER, DEFAULT_HTTPS_ACCESS_LOG),
 						},
 					}},
+					ListenerFilters: []listener.ListenerFilter{
+						envoy.TLSInspector(),
+					},
 				},
 			},
 		},
@@ -411,6 +424,9 @@ func TestListenerVisit(t *testing.T) {
 						},
 						UseProxyProto: &types.BoolValue{Value: true},
 					}},
+					ListenerFilters: []listener.ListenerFilter{
+						envoy.TLSInspector(),
+					},
 				},
 			},
 		},

--- a/internal/e2e/lds_test.go
+++ b/internal/e2e/lds_test.go
@@ -1007,7 +1007,7 @@ func filterchain(useproxy bool, filters ...listener.Filter) listener.FilterChain
 func filterchaintls(domains []string, cert, key string, useproxy bool, filters ...listener.Filter) listener.FilterChain {
 	fc := filterchain(useproxy, filters...)
 	fc.FilterChainMatch = &listener.FilterChainMatch{
-		SniDomains: domains,
+		ServerNames: domains,
 	}
 	fc.TlsContext = &auth.DownstreamTlsContext{
 		CommonTlsContext: &auth.CommonTlsContext{

--- a/internal/e2e/lds_test.go
+++ b/internal/e2e/lds_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/gogo/protobuf/types"
 	"github.com/heptio/contour/apis/generated/clientset/versioned/fake"
 	"github.com/heptio/contour/internal/contour"
+	"github.com/heptio/contour/internal/envoy"
 	"github.com/heptio/contour/internal/k8s"
 	"google.golang.org/grpc"
 	"k8s.io/api/core/v1"
@@ -197,6 +198,9 @@ func TestTLSListener(t *testing.T) {
 				FilterChains: []listener.FilterChain{
 					filterchaintls([]string{"kuard.example.com"}, "certificate", "key", false, httpfilter("ingress_https")),
 				},
+				ListenerFilters: []listener.ListenerFilter{
+					envoy.TLSInspector(),
+				},
 			}),
 		},
 		TypeUrl: listenerType,
@@ -231,6 +235,9 @@ func TestTLSListener(t *testing.T) {
 				Address: socketaddress("0.0.0.0", 8443),
 				FilterChains: []listener.FilterChain{
 					filterchaintls([]string{"kuard.example.com"}, "certificate", "key", false, httpfilter("ingress_https")),
+				},
+				ListenerFilters: []listener.ListenerFilter{
+					envoy.TLSInspector(),
 				},
 			}),
 		},
@@ -329,6 +336,9 @@ func TestIngressRouteTLSListener(t *testing.T) {
 		FilterChains: []listener.FilterChain{
 			filterchaintls([]string{"kuard.example.com"}, "certificate", "key", false, httpfilter("ingress_https")),
 		},
+		ListenerFilters: []listener.ListenerFilter{
+			envoy.TLSInspector(),
+		},
 	}
 
 	l1.FilterChains[0].TlsContext.CommonTlsContext.TlsParams.TlsMinimumProtocolVersion = auth.TlsParameters_TLSv1_1
@@ -377,6 +387,10 @@ func TestIngressRouteTLSListener(t *testing.T) {
 		FilterChains: []listener.FilterChain{
 			filterchaintls([]string{"kuard.example.com"}, "certificate", "key", false, httpfilter("ingress_https")),
 		},
+		ListenerFilters: []listener.ListenerFilter{{
+			Name:   "envoy.listener.tls_inspector",
+			Config: new(types.Struct),
+		}},
 	}
 
 	l2.FilterChains[0].TlsContext.CommonTlsContext.TlsParams.TlsMinimumProtocolVersion = auth.TlsParameters_TLSv1_3
@@ -444,6 +458,9 @@ func TestLDSFilter(t *testing.T) {
 				Address: socketaddress("0.0.0.0", 8443),
 				FilterChains: []listener.FilterChain{
 					filterchaintls([]string{"kuard.example.com"}, "certificate", "key", false, httpfilter("ingress_https")),
+				},
+				ListenerFilters: []listener.ListenerFilter{
+					envoy.TLSInspector(),
 				},
 			}),
 		},
@@ -531,6 +548,9 @@ func TestLDSTLSMinimumProtocolVersion(t *testing.T) {
 				FilterChains: []listener.FilterChain{
 					filterchaintls([]string{"kuard.example.com"}, "certificate", "key", false, httpfilter("ingress_https")),
 				},
+				ListenerFilters: []listener.ListenerFilter{
+					envoy.TLSInspector(),
+				},
 			}),
 		},
 		TypeUrl: listenerType,
@@ -563,6 +583,10 @@ func TestLDSTLSMinimumProtocolVersion(t *testing.T) {
 		FilterChains: []listener.FilterChain{
 			filterchaintls([]string{"kuard.example.com"}, "certificate", "key", false, httpfilter("ingress_https")),
 		},
+		ListenerFilters: []listener.ListenerFilter{{
+			Name:   "envoy.listener.tls_inspector",
+			Config: new(types.Struct),
+		}},
 	}
 	// easier to patch this up than add more params to filterchaintls
 	l1.FilterChains[0].TlsContext.CommonTlsContext.TlsParams.TlsMinimumProtocolVersion = auth.TlsParameters_TLSv1_3
@@ -676,6 +700,9 @@ func TestLDSIngressHTTPSUseProxyProtocol(t *testing.T) {
 		FilterChains: []listener.FilterChain{
 			filterchaintls([]string{"kuard.example.com"}, "certificate", "key", false, httpfilter("ingress_https")),
 		},
+		ListenerFilters: []listener.ListenerFilter{
+			envoy.TLSInspector(),
+		},
 	}
 	ingress_https.FilterChains[0].UseProxyProto = &types.BoolValue{Value: true}
 	assertEqual(t, &v2.DiscoveryResponse{
@@ -758,6 +785,9 @@ func TestLDSCustomAddressAndPort(t *testing.T) {
 		Address: socketaddress("127.0.0.200", 9200),
 		FilterChains: []listener.FilterChain{
 			filterchaintls([]string{"kuard.example.com"}, "certificate", "key", false, httpfilter("ingress_https")),
+		},
+		ListenerFilters: []listener.ListenerFilter{
+			envoy.TLSInspector(),
 		},
 	}
 	assertEqual(t, &v2.DiscoveryResponse{
@@ -944,6 +974,9 @@ func TestIngressRouteHTTPS(t *testing.T) {
 		Address: socketaddress("0.0.0.0", 8443),
 		FilterChains: []listener.FilterChain{
 			filterchaintls([]string{"example.com"}, "certificate", "key", false, httpfilter("ingress_https")),
+		},
+		ListenerFilters: []listener.ListenerFilter{
+			envoy.TLSInspector(),
 		},
 	}
 	assertEqual(t, &v2.DiscoveryResponse{

--- a/internal/envoy/listener.go
+++ b/internal/envoy/listener.go
@@ -1,0 +1,30 @@
+// Copyright © 2018 Heptio
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package envoy contains a configuration writer for v2 YAML config.
+// To avoid a dependncy on a YAML library, we generate the YAML using
+// the text/template package.
+package envoy
+
+import (
+	"github.com/envoyproxy/go-control-plane/envoy/api/v2/listener"
+	"github.com/gogo/protobuf/types"
+)
+
+// TLSInspector returns a new TLS inspector listener filter.
+func TLSInspector() listener.ListenerFilter {
+	return listener.ListenerFilter{
+		Name:   "envoy.listener.tls_inspector",
+		Config: new(types.Struct),
+	}
+}


### PR DESCRIPTION
Fixes #706

Always inject envoy.listener.tls_inspector listener filter into TLS
enabled listeners.

Signed-off-by: Dave Cheney <dave@cheney.net>