### PR TITLE
internal/envoy: move v2/route helpers into internal/envoy

### DIFF
--- a/internal/contour/cluster_test.go
+++ b/internal/contour/cluster_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/gogo/protobuf/types"
 	"github.com/google/go-cmp/cmp"
 	ingressroutev1 "github.com/heptio/contour/apis/contour/v1beta1"
-	"github.com/heptio/contour/internal/dag"
 	"github.com/heptio/contour/internal/metrics"
 	"github.com/prometheus/client_golang/prometheus"
 	"k8s.io/api/core/v1"
@@ -869,67 +868,6 @@ func TestClusterVisit(t *testing.T) {
 				Visitable:    reh.Build(),
 			}
 			got := v.Visit()
-			if diff := cmp.Diff(tc.want, got); diff != "" {
-				t.Fatal(diff)
-			}
-		})
-	}
-}
-
-func TestClustername(t *testing.T) {
-	tests := map[string]struct {
-		service *dag.Service
-		want    string
-	}{
-		"simple": {
-			service: &dag.Service{
-				Object: service("default", "backend"),
-				ServicePort: &v1.ServicePort{
-					Name:       "http",
-					Protocol:   "TCP",
-					Port:       80,
-					TargetPort: intstr.FromInt(6502),
-				},
-			},
-			want: "default/backend/80/da39a3ee5e",
-		},
-		"far too long": {
-			service: &dag.Service{
-				Object: service("it-is-a-truth-universally-acknowledged-that-a-single-man-in-possession-of-a-good-fortune", "must-be-in-want-of-a-wife"),
-				ServicePort: &v1.ServicePort{
-					Name:       "http",
-					Protocol:   "TCP",
-					Port:       9999,
-					TargetPort: intstr.FromString("http-alt"),
-				},
-			},
-			want: "it-is-a--dea8b0/must-be--dea8b0/9999/da39a3ee5e",
-		},
-		"various healthcheck params": {
-			service: &dag.Service{
-				Object: service("default", "backend"),
-				ServicePort: &v1.ServicePort{
-					Name:       "http",
-					Protocol:   "TCP",
-					Port:       80,
-					TargetPort: intstr.FromInt(6502),
-				},
-				LoadBalancerStrategy: "Maglev",
-				HealthCheck: &ingressroutev1.HealthCheck{
-					Path:                    "/healthz",
-					IntervalSeconds:         5,
-					TimeoutSeconds:          30,
-					UnhealthyThresholdCount: 3,
-					HealthyThresholdCount:   1,
-				},
-			},
-			want: "default/backend/80/32737eb011",
-		},
-	}
-
-	for name, tc := range tests {
-		t.Run(name, func(t *testing.T) {
-			got := clustername(tc.service)
 			if diff := cmp.Diff(tc.want, got); diff != "" {
 				t.Fatal(diff)
 			}

--- a/internal/envoy/cluster.go
+++ b/internal/envoy/cluster.go
@@ -1,0 +1,98 @@
+// Copyright © 2018 Heptio
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package envoy
+
+import (
+	"crypto/sha1"
+	"crypto/sha256"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/heptio/contour/internal/dag"
+)
+
+// Clustername returns the name of the CDS cluster for this service.
+func Clustername(service *dag.Service) string {
+	buf := service.LoadBalancerStrategy
+	if hc := service.HealthCheck; hc != nil {
+		if hc.TimeoutSeconds > 0 {
+			buf += (time.Duration(hc.TimeoutSeconds) * time.Second).String()
+		}
+		if hc.IntervalSeconds > 0 {
+			buf += (time.Duration(hc.IntervalSeconds) * time.Second).String()
+		}
+		if hc.UnhealthyThresholdCount > 0 {
+			buf += strconv.Itoa(int(hc.UnhealthyThresholdCount))
+		}
+		if hc.HealthyThresholdCount > 0 {
+			buf += strconv.Itoa(int(hc.HealthyThresholdCount))
+		}
+		buf += hc.Path
+	}
+
+	hash := sha1.Sum([]byte(buf))
+	ns := service.Namespace()
+	name := service.Name()
+	return Hashname(60, ns, name, strconv.Itoa(int(service.Port)), fmt.Sprintf("%x", hash[:5]))
+}
+
+// Hashname takes a lenth l and a varargs of strings s and returns a string whose length
+// which does not exceed l. Internally s is joined with strings.Join(s, "/"). If the
+// combined length exceeds l then hashname truncates each element in s, starting from the
+// end using a hash derived from the contents of s (not the current element). This process
+// continues until the length of s does not exceed l, or all elements have been truncated.
+// In which case, the entire string is replaced with a hash not exceeding the length of l.
+func Hashname(l int, s ...string) string {
+	const shorthash = 6 // the length of the shorthash
+
+	r := strings.Join(s, "/")
+	if l > len(r) {
+		// we're under the limit, nothing to do
+		return r
+	}
+	hash := fmt.Sprintf("%x", sha256.Sum256([]byte(r)))
+	for n := len(s) - 1; n >= 0; n-- {
+		s[n] = truncate(l/len(s), s[n], hash[:shorthash])
+		r = strings.Join(s, "/")
+		if l > len(r) {
+			return r
+		}
+	}
+	// truncated everything, but we're still too long
+	// just return the hash truncated to l.
+	return hash[:min(len(hash), l)]
+}
+
+// truncate truncates s to l length by replacing the
+// end of s with -suffix.
+func truncate(l int, s, suffix string) string {
+	if l >= len(s) {
+		// under the limit, nothing to do
+		return s
+	}
+	if l <= len(suffix) {
+		// easy case, just return the start of the suffix
+		return suffix[:min(l, len(suffix))]
+	}
+	return s[:l-len(suffix)-1] + "-" + suffix
+}
+
+func min(a, b int) int {
+	if a > b {
+		return b
+	}
+	return a
+}

--- a/internal/envoy/cluster_test.go
+++ b/internal/envoy/cluster_test.go
@@ -1,0 +1,157 @@
+// Copyright © 2018 Heptio
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package envoy
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	ingressroutev1 "github.com/heptio/contour/apis/contour/v1beta1"
+	"github.com/heptio/contour/internal/dag"
+	"k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+func TestClustername(t *testing.T) {
+	tests := map[string]struct {
+		service *dag.Service
+		want    string
+	}{
+		"simple": {
+			service: &dag.Service{
+				Object: service("default", "backend"),
+				ServicePort: &v1.ServicePort{
+					Name:       "http",
+					Protocol:   "TCP",
+					Port:       80,
+					TargetPort: intstr.FromInt(6502),
+				},
+			},
+			want: "default/backend/80/da39a3ee5e",
+		},
+		"far too long": {
+			service: &dag.Service{
+				Object: service("it-is-a-truth-universally-acknowledged-that-a-single-man-in-possession-of-a-good-fortune", "must-be-in-want-of-a-wife"),
+				ServicePort: &v1.ServicePort{
+					Name:       "http",
+					Protocol:   "TCP",
+					Port:       9999,
+					TargetPort: intstr.FromString("http-alt"),
+				},
+			},
+			want: "it-is-a--dea8b0/must-be--dea8b0/9999/da39a3ee5e",
+		},
+		"various healthcheck params": {
+			service: &dag.Service{
+				Object: service("default", "backend"),
+				ServicePort: &v1.ServicePort{
+					Name:       "http",
+					Protocol:   "TCP",
+					Port:       80,
+					TargetPort: intstr.FromInt(6502),
+				},
+				LoadBalancerStrategy: "Maglev",
+				HealthCheck: &ingressroutev1.HealthCheck{
+					Path:                    "/healthz",
+					IntervalSeconds:         5,
+					TimeoutSeconds:          30,
+					UnhealthyThresholdCount: 3,
+					HealthyThresholdCount:   1,
+				},
+			},
+			want: "default/backend/80/32737eb011",
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := Clustername(tc.service)
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Fatal(diff)
+			}
+		})
+	}
+}
+
+func TestHashname(t *testing.T) {
+	tests := []struct {
+		name string
+		l    int
+		s    []string
+		want string
+	}{
+		{name: "empty s", l: 99, s: nil, want: ""},
+		{name: "single element", l: 99, s: []string{"alpha"}, want: "alpha"},
+		{name: "long single element, hashed", l: 12, s: []string{"gammagammagamma"}, want: "0d350ea5c204"},
+		{name: "single element, truncated", l: 4, s: []string{"alpha"}, want: "8ed3"},
+		{name: "two elements, truncated", l: 19, s: []string{"gammagamma", "betabeta"}, want: "ga-edf159/betabeta"},
+		{name: "three elements", l: 99, s: []string{"alpha", "beta", "gamma"}, want: "alpha/beta/gamma"},
+		{name: "issue/25", l: 60, s: []string{"default", "my-service-name", "my-very-very-long-service-host-name.my.domainname"}, want: "default/my-service-name/my-very-very--c4d2d4"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := Hashname(tc.l, append([]string{}, tc.s...)...)
+			if got != tc.want {
+				t.Fatalf("hashname(%d, %q): got %q, want %q", tc.l, tc.s, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestTruncate(t *testing.T) {
+	tests := []struct {
+		name   string
+		l      int
+		s      string
+		suffix string
+		want   string
+	}{
+		{name: "no truncate", l: 10, s: "quijibo", suffix: "a8c5e6", want: "quijibo"},
+		{name: "limit", l: len("quijibo"), s: "quijibo", suffix: "a8c5e6", want: "quijibo"},
+		{name: "truncate some", l: 6, s: "quijibo", suffix: "a8c5", want: "q-a8c5"},
+		{name: "truncate suffix", l: 4, s: "quijibo", suffix: "a8c5", want: "a8c5"},
+		{name: "truncate more", l: 3, s: "quijibo", suffix: "a8c5", want: "a8c"},
+		{name: "long single element, truncated", l: 9, s: "gammagamma", suffix: "0d350e", want: "ga-0d350e"},
+		{name: "long single element, truncated", l: 12, s: "gammagammagamma", suffix: "0d350e", want: "gamma-0d350e"},
+		{name: "issue/25", l: 60 / 3, s: "my-very-very-long-service-host-name.my.domainname", suffix: "a8c5e6", want: "my-very-very--a8c5e6"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := truncate(tc.l, tc.s, tc.suffix)
+			if got != tc.want {
+				t.Fatalf("hashname(%d, %q, %q): got %q, want %q", tc.l, tc.s, tc.suffix, got, tc.want)
+			}
+		})
+	}
+}
+
+func service(ns, name string, ports ...v1.ServicePort) *v1.Service {
+	return serviceWithAnnotations(ns, name, nil, ports...)
+}
+
+func serviceWithAnnotations(ns, name string, annotations map[string]string, ports ...v1.ServicePort) *v1.Service {
+	return &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        name,
+			Namespace:   ns,
+			Annotations: annotations,
+		},
+		Spec: v1.ServiceSpec{
+			Ports: ports,
+		},
+	}
+}

--- a/internal/envoy/listener.go
+++ b/internal/envoy/listener.go
@@ -11,9 +11,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package envoy contains a configuration writer for v2 YAML config.
-// To avoid a dependncy on a YAML library, we generate the YAML using
-// the text/template package.
 package envoy
 
 import (

--- a/internal/envoy/route.go
+++ b/internal/envoy/route.go
@@ -1,0 +1,89 @@
+// Copyright © 2018 Heptio
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package envoy
+
+import (
+	"sort"
+
+	"github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
+	"github.com/gogo/protobuf/types"
+	"github.com/heptio/contour/internal/dag"
+)
+
+// RouteRoute returns a route.Route_Route for the services supplied.
+// If len(services) is greater than one, the route's action will be a
+// weighted cluster.
+func RouteRoute(services []*dag.Service) route.Route_Route {
+	switch len(services) {
+	case 1:
+		return RouteCluster(services[0])
+	default:
+		return route.Route_Route{
+			Route: &route.RouteAction{
+				ClusterSpecifier: &route.RouteAction_WeightedClusters{
+					WeightedClusters: WeightedClusters(services),
+				},
+			},
+		}
+	}
+}
+
+// RouteCluster returns a route.Route_Route for a single service.
+func RouteCluster(service *dag.Service) route.Route_Route {
+	return route.Route_Route{
+		Route: &route.RouteAction{
+			ClusterSpecifier: &route.RouteAction_Cluster{
+				Cluster: Clustername(service),
+			},
+		},
+	}
+}
+
+// WeightedClusters returns a route.WeightedCluster for multiple services.
+func WeightedClusters(services []*dag.Service) *route.WeightedCluster {
+	var wc route.WeightedCluster
+	var total int
+	for _, svc := range services {
+		total += svc.Weight
+		wc.Clusters = append(wc.Clusters, &route.WeightedCluster_ClusterWeight{
+			Name:   Clustername(svc),
+			Weight: &types.UInt32Value{Value: uint32(svc.Weight)},
+		})
+	}
+	// Check if no weights were defined, if not default to even distribution
+	if total == 0 {
+		for _, c := range wc.Clusters {
+			c.Weight.Value = 1
+		}
+		total = len(services)
+	}
+	wc.TotalWeight = &types.UInt32Value{
+		Value: uint32(total),
+	}
+
+	sort.Stable(clusterWeightByName(wc.Clusters))
+	return &wc
+}
+
+type clusterWeightByName []*route.WeightedCluster_ClusterWeight
+
+func (c clusterWeightByName) Len() int      { return len(c) }
+func (c clusterWeightByName) Swap(i, j int) { c[i], c[j] = c[j], c[i] }
+func (c clusterWeightByName) Less(i, j int) bool {
+	if c[i].Name == c[j].Name {
+		return c[i].Weight.Value < c[j].Weight.Value
+	}
+	return c[i].Name < c[j].Name
+
+}


### PR DESCRIPTION
Updates #708

Move route related helpers into internal/envoy.

Signed-off-by: Dave Cheney <dave@cheney.net>