### PR TITLE
internal/contour: use routeaction_cluster for single backend routes

### DIFF
--- a/internal/contour/route_test.go
+++ b/internal/contour/route_test.go
@@ -86,7 +86,7 @@ func TestRouteVisit(t *testing.T) {
 						Domains: []string{"*"},
 						Routes: []route.Route{{
 							Match:  prefixmatch("/"),
-							Action: routeroute("default/kuard/8080/da39a3ee5e"),
+							Action: routecluster("default/kuard/8080/da39a3ee5e"),
 						}},
 					}},
 				},
@@ -139,7 +139,7 @@ func TestRouteVisit(t *testing.T) {
 						Domains: []string{"www.example.com", "www.example.com:80"},
 						Routes: []route.Route{{
 							Match:  prefixmatch("/"),
-							Action: routeroute("default/backend/80/da39a3ee5e"),
+							Action: routecluster("default/backend/80/da39a3ee5e"),
 						}},
 					}},
 				},
@@ -195,7 +195,7 @@ func TestRouteVisit(t *testing.T) {
 						Domains: []string{"*"},
 						Routes: []route.Route{{
 							Match:  prefixmatch("/"),
-							Action: routeroute("default/kuard/8080/da39a3ee5e"),
+							Action: routecluster("default/kuard/8080/da39a3ee5e"),
 						}},
 					}},
 				},
@@ -261,7 +261,7 @@ func TestRouteVisit(t *testing.T) {
 						Domains: []string{"www.example.com", "www.example.com:80"},
 						Routes: []route.Route{{
 							Match:  prefixmatch("/"),
-							Action: routeroute("default/kuard/8080/da39a3ee5e"),
+							Action: routecluster("default/kuard/8080/da39a3ee5e"),
 						}},
 					}},
 				},
@@ -272,7 +272,7 @@ func TestRouteVisit(t *testing.T) {
 						Domains: []string{"www.example.com", "www.example.com:443"},
 						Routes: []route.Route{{
 							Match:  prefixmatch("/"),
-							Action: routeroute("default/kuard/8080/da39a3ee5e"),
+							Action: routecluster("default/kuard/8080/da39a3ee5e"),
 						}},
 					}},
 				},
@@ -347,7 +347,7 @@ func TestRouteVisit(t *testing.T) {
 						Domains: []string{"www.example.com", "www.example.com:443"},
 						Routes: []route.Route{{
 							Match:  prefixmatch("/"),
-							Action: routeroute("default/backend/8080/da39a3ee5e"),
+							Action: routecluster("default/backend/8080/da39a3ee5e"),
 						}},
 					}},
 				},
@@ -416,7 +416,7 @@ func TestRouteVisit(t *testing.T) {
 						Domains: []string{"www.example.com", "www.example.com:443"},
 						Routes: []route.Route{{
 							Match:  prefixmatch("/"),
-							Action: routeroute("default/kuard/8080/da39a3ee5e"),
+							Action: routecluster("default/kuard/8080/da39a3ee5e"),
 						}},
 					}},
 				},
@@ -497,7 +497,7 @@ func TestRouteVisit(t *testing.T) {
 						Domains: []string{"www.example.com", "www.example.com:443"},
 						Routes: []route.Route{{
 							Match:  prefixmatch("/"),
-							Action: routeroute("default/kuard/8080/da39a3ee5e"),
+							Action: routecluster("default/kuard/8080/da39a3ee5e"),
 						}},
 					}},
 				},
@@ -562,7 +562,7 @@ func TestRouteVisit(t *testing.T) {
 							Action: websocketroute("default/kuard/8080/da39a3ee5e"),
 						}, {
 							Match:  prefixmatch("/"),
-							Action: routeroute("default/kuard/8080/da39a3ee5e"),
+							Action: routecluster("default/kuard/8080/da39a3ee5e"),
 						}},
 					}},
 				},
@@ -762,7 +762,7 @@ func TestRouteVisit(t *testing.T) {
 						Domains: []string{"my-very-very-long-service-host-name.subdomain.boring-dept.my.company", "my-very-very-long-service-host-name.subdomain.boring-dept.my.company:80"},
 						Routes: []route.Route{{
 							Match:  prefixmatch("/"),
-							Action: routeroute("default/kuard/80/da39a3ee5e"),
+							Action: routecluster("default/kuard/80/da39a3ee5e"),
 						}},
 					}},
 				},
@@ -850,7 +850,7 @@ func TestRouteVisit(t *testing.T) {
 						Domains: []string{"*"},
 						Routes: []route.Route{{
 							Match:  prefixmatch("/"),
-							Action: routeroute("default/kuard/8080/da39a3ee5e"),
+							Action: routecluster("default/kuard/8080/da39a3ee5e"),
 						}},
 					}},
 				},
@@ -1334,36 +1334,31 @@ func TestRouteVisit(t *testing.T) {
 	}
 }
 
-func routeroute(cluster string) *route.Route_Route {
+func routecluster(cluster string) *route.Route_Route {
 	return &route.Route_Route{
 		Route: &route.RouteAction{
-			ClusterSpecifier: &route.RouteAction_WeightedClusters{
-				WeightedClusters: &route.WeightedCluster{
-					Clusters: []*route.WeightedCluster_ClusterWeight{{
-						Name:   cluster,
-						Weight: u32(1),
-					}},
-					TotalWeight: u32(1),
-				},
+			ClusterSpecifier: &route.RouteAction_Cluster{
+				Cluster: cluster,
 			},
 		},
 	}
+
 }
 
 func websocketroute(c string) *route.Route_Route {
-	r := routeroute(c)
+	r := routecluster(c)
 	r.Route.UseWebsocket = &types.BoolValue{Value: true}
 	return r
 }
 
 func routetimeout(cluster string, timeout *time.Duration) *route.Route_Route {
-	r := routeroute(cluster)
+	r := routecluster(cluster)
 	r.Route.Timeout = timeout
 	return r
 }
 
-func routeretry(cluster string, retryOn string, numRetries uint32, perTryTimeout time.Duration) *route.Route_Route {
-	r := routeroute(cluster)
+func routeretry(cluster string, retryOn string, numRetries int, perTryTimeout time.Duration) *route.Route_Route {
+	r := routecluster(cluster)
 	r.Route.RetryPolicy = &route.RouteAction_RetryPolicy{
 		RetryOn: retryOn,
 	}
@@ -1398,14 +1393,8 @@ func TestActionRoute(t *testing.T) {
 			},
 			want: &route.Route_Route{
 				Route: &route.RouteAction{
-					ClusterSpecifier: &route.RouteAction_WeightedClusters{
-						WeightedClusters: &route.WeightedCluster{
-							Clusters: []*route.WeightedCluster_ClusterWeight{{
-								Name:   "default/kuard/8080/da39a3ee5e",
-								Weight: u32(1),
-							}},
-							TotalWeight: u32(1),
-						},
+					ClusterSpecifier: &route.RouteAction_Cluster{
+						Cluster: "default/kuard/8080/da39a3ee5e",
 					},
 				},
 			},
@@ -1429,14 +1418,8 @@ func TestActionRoute(t *testing.T) {
 			},
 			want: &route.Route_Route{
 				Route: &route.RouteAction{
-					ClusterSpecifier: &route.RouteAction_WeightedClusters{
-						WeightedClusters: &route.WeightedCluster{
-							Clusters: []*route.WeightedCluster_ClusterWeight{{
-								Name:   "default/kuard/8080/da39a3ee5e",
-								Weight: u32(1),
-							}},
-							TotalWeight: u32(1),
-						},
+					ClusterSpecifier: &route.RouteAction_Cluster{
+						Cluster: "default/kuard/8080/da39a3ee5e",
 					},
 					Timeout: pduration(30 * time.Second),
 				},
@@ -1461,14 +1444,8 @@ func TestActionRoute(t *testing.T) {
 			},
 			want: &route.Route_Route{
 				Route: &route.RouteAction{
-					ClusterSpecifier: &route.RouteAction_WeightedClusters{
-						WeightedClusters: &route.WeightedCluster{
-							Clusters: []*route.WeightedCluster_ClusterWeight{{
-								Name:   "default/kuard/8080/da39a3ee5e",
-								Weight: u32(1),
-							}},
-							TotalWeight: u32(1),
-						},
+					ClusterSpecifier: &route.RouteAction_Cluster{
+						Cluster: "default/kuard/8080/da39a3ee5e",
 					},
 					Timeout: pduration(0),
 				},
@@ -1493,14 +1470,8 @@ func TestActionRoute(t *testing.T) {
 			},
 			want: &route.Route_Route{
 				Route: &route.RouteAction{
-					ClusterSpecifier: &route.RouteAction_WeightedClusters{
-						WeightedClusters: &route.WeightedCluster{
-							Clusters: []*route.WeightedCluster_ClusterWeight{{
-								Name:   "default/kuard/8080/da39a3ee5e",
-								Weight: u32(1),
-							}},
-							TotalWeight: u32(1),
-						},
+					ClusterSpecifier: &route.RouteAction_Cluster{
+						Cluster: "default/kuard/8080/da39a3ee5e",
 					},
 					UseWebsocket: &types.BoolValue{Value: true},
 				},
@@ -1526,14 +1497,8 @@ func TestActionRoute(t *testing.T) {
 			},
 			want: &route.Route_Route{
 				Route: &route.RouteAction{
-					ClusterSpecifier: &route.RouteAction_WeightedClusters{
-						WeightedClusters: &route.WeightedCluster{
-							Clusters: []*route.WeightedCluster_ClusterWeight{{
-								Name:   "default/kuard/8080/da39a3ee5e",
-								Weight: u32(1),
-							}},
-							TotalWeight: u32(1),
-						},
+					ClusterSpecifier: &route.RouteAction_Cluster{
+						Cluster: "default/kuard/8080/da39a3ee5e",
 					},
 					Timeout:      pduration(5 * time.Second),
 					UseWebsocket: &types.BoolValue{Value: true},
@@ -1560,14 +1525,8 @@ func TestActionRoute(t *testing.T) {
 			},
 			want: &route.Route_Route{
 				Route: &route.RouteAction{
-					ClusterSpecifier: &route.RouteAction_WeightedClusters{
-						WeightedClusters: &route.WeightedCluster{
-							Clusters: []*route.WeightedCluster_ClusterWeight{{
-								Name:   "default/kuard/8080/da39a3ee5e",
-								Weight: u32(1),
-							}},
-							TotalWeight: u32(1),
-						},
+					ClusterSpecifier: &route.RouteAction_Cluster{
+						Cluster: "default/kuard/8080/da39a3ee5e",
 					},
 				},
 			},
@@ -1593,14 +1552,8 @@ func TestActionRoute(t *testing.T) {
 			},
 			want: &route.Route_Route{
 				Route: &route.RouteAction{
-					ClusterSpecifier: &route.RouteAction_WeightedClusters{
-						WeightedClusters: &route.WeightedCluster{
-							Clusters: []*route.WeightedCluster_ClusterWeight{{
-								Name:   "default/kuard/8080/da39a3ee5e",
-								Weight: u32(1),
-							}},
-							TotalWeight: u32(1),
-						},
+					ClusterSpecifier: &route.RouteAction_Cluster{
+						Cluster: "default/kuard/8080/da39a3ee5e",
 					},
 					RetryPolicy: &route.RouteAction_RetryPolicy{
 						RetryOn:       "50x",
@@ -1769,4 +1722,4 @@ func pduration(d time.Duration) *time.Duration {
 	return &d
 }
 
-func u32(val uint32) *types.UInt32Value { return &types.UInt32Value{Value: val} }
+func u32(val int) *types.UInt32Value { return &types.UInt32Value{Value: uint32(val)} }

--- a/internal/e2e/rds_test.go
+++ b/internal/e2e/rds_test.go
@@ -1599,7 +1599,7 @@ func TestRouteWithAServiceWeight(t *testing.T) {
 				Services: []ingressroutev1.Service{{
 					Name:   "kuard",
 					Port:   80,
-					Weight: 90,
+					Weight: 90, // ignored
 				}},
 			}},
 		},
@@ -1611,7 +1611,7 @@ func TestRouteWithAServiceWeight(t *testing.T) {
 		Domains: []string{"test2.test.com", "test2.test.com:80"},
 		Routes: []route.Route{{
 			Match:  prefixmatch("/a"), // match all
-			Action: routeweightedcluster(weightedcluster{"default/kuard/80/da39a3ee5e", 90}),
+			Action: routecluster("default/kuard/80/da39a3ee5e"),
 		}},
 	}}, nil)
 
@@ -1939,7 +1939,13 @@ type weightedcluster struct {
 }
 
 func routecluster(cluster string) *route.Route_Route {
-	return routeweightedcluster(weightedcluster{cluster, 1})
+	return &route.Route_Route{
+		Route: &route.RouteAction{
+			ClusterSpecifier: &route.RouteAction_Cluster{
+				Cluster: cluster,
+			},
+		},
+	}
 }
 
 func routeweightedcluster(first weightedcluster, rest ...weightedcluster) *route.Route_Route {


### PR DESCRIPTION
Fixes #726

Envoy 1.7.0 does not support websocket connections on a
routeaction_weightedcluster backend. This PR changes the route visitor
to generate routeaction_cluster configuration for routes with singleton
backend services.

Signed-off-by: Dave Cheney <dave@cheney.net>