### PR TITLE
Supports contour.heptio.com/ingress.class annotation for IngressRoutes

### DIFF
--- a/internal/contour/k8s.go
+++ b/internal/contour/k8s.go
@@ -19,6 +19,7 @@ package contour
 import (
 	"reflect"
 
+	ingressroutev1 "github.com/heptio/contour/apis/contour/v1beta1"
 	"github.com/heptio/contour/internal/dag"
 	"github.com/heptio/contour/internal/metrics"
 	"github.com/prometheus/client_golang/prometheus"
@@ -97,16 +98,22 @@ func (reh *ResourceEventHandler) update() {
 
 // validIngressClass returns true iff:
 //
-// 1. obj is not of type *v1beta1.Ingress.
+// 1. obj is not of type *v1beta1.Ingress or ingressroutev1.IngressRoute.
 // 2. obj has no ingress.class annotation.
 // 2. obj's ingress.class annotation matches d.IngressClass.
 func (reh *ResourceEventHandler) validIngressClass(obj interface{}) bool {
-	i, ok := obj.(*v1beta1.Ingress)
-	if !ok {
-		return true
+	ir, ok := obj.(*ingressroutev1.IngressRoute)
+	if ok {
+		class, ok := getIngressClassAnnotation(ir.Annotations)
+		return !ok || class == reh.ingressClass()
 	}
-	class, ok := i.Annotations["kubernetes.io/ingress.class"]
-	return !ok || class == reh.ingressClass()
+
+	i, ok := obj.(*v1beta1.Ingress)
+	if ok {
+		class, ok := getIngressClassAnnotation(i.Annotations)
+		return !ok || class == reh.ingressClass()
+	}
+	return true
 }
 
 // ingressClass returns the IngressClass
@@ -116,4 +123,23 @@ func (reh *ResourceEventHandler) ingressClass() string {
 		return reh.IngressClass
 	}
 	return DEFAULT_INGRESS_CLASS
+}
+
+// getIngressClassAnnotation checks for the acceptable ingress class annotations
+// 1. contour.heptio.com/ingress.class
+// 2. kubernetes.io/ingress.class
+//
+// it returns the first matching ingress annotation (in the above order) with test
+func getIngressClassAnnotation(annotations map[string]string) (string, bool) {
+	class, ok := annotations["contour.heptio.com/ingress.class"]
+	if ok {
+		return class, true
+	}
+
+	class, ok = annotations["kubernetes.io/ingress.class"]
+	if ok {
+		return class, true
+	}
+
+	return "", false
 }

--- a/internal/e2e/rds_test.go
+++ b/internal/e2e/rds_test.go
@@ -1350,7 +1350,184 @@ func TestRDSIngressRouteOutsideRootNamespaces(t *testing.T) {
 // Test DAGAdapter.IngressClass setting works, this could be done
 // in LDS or RDS, or even CDS, but this test mirrors the place it's
 // tested in internal/contour/route_test.go
-func TestRDSIngressClass(t *testing.T) {
+func TestRDSIngressRouteClassAnnotation(t *testing.T) {
+	rh, cc, done := setup(t, func(reh *contour.ResourceEventHandler) {
+		reh.IngressClass = "linkerd"
+	})
+	defer done()
+
+	rh.OnAdd(&v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "kuard",
+			Namespace: "default",
+		},
+		Spec: v1.ServiceSpec{
+			Ports: []v1.ServicePort{{
+				Protocol:   "TCP",
+				Port:       8080,
+				TargetPort: intstr.FromInt(8080),
+			}},
+		},
+	})
+
+	ir1 := &ingressroutev1.IngressRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "kuard ",
+			Namespace: "default",
+		},
+		Spec: ingressroutev1.IngressRouteSpec{
+			VirtualHost: &ingressroutev1.VirtualHost{
+				Fqdn: "www.example.com",
+			},
+			Routes: []ingressroutev1.Route{{
+				Match: "/",
+				Services: []ingressroutev1.Service{
+					{
+						Name: "kuard",
+						Port: 8080,
+					},
+				},
+			}},
+		},
+	}
+
+	rh.OnAdd(ir1)
+	assertRDS(t, cc, []route.VirtualHost{{
+		Name:    "www.example.com",
+		Domains: []string{"www.example.com", "www.example.com:80"},
+		Routes: []route.Route{{
+			Match:  prefixmatch("/"),
+			Action: routecluster("default/kuard/8080/da39a3ee5e"),
+		}},
+	}}, nil)
+
+	ir2 := &ingressroutev1.IngressRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "kuard ",
+			Namespace: "default",
+			Annotations: map[string]string{
+				"kubernetes.io/ingress.class": "contour",
+			},
+		},
+		Spec: ingressroutev1.IngressRouteSpec{
+			VirtualHost: &ingressroutev1.VirtualHost{
+				Fqdn: "www.example.com",
+			},
+			Routes: []ingressroutev1.Route{{
+				Match: "/",
+				Services: []ingressroutev1.Service{
+					{
+						Name: "kuard",
+						Port: 8080,
+					},
+				},
+			}},
+		},
+	}
+	rh.OnUpdate(ir1, ir2)
+	assertRDS(t, cc, nil, nil)
+
+	ir3 := &ingressroutev1.IngressRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "kuard ",
+			Namespace: "default",
+			Annotations: map[string]string{
+				"contour.heptio.com/ingress.class": "contour",
+			},
+		},
+		Spec: ingressroutev1.IngressRouteSpec{
+			VirtualHost: &ingressroutev1.VirtualHost{
+				Fqdn: "www.example.com",
+			},
+			Routes: []ingressroutev1.Route{{
+				Match: "/",
+				Services: []ingressroutev1.Service{
+					{
+						Name: "kuard",
+						Port: 8080,
+					},
+				},
+			}},
+		},
+	}
+	rh.OnUpdate(ir2, ir3)
+	assertRDS(t, cc, nil, nil)
+
+	ir4 := &ingressroutev1.IngressRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "kuard ",
+			Namespace: "default",
+			Annotations: map[string]string{
+				"contour.heptio.com/ingress.class": "linkerd",
+			},
+		},
+		Spec: ingressroutev1.IngressRouteSpec{
+			VirtualHost: &ingressroutev1.VirtualHost{
+				Fqdn: "www.example.com",
+			},
+			Routes: []ingressroutev1.Route{{
+				Match: "/",
+				Services: []ingressroutev1.Service{
+					{
+						Name: "kuard",
+						Port: 8080,
+					},
+				},
+			}},
+		},
+	}
+	rh.OnUpdate(ir3, ir4)
+	assertRDS(t, cc, []route.VirtualHost{{
+		Name:    "www.example.com",
+		Domains: []string{"www.example.com", "www.example.com:80"},
+		Routes: []route.Route{{
+			Match:  prefixmatch("/"),
+			Action: routecluster("default/kuard/8080/da39a3ee5e"),
+		}},
+	}}, nil)
+
+	ir5 := &ingressroutev1.IngressRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "kuard ",
+			Namespace: "default",
+			Annotations: map[string]string{
+				"kubernetes.io/ingress.class": "linkerd",
+			},
+		},
+		Spec: ingressroutev1.IngressRouteSpec{
+			VirtualHost: &ingressroutev1.VirtualHost{
+				Fqdn: "www.example.com",
+			},
+			Routes: []ingressroutev1.Route{{
+				Match: "/",
+				Services: []ingressroutev1.Service{
+					{
+						Name: "kuard",
+						Port: 8080,
+					},
+				},
+			}},
+		},
+	}
+	rh.OnUpdate(ir4, ir5)
+
+	assertRDS(t, cc, []route.VirtualHost{{
+		Name:    "www.example.com",
+		Domains: []string{"www.example.com", "www.example.com:80"},
+		Routes: []route.Route{{
+			Match:  prefixmatch("/"),
+			Action: routecluster("default/kuard/8080/da39a3ee5e"),
+		}},
+	}}, nil)
+
+	rh.OnUpdate(ir5, ir3)
+	assertRDS(t, cc, nil, nil)
+}
+
+// Test DAGAdapter.IngressClass setting works, this could be done
+// in LDS or RDS, or even CDS, but this test mirrors the place it's
+// tested in internal/contour/route_test.go
+func TestRDSIngressClassAnnotation(t *testing.T) {
 	rh, cc, done := setup(t, func(reh *contour.ResourceEventHandler) {
 		reh.IngressClass = "linkerd"
 	})
@@ -1415,7 +1592,7 @@ func TestRDSIngressClass(t *testing.T) {
 			Name:      "kuard-ing",
 			Namespace: "default",
 			Annotations: map[string]string{
-				"kubernetes.io/ingress.class": "linkerd",
+				"contour.heptio.com/ingress.class": "contour",
 			},
 		},
 		Spec: v1beta1.IngressSpec{
@@ -1426,6 +1603,24 @@ func TestRDSIngressClass(t *testing.T) {
 		},
 	}
 	rh.OnUpdate(i2, i3)
+	assertRDS(t, cc, nil, nil)
+
+	i4 := &v1beta1.Ingress{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "kuard-ing",
+			Namespace: "default",
+			Annotations: map[string]string{
+				"kubernetes.io/ingress.class": "linkerd",
+			},
+		},
+		Spec: v1beta1.IngressSpec{
+			Backend: &v1beta1.IngressBackend{
+				ServiceName: "kuard",
+				ServicePort: intstr.FromInt(8080),
+			},
+		},
+	}
+	rh.OnUpdate(i3, i4)
 	assertRDS(t, cc, []route.VirtualHost{{
 		Name:    "*",
 		Domains: []string{"*"},
@@ -1435,7 +1630,32 @@ func TestRDSIngressClass(t *testing.T) {
 		}},
 	}}, nil)
 
-	rh.OnUpdate(i3, i2)
+	i5 := &v1beta1.Ingress{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "kuard-ing",
+			Namespace: "default",
+			Annotations: map[string]string{
+				"contour.heptio.com/ingress.class": "linkerd",
+			},
+		},
+		Spec: v1beta1.IngressSpec{
+			Backend: &v1beta1.IngressBackend{
+				ServiceName: "kuard",
+				ServicePort: intstr.FromInt(8080),
+			},
+		},
+	}
+	rh.OnUpdate(i4, i5)
+	assertRDS(t, cc, []route.VirtualHost{{
+		Name:    "*",
+		Domains: []string{"*"},
+		Routes: []route.Route{{
+			Match:  prefixmatch("/"),
+			Action: routecluster("default/kuard/8080/da39a3ee5e"),
+		}},
+	}}, nil)
+
+	rh.OnUpdate(i5, i3)
 	assertRDS(t, cc, nil, nil)
 }
 


### PR DESCRIPTION
I would like to propose the following PR as a solution to #720 

It works by checking for IngressRoute objects and testing for a `contour.heptio.com/ingress.class` annotation `validIngressClass`

Not sure if this is the correct approach, but my tests suggest it is functional.