### PR TITLE
append x-request-start header to incoming HTTP requests

### DIFF
--- a/internal/contour/route_test.go
+++ b/internal/contour/route_test.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2"
+	"github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
 	"github.com/gogo/protobuf/types"
 	"github.com/google/go-cmp/cmp"
@@ -1072,9 +1073,23 @@ func TestRouteVisit(t *testing.T) {
 											Clusters: []*route.WeightedCluster_ClusterWeight{{
 												Name:   "default/backend/80/da39a3ee5e",
 												Weight: u32(1),
+												RequestHeadersToAdd: []*core.HeaderValueOption{{
+													Header: &core.HeaderValue{
+														Key:   "x-request-start",
+														Value: "t=%START_TIME(%s.%3f)%",
+													},
+													Append: &types.BoolValue{Value: true},
+												}},
 											}, {
 												Name:   "default/backendtwo/80/da39a3ee5e",
 												Weight: u32(1),
+												RequestHeadersToAdd: []*core.HeaderValueOption{{
+													Header: &core.HeaderValue{
+														Key:   "x-request-start",
+														Value: "t=%START_TIME(%s.%3f)%",
+													},
+													Append: &types.BoolValue{Value: true},
+												}},
 											}},
 											TotalWeight: u32(2),
 										},
@@ -1158,9 +1173,23 @@ func TestRouteVisit(t *testing.T) {
 											Clusters: []*route.WeightedCluster_ClusterWeight{{
 												Name:   "default/backend/80/da39a3ee5e",
 												Weight: u32(0),
+												RequestHeadersToAdd: []*core.HeaderValueOption{{
+													Header: &core.HeaderValue{
+														Key:   "x-request-start",
+														Value: "t=%START_TIME(%s.%3f)%",
+													},
+													Append: &types.BoolValue{Value: true},
+												}},
 											}, {
 												Name:   "default/backendtwo/80/da39a3ee5e",
 												Weight: u32(50),
+												RequestHeadersToAdd: []*core.HeaderValueOption{{
+													Header: &core.HeaderValue{
+														Key:   "x-request-start",
+														Value: "t=%START_TIME(%s.%3f)%",
+													},
+													Append: &types.BoolValue{Value: true},
+												}},
 											}},
 											TotalWeight: u32(50),
 										},
@@ -1245,9 +1274,23 @@ func TestRouteVisit(t *testing.T) {
 											Clusters: []*route.WeightedCluster_ClusterWeight{{
 												Name:   "default/backend/80/da39a3ee5e",
 												Weight: u32(22),
+												RequestHeadersToAdd: []*core.HeaderValueOption{{
+													Header: &core.HeaderValue{
+														Key:   "x-request-start",
+														Value: "t=%START_TIME(%s.%3f)%",
+													},
+													Append: &types.BoolValue{Value: true},
+												}},
 											}, {
 												Name:   "default/backendtwo/80/da39a3ee5e",
 												Weight: u32(50),
+												RequestHeadersToAdd: []*core.HeaderValueOption{{
+													Header: &core.HeaderValue{
+														Key:   "x-request-start",
+														Value: "t=%START_TIME(%s.%3f)%",
+													},
+													Append: &types.BoolValue{Value: true},
+												}},
 											}},
 											TotalWeight: u32(72),
 										},
@@ -1338,6 +1381,13 @@ func routecluster(cluster string) *route.Route_Route {
 			ClusterSpecifier: &route.RouteAction_Cluster{
 				Cluster: cluster,
 			},
+			RequestHeadersToAdd: []*core.HeaderValueOption{{
+				Header: &core.HeaderValue{
+					Key:   "x-request-start",
+					Value: "t=%START_TIME(%s.%3f)%",
+				},
+				Append: &types.BoolValue{Value: true},
+			}},
 		},
 	}
 
@@ -1394,6 +1444,13 @@ func TestActionRoute(t *testing.T) {
 					ClusterSpecifier: &route.RouteAction_Cluster{
 						Cluster: "default/kuard/8080/da39a3ee5e",
 					},
+					RequestHeadersToAdd: []*core.HeaderValueOption{{
+						Header: &core.HeaderValue{
+							Key:   "x-request-start",
+							Value: "t=%START_TIME(%s.%3f)%",
+						},
+						Append: &types.BoolValue{Value: true},
+					}},
 				},
 			},
 		},
@@ -1420,6 +1477,13 @@ func TestActionRoute(t *testing.T) {
 						Cluster: "default/kuard/8080/da39a3ee5e",
 					},
 					Timeout: duration(30 * time.Second),
+					RequestHeadersToAdd: []*core.HeaderValueOption{{
+						Header: &core.HeaderValue{
+							Key:   "x-request-start",
+							Value: "t=%START_TIME(%s.%3f)%",
+						},
+						Append: &types.BoolValue{Value: true},
+					}},
 				},
 			},
 		},
@@ -1446,6 +1510,13 @@ func TestActionRoute(t *testing.T) {
 						Cluster: "default/kuard/8080/da39a3ee5e",
 					},
 					Timeout: duration(0),
+					RequestHeadersToAdd: []*core.HeaderValueOption{{
+						Header: &core.HeaderValue{
+							Key:   "x-request-start",
+							Value: "t=%START_TIME(%s.%3f)%",
+						},
+						Append: &types.BoolValue{Value: true},
+					}},
 				},
 			},
 		},
@@ -1472,6 +1543,13 @@ func TestActionRoute(t *testing.T) {
 						Cluster: "default/kuard/8080/da39a3ee5e",
 					},
 					UseWebsocket: &types.BoolValue{Value: true},
+					RequestHeadersToAdd: []*core.HeaderValueOption{{
+						Header: &core.HeaderValue{
+							Key:   "x-request-start",
+							Value: "t=%START_TIME(%s.%3f)%",
+						},
+						Append: &types.BoolValue{Value: true},
+					}},
 				},
 			},
 		},
@@ -1500,6 +1578,13 @@ func TestActionRoute(t *testing.T) {
 					},
 					Timeout:      duration(5 * time.Second),
 					UseWebsocket: &types.BoolValue{Value: true},
+					RequestHeadersToAdd: []*core.HeaderValueOption{{
+						Header: &core.HeaderValue{
+							Key:   "x-request-start",
+							Value: "t=%START_TIME(%s.%3f)%",
+						},
+						Append: &types.BoolValue{Value: true},
+					}},
 				},
 			},
 		},
@@ -1526,6 +1611,13 @@ func TestActionRoute(t *testing.T) {
 					ClusterSpecifier: &route.RouteAction_Cluster{
 						Cluster: "default/kuard/8080/da39a3ee5e",
 					},
+					RequestHeadersToAdd: []*core.HeaderValueOption{{
+						Header: &core.HeaderValue{
+							Key:   "x-request-start",
+							Value: "t=%START_TIME(%s.%3f)%",
+						},
+						Append: &types.BoolValue{Value: true},
+					}},
 				},
 			},
 		},
@@ -1558,6 +1650,13 @@ func TestActionRoute(t *testing.T) {
 						NumRetries:    u32(7),
 						PerTryTimeout: duration(10 * time.Second),
 					},
+					RequestHeadersToAdd: []*core.HeaderValueOption{{
+						Header: &core.HeaderValue{
+							Key:   "x-request-start",
+							Value: "t=%START_TIME(%s.%3f)%",
+						},
+						Append: &types.BoolValue{Value: true},
+					}},
 				},
 			},
 		},
@@ -1594,9 +1693,23 @@ func TestActionRoute(t *testing.T) {
 							Clusters: []*route.WeightedCluster_ClusterWeight{{
 								Name:   "default/kuard/8080/da39a3ee5e",
 								Weight: u32(1),
+								RequestHeadersToAdd: []*core.HeaderValueOption{{
+									Header: &core.HeaderValue{
+										Key:   "x-request-start",
+										Value: "t=%START_TIME(%s.%3f)%",
+									},
+									Append: &types.BoolValue{Value: true},
+								}},
 							}, {
 								Name:   "default/nginx/8080/da39a3ee5e",
 								Weight: u32(1),
+								RequestHeadersToAdd: []*core.HeaderValueOption{{
+									Header: &core.HeaderValue{
+										Key:   "x-request-start",
+										Value: "t=%START_TIME(%s.%3f)%",
+									},
+									Append: &types.BoolValue{Value: true},
+								}},
 							}},
 							TotalWeight: u32(2),
 						},
@@ -1636,9 +1749,23 @@ func TestActionRoute(t *testing.T) {
 							Clusters: []*route.WeightedCluster_ClusterWeight{{
 								Name:   "default/kuard/8080/da39a3ee5e",
 								Weight: u32(80),
+								RequestHeadersToAdd: []*core.HeaderValueOption{{
+									Header: &core.HeaderValue{
+										Key:   "x-request-start",
+										Value: "t=%START_TIME(%s.%3f)%",
+									},
+									Append: &types.BoolValue{Value: true},
+								}},
 							}, {
 								Name:   "default/nginx/8080/da39a3ee5e",
 								Weight: u32(20),
+								RequestHeadersToAdd: []*core.HeaderValueOption{{
+									Header: &core.HeaderValue{
+										Key:   "x-request-start",
+										Value: "t=%START_TIME(%s.%3f)%",
+									},
+									Append: &types.BoolValue{Value: true},
+								}},
 							}},
 							TotalWeight: u32(100),
 						},
@@ -1691,12 +1818,33 @@ func TestActionRoute(t *testing.T) {
 							Clusters: []*route.WeightedCluster_ClusterWeight{{
 								Name:   "default/kuard/8080/da39a3ee5e",
 								Weight: u32(80),
+								RequestHeadersToAdd: []*core.HeaderValueOption{{
+									Header: &core.HeaderValue{
+										Key:   "x-request-start",
+										Value: "t=%START_TIME(%s.%3f)%",
+									},
+									Append: &types.BoolValue{Value: true},
+								}},
 							}, {
 								Name:   "default/nginx/8080/da39a3ee5e",
 								Weight: u32(20),
+								RequestHeadersToAdd: []*core.HeaderValueOption{{
+									Header: &core.HeaderValue{
+										Key:   "x-request-start",
+										Value: "t=%START_TIME(%s.%3f)%",
+									},
+									Append: &types.BoolValue{Value: true},
+								}},
 							}, {
 								Name:   "default/notraffic/8080/da39a3ee5e",
 								Weight: u32(0),
+								RequestHeadersToAdd: []*core.HeaderValueOption{{
+									Header: &core.HeaderValue{
+										Key:   "x-request-start",
+										Value: "t=%START_TIME(%s.%3f)%",
+									},
+									Append: &types.BoolValue{Value: true},
+								}},
 							}},
 							TotalWeight: u32(100),
 						},

--- a/internal/e2e/rds_test.go
+++ b/internal/e2e/rds_test.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2"
+	"github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
 	"github.com/gogo/protobuf/types"
 	ingressroutev1 "github.com/heptio/contour/apis/contour/v1beta1"
@@ -1939,6 +1940,13 @@ func routecluster(cluster string) *route.Route_Route {
 			ClusterSpecifier: &route.RouteAction_Cluster{
 				Cluster: cluster,
 			},
+			RequestHeadersToAdd: []*core.HeaderValueOption{{
+				Header: &core.HeaderValue{
+					Key:   "x-request-start",
+					Value: "t=%START_TIME(%s.%3f)%",
+				},
+				Append: &types.BoolValue{Value: true},
+			}},
 		},
 	}
 }
@@ -1961,6 +1969,13 @@ func weightedclusters(clusters []weightedcluster) *route.WeightedCluster {
 		wc.Clusters = append(wc.Clusters, &route.WeightedCluster_ClusterWeight{
 			Name:   c.name,
 			Weight: &types.UInt32Value{Value: c.weight},
+			RequestHeadersToAdd: []*core.HeaderValueOption{{
+				Header: &core.HeaderValue{
+					Key:   "x-request-start",
+					Value: "t=%START_TIME(%s.%3f)%",
+				},
+				Append: &types.BoolValue{Value: true},
+			}},
 		})
 	}
 	wc.TotalWeight = &types.UInt32Value{

--- a/internal/envoy/route.go
+++ b/internal/envoy/route.go
@@ -16,6 +16,7 @@ package envoy
 import (
 	"sort"
 
+	"github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
 	"github.com/gogo/protobuf/types"
 	"github.com/heptio/contour/internal/dag"
@@ -46,6 +47,13 @@ func RouteCluster(service *dag.Service) route.Route_Route {
 			ClusterSpecifier: &route.RouteAction_Cluster{
 				Cluster: Clustername(service),
 			},
+			RequestHeadersToAdd: []*core.HeaderValueOption{{
+				Header: &core.HeaderValue{
+					Key:   "x-request-start",
+					Value: "t=%START_TIME(%s.%3f)%",
+				},
+				Append: &types.BoolValue{Value: true},
+			}},
 		},
 	}
 }
@@ -59,6 +67,13 @@ func WeightedClusters(services []*dag.Service) *route.WeightedCluster {
 		wc.Clusters = append(wc.Clusters, &route.WeightedCluster_ClusterWeight{
 			Name:   Clustername(svc),
 			Weight: u32(svc.Weight),
+			RequestHeadersToAdd: []*core.HeaderValueOption{{
+				Header: &core.HeaderValue{
+					Key:   "x-request-start",
+					Value: "t=%START_TIME(%s.%3f)%",
+				},
+				Append: &types.BoolValue{Value: true},
+			}},
 		})
 	}
 	// Check if no weights were defined, if not default to even distribution

--- a/internal/envoy/route_test.go
+++ b/internal/envoy/route_test.go
@@ -16,7 +16,9 @@ package envoy
 import (
 	"testing"
 
+	"github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
+	"github.com/gogo/protobuf/types"
 	"github.com/google/go-cmp/cmp"
 	"github.com/heptio/contour/internal/dag"
 	"k8s.io/api/core/v1"
@@ -54,9 +56,23 @@ func TestWeightedClusters(t *testing.T) {
 				Clusters: []*route.WeightedCluster_ClusterWeight{{
 					Name:   "default/kuard/8080/da39a3ee5e",
 					Weight: u32(1),
+					RequestHeadersToAdd: []*core.HeaderValueOption{{
+						Header: &core.HeaderValue{
+							Key:   "x-request-start",
+							Value: "t=%START_TIME(%s.%3f)%",
+						},
+						Append: &types.BoolValue{Value: true},
+					}},
 				}, {
 					Name:   "default/nginx/8080/da39a3ee5e",
 					Weight: u32(1),
+					RequestHeadersToAdd: []*core.HeaderValueOption{{
+						Header: &core.HeaderValue{
+							Key:   "x-request-start",
+							Value: "t=%START_TIME(%s.%3f)%",
+						},
+						Append: &types.BoolValue{Value: true},
+					}},
 				}},
 				TotalWeight: u32(2),
 			},
@@ -89,9 +105,23 @@ func TestWeightedClusters(t *testing.T) {
 				Clusters: []*route.WeightedCluster_ClusterWeight{{
 					Name:   "default/kuard/8080/da39a3ee5e",
 					Weight: u32(80),
+					RequestHeadersToAdd: []*core.HeaderValueOption{{
+						Header: &core.HeaderValue{
+							Key:   "x-request-start",
+							Value: "t=%START_TIME(%s.%3f)%",
+						},
+						Append: &types.BoolValue{Value: true},
+					}},
 				}, {
 					Name:   "default/nginx/8080/da39a3ee5e",
 					Weight: u32(20),
+					RequestHeadersToAdd: []*core.HeaderValueOption{{
+						Header: &core.HeaderValue{
+							Key:   "x-request-start",
+							Value: "t=%START_TIME(%s.%3f)%",
+						},
+						Append: &types.BoolValue{Value: true},
+					}},
 				}},
 				TotalWeight: u32(100),
 			},
@@ -134,12 +164,33 @@ func TestWeightedClusters(t *testing.T) {
 				Clusters: []*route.WeightedCluster_ClusterWeight{{
 					Name:   "default/kuard/8080/da39a3ee5e",
 					Weight: u32(80),
+					RequestHeadersToAdd: []*core.HeaderValueOption{{
+						Header: &core.HeaderValue{
+							Key:   "x-request-start",
+							Value: "t=%START_TIME(%s.%3f)%",
+						},
+						Append: &types.BoolValue{Value: true},
+					}},
 				}, {
 					Name:   "default/nginx/8080/da39a3ee5e",
 					Weight: u32(20),
+					RequestHeadersToAdd: []*core.HeaderValueOption{{
+						Header: &core.HeaderValue{
+							Key:   "x-request-start",
+							Value: "t=%START_TIME(%s.%3f)%",
+						},
+						Append: &types.BoolValue{Value: true},
+					}},
 				}, {
 					Name:   "default/notraffic/8080/da39a3ee5e",
 					Weight: u32(0),
+					RequestHeadersToAdd: []*core.HeaderValueOption{{
+						Header: &core.HeaderValue{
+							Key:   "x-request-start",
+							Value: "t=%START_TIME(%s.%3f)%",
+						},
+						Append: &types.BoolValue{Value: true},
+					}},
 				}},
 				TotalWeight: u32(100),
 			},


### PR DESCRIPTION
Some tracing applications support reporting on queuing time for incoming requests. Generally this is implemented by adding a `X-Request-Start` timestamp header to the requests as early as possible in the request path.

[New Relic](https://docs.newrelic.com/docs/apm/applications-menu/features/request-queue-server-configuration-examples) and [datadog](https://github.com/DataDog/dd-trace-rb/blob/master/docs/GettingStarted.md#http-request-queuing) are two examples of tools that support this header.

The [envoy docs](https://www.envoyproxy.io/docs/envoy/latest/configuration/http_conn_man/headers#custom-request-response-headers) say:

> Custom request/response headers can be added to a request/response at
> the weighted cluster, route, virtual host, and/or global route
> configuration level

I've opted to add them at the weighted cluster level, based on a [slack discussion with @stevesloka](https://kubernetes.slack.com/archives/C8XRH2R4J/p1538487259000100). I'm happy to change that if requested though - my envoy knowledge is pretty low, and I'm not sure what the tradeoffs of each location are.

The header is added to all requests unconditionally, as suggested in the original github issue.

Fixes #646