### PR TITLE
enable automatic gzip compression of responses

### DIFF
--- a/internal/contour/listener.go
+++ b/internal/contour/listener.go
@@ -186,6 +186,7 @@ const (
 
 	router     = "envoy.router"
 	grpcWeb    = "envoy.grpc_web"
+	gzip       = "envoy.gzip"
 	httpFilter = "envoy.http_connection_manager"
 	accessLog  = "envoy.file_access_log"
 )
@@ -295,6 +296,9 @@ func httpfilter(routename, accessLogPath string) listener.Filter {
 					}),
 				}),
 				"http_filters": lv(
+					st(map[string]*types.Value{
+						"name": sv(gzip),
+					}),
 					st(map[string]*types.Value{
 						"name": sv(grpcWeb),
 					}),

--- a/internal/e2e/lds_test.go
+++ b/internal/e2e/lds_test.go
@@ -1095,6 +1095,7 @@ func httpfilter(routename string) listener.Filter {
 			}},
 			UseRemoteAddress: &types.BoolValue{Value: true},
 			HttpFilters: []*envoy_config_v2_http_conn_mgr.HttpFilter{
+				{Name: "envoy.gzip"},
 				{Name: "envoy.grpc_web"},
 				{Name: "envoy.router"},
 			},


### PR DESCRIPTION
This unconditionally enables envoys [gzip http_filter](https://www.envoyproxy.io/docs/envoy/latest/configuration/http_filters/gzip_filter), which will compress responses if the request indicates it can handle it (via a "accept-encoding: gzip" request header).

I've enabled it with no options, which means it gets the defaults, as
listed [here](https://www.envoyproxy.io/docs/envoy/latest/api-v2/config/filter/http/gzip/v2/gzip.proto
). In envoy 1.7.0, they're:

```yaml
    {
      "memory_level": 5,
      "content_length": 30",
      "compression_level": "DEFAULT",
      "compression_strategy": "DEFAULT",
      "content_type": [“application/javascript”, “application/json”, “application/xhtml+xml”, “image/svg+xml”, “text/css”, “text/html”, “text/plain”, “text/xml”],
      "disable_on_etag_header": false,
      "remove_accept_encoding_header": false,
      "window_bits": 12
    }
```

Note the list of content types that will be compressed. It's possible some users will want to customise this list, but for now I haven't exposed that option.

Fixes #310

Signed-off-by: James Healy <james@yob.id.au>