### PR TITLE
internal/envoy: move more helpers into internal/envoy

### DIFF
--- a/internal/contour/cluster.go
+++ b/internal/contour/cluster.go
@@ -197,7 +197,7 @@ func uint32OrNil(val int) *types.UInt32Value {
 	}
 }
 
-func edsconfig(source string, service *dag.Service) *v2.Cluster_EdsClusterConfig {
+func edsconfig(cluster string, service *dag.Service) *v2.Cluster_EdsClusterConfig {
 	name := []string{
 		service.Namespace(),
 		service.Name(),
@@ -207,28 +207,7 @@ func edsconfig(source string, service *dag.Service) *v2.Cluster_EdsClusterConfig
 		name = name[:2]
 	}
 	return &v2.Cluster_EdsClusterConfig{
-		EdsConfig:   apiconfigsource(source), // hard coded by initconfig
+		EdsConfig:   envoy.ConfigSource(cluster),
 		ServiceName: strings.Join(name, "/"),
-	}
-}
-
-func apiconfigsource(clusters ...string) *core.ConfigSource {
-	services := make([]*core.GrpcService, 0, len(clusters))
-	for _, c := range clusters {
-		services = append(services, &core.GrpcService{
-			TargetSpecifier: &core.GrpcService_EnvoyGrpc_{
-				EnvoyGrpc: &core.GrpcService_EnvoyGrpc{
-					ClusterName: c,
-				},
-			},
-		})
-	}
-	return &core.ConfigSource{
-		ConfigSourceSpecifier: &core.ConfigSource_ApiConfigSource{
-			ApiConfigSource: &core.ApiConfigSource{
-				ApiType:      core.ApiConfigSource_GRPC,
-				GrpcServices: services,
-			},
-		},
 	}
 }

--- a/internal/contour/cluster_test.go
+++ b/internal/contour/cluster_test.go
@@ -21,7 +21,6 @@ import (
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2/cluster"
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 	envoy_type "github.com/envoyproxy/go-control-plane/envoy/type"
-	"github.com/gogo/protobuf/types"
 	"github.com/google/go-cmp/cmp"
 	ingressroutev1 "github.com/heptio/contour/apis/contour/v1beta1"
 	"github.com/heptio/contour/internal/metrics"
@@ -315,14 +314,10 @@ func TestClusterVisit(t *testing.T) {
 					ConnectTimeout: 250 * time.Millisecond,
 					LbPolicy:       v2.Cluster_ROUND_ROBIN,
 					HealthChecks: []*core.HealthCheck{{
-						Timeout:  duration(hcTimeout),
-						Interval: duration(hcInterval),
-						UnhealthyThreshold: &types.UInt32Value{
-							Value: hcUnhealthyThreshold,
-						},
-						HealthyThreshold: &types.UInt32Value{
-							Value: hcHealthyThreshold,
-						},
+						Timeout:            duration(2 * time.Second),
+						Interval:           duration(10 * time.Second),
+						UnhealthyThreshold: u32(3),
+						HealthyThreshold:   u32(2),
 						HealthChecker: &core.HealthCheck_HttpHealthCheck_{
 							HttpHealthCheck: &core.HealthCheck_HttpHealthCheck{
 								Path: "/healthy",
@@ -384,14 +379,10 @@ func TestClusterVisit(t *testing.T) {
 					ConnectTimeout: 250 * time.Millisecond,
 					LbPolicy:       v2.Cluster_ROUND_ROBIN,
 					HealthChecks: []*core.HealthCheck{{
-						Timeout:  duration(99 * time.Second),
-						Interval: duration(98 * time.Second),
-						UnhealthyThreshold: &types.UInt32Value{
-							Value: 97,
-						},
-						HealthyThreshold: &types.UInt32Value{
-							Value: 96,
-						},
+						Timeout:            duration(99 * time.Second),
+						Interval:           duration(98 * time.Second),
+						UnhealthyThreshold: u32(97),
+						HealthyThreshold:   u32(96),
 						HealthChecker: &core.HealthCheck_HttpHealthCheck_{
 							HttpHealthCheck: &core.HealthCheck_HttpHealthCheck{
 								Path: "/healthy",
@@ -794,10 +785,10 @@ func TestClusterVisit(t *testing.T) {
 					LbPolicy:       v2.Cluster_ROUND_ROBIN,
 					CircuitBreakers: &cluster.CircuitBreakers{
 						Thresholds: []*cluster.CircuitBreakers_Thresholds{{
-							MaxConnections:     uint32t(9000),
-							MaxPendingRequests: uint32t(4096),
-							MaxRequests:        uint32t(404),
-							MaxRetries:         uint32t(7),
+							MaxConnections:     u32(9000),
+							MaxPendingRequests: u32(4096),
+							MaxRequests:        u32(404),
+							MaxRetries:         u32(7),
 						}},
 					},
 					CommonLbConfig: &v2.Cluster_CommonLbConfig{
@@ -875,10 +866,6 @@ func TestClusterVisit(t *testing.T) {
 	}
 }
 
-func uint32t(v int) *types.UInt32Value {
-	return &types.UInt32Value{Value: uint32(v)}
-}
-
 func service(ns, name string, ports ...v1.ServicePort) *v1.Service {
 	return serviceWithAnnotations(ns, name, nil, ports...)
 }
@@ -904,6 +891,4 @@ func clustermap(clusters ...*v2.Cluster) map[string]*v2.Cluster {
 	return m
 }
 
-func duration(d time.Duration) *time.Duration {
-	return &d
-}
+func duration(d time.Duration) *time.Duration { return &d }

--- a/internal/contour/cluster_test.go
+++ b/internal/contour/cluster_test.go
@@ -23,6 +23,7 @@ import (
 	envoy_type "github.com/envoyproxy/go-control-plane/envoy/type"
 	"github.com/google/go-cmp/cmp"
 	ingressroutev1 "github.com/heptio/contour/apis/contour/v1beta1"
+	"github.com/heptio/contour/internal/envoy"
 	"github.com/heptio/contour/internal/metrics"
 	"github.com/prometheus/client_golang/prometheus"
 	"k8s.io/api/core/v1"
@@ -67,7 +68,7 @@ func TestClusterVisit(t *testing.T) {
 					Name: "default/kuard/443/da39a3ee5e",
 					Type: v2.Cluster_EDS,
 					EdsClusterConfig: &v2.Cluster_EdsClusterConfig{
-						EdsConfig:   apiconfigsource("contour"), // hard coded by initconfig
+						EdsConfig:   envoy.ConfigSource("contour"),
 						ServiceName: "default/kuard",
 					},
 					ConnectTimeout: 250 * time.Millisecond,
@@ -107,7 +108,7 @@ func TestClusterVisit(t *testing.T) {
 					Name: "default/kuard/443/da39a3ee5e",
 					Type: v2.Cluster_EDS,
 					EdsClusterConfig: &v2.Cluster_EdsClusterConfig{
-						EdsConfig:   apiconfigsource("contour"), // hard coded by initconfig
+						EdsConfig:   envoy.ConfigSource("contour"),
 						ServiceName: "default/kuard/https",
 					},
 					ConnectTimeout: 250 * time.Millisecond,
@@ -151,7 +152,7 @@ func TestClusterVisit(t *testing.T) {
 					Name: "default/kuard/80/da39a3ee5e",
 					Type: v2.Cluster_EDS,
 					EdsClusterConfig: &v2.Cluster_EdsClusterConfig{
-						EdsConfig:   apiconfigsource("contour"), // hard coded by initconfig
+						EdsConfig:   envoy.ConfigSource("contour"),
 						ServiceName: "default/kuard/http",
 					},
 					ConnectTimeout:       250 * time.Millisecond,
@@ -193,7 +194,7 @@ func TestClusterVisit(t *testing.T) {
 					Name: "beurocra-7fe4b4/tiny-cog-7fe4b4/443/da39a3ee5e",
 					Type: v2.Cluster_EDS,
 					EdsClusterConfig: &v2.Cluster_EdsClusterConfig{
-						EdsConfig:   apiconfigsource("contour"), // hard coded by initconfig
+						EdsConfig:   envoy.ConfigSource("contour"),
 						ServiceName: "beurocratic-company-test-domain-1/tiny-cog-department-test-instance/svc-0",
 					},
 					ConnectTimeout: 250 * time.Millisecond,
@@ -245,7 +246,7 @@ func TestClusterVisit(t *testing.T) {
 					Name: "default/backend/80/da39a3ee5e",
 					Type: v2.Cluster_EDS,
 					EdsClusterConfig: &v2.Cluster_EdsClusterConfig{
-						EdsConfig:   apiconfigsource("contour"), // hard coded by initconfig
+						EdsConfig:   envoy.ConfigSource("contour"),
 						ServiceName: "default/backend/http",
 					},
 					ConnectTimeout: 250 * time.Millisecond,
@@ -260,7 +261,7 @@ func TestClusterVisit(t *testing.T) {
 					Name: "default/backend/8080/da39a3ee5e",
 					Type: v2.Cluster_EDS,
 					EdsClusterConfig: &v2.Cluster_EdsClusterConfig{
-						EdsConfig:   apiconfigsource("contour"), // hard coded by initconfig
+						EdsConfig:   envoy.ConfigSource("contour"),
 						ServiceName: "default/backend/alt",
 					},
 					ConnectTimeout: 250 * time.Millisecond,
@@ -308,7 +309,7 @@ func TestClusterVisit(t *testing.T) {
 					Name: "default/backend/80/c184349821",
 					Type: v2.Cluster_EDS,
 					EdsClusterConfig: &v2.Cluster_EdsClusterConfig{
-						EdsConfig:   apiconfigsource("contour"), // hard coded by initconfig
+						EdsConfig:   envoy.ConfigSource("contour"),
 						ServiceName: "default/backend/http",
 					},
 					ConnectTimeout: 250 * time.Millisecond,
@@ -373,7 +374,7 @@ func TestClusterVisit(t *testing.T) {
 					Name: "default/backend/80/7f8051653a",
 					Type: v2.Cluster_EDS,
 					EdsClusterConfig: &v2.Cluster_EdsClusterConfig{
-						EdsConfig:   apiconfigsource("contour"), // hard coded by initconfig
+						EdsConfig:   envoy.ConfigSource("contour"),
 						ServiceName: "default/backend/http",
 					},
 					ConnectTimeout: 250 * time.Millisecond,
@@ -431,7 +432,7 @@ func TestClusterVisit(t *testing.T) {
 					Name: "default/backend/80/f3b72af6a9",
 					Type: v2.Cluster_EDS,
 					EdsClusterConfig: &v2.Cluster_EdsClusterConfig{
-						EdsConfig:   apiconfigsource("contour"), // hard coded by initconfig
+						EdsConfig:   envoy.ConfigSource("contour"),
 						ServiceName: "default/backend/http",
 					},
 					ConnectTimeout: 250 * time.Millisecond,
@@ -477,7 +478,7 @@ func TestClusterVisit(t *testing.T) {
 					Name: "default/backend/80/8bf87fefba",
 					Type: v2.Cluster_EDS,
 					EdsClusterConfig: &v2.Cluster_EdsClusterConfig{
-						EdsConfig:   apiconfigsource("contour"), // hard coded by initconfig
+						EdsConfig:   envoy.ConfigSource("contour"),
 						ServiceName: "default/backend/http",
 					},
 					ConnectTimeout: 250 * time.Millisecond,
@@ -523,7 +524,7 @@ func TestClusterVisit(t *testing.T) {
 					Name: "default/backend/80/40633a6ca9",
 					Type: v2.Cluster_EDS,
 					EdsClusterConfig: &v2.Cluster_EdsClusterConfig{
-						EdsConfig:   apiconfigsource("contour"), // hard coded by initconfig
+						EdsConfig:   envoy.ConfigSource("contour"),
 						ServiceName: "default/backend/http",
 					},
 					ConnectTimeout: 250 * time.Millisecond,
@@ -569,7 +570,7 @@ func TestClusterVisit(t *testing.T) {
 					Name: "default/backend/80/843e4ded8f",
 					Type: v2.Cluster_EDS,
 					EdsClusterConfig: &v2.Cluster_EdsClusterConfig{
-						EdsConfig:   apiconfigsource("contour"), // hard coded by initconfig
+						EdsConfig:   envoy.ConfigSource("contour"),
 						ServiceName: "default/backend/http",
 					},
 					ConnectTimeout: 250 * time.Millisecond,
@@ -615,7 +616,7 @@ func TestClusterVisit(t *testing.T) {
 					Name: "default/backend/80/58d888c08a",
 					Type: v2.Cluster_EDS,
 					EdsClusterConfig: &v2.Cluster_EdsClusterConfig{
-						EdsConfig:   apiconfigsource("contour"), // hard coded by initconfig
+						EdsConfig:   envoy.ConfigSource("contour"),
 						ServiceName: "default/backend/http",
 					},
 					ConnectTimeout: 250 * time.Millisecond,
@@ -668,7 +669,7 @@ func TestClusterVisit(t *testing.T) {
 					Name: "default/backend/80/58d888c08a",
 					Type: v2.Cluster_EDS,
 					EdsClusterConfig: &v2.Cluster_EdsClusterConfig{
-						EdsConfig:   apiconfigsource("contour"), // hard coded by initconfig
+						EdsConfig:   envoy.ConfigSource("contour"),
 						ServiceName: "default/backend/http",
 					},
 					ConnectTimeout: 250 * time.Millisecond,
@@ -683,7 +684,7 @@ func TestClusterVisit(t *testing.T) {
 					Name: "default/backend/80/843e4ded8f",
 					Type: v2.Cluster_EDS,
 					EdsClusterConfig: &v2.Cluster_EdsClusterConfig{
-						EdsConfig:   apiconfigsource("contour"), // hard coded by initconfig
+						EdsConfig:   envoy.ConfigSource("contour"),
 						ServiceName: "default/backend/http",
 					},
 					ConnectTimeout: 250 * time.Millisecond,
@@ -730,7 +731,7 @@ func TestClusterVisit(t *testing.T) {
 					Name: "default/backend/80/86d7a9c129",
 					Type: v2.Cluster_EDS,
 					EdsClusterConfig: &v2.Cluster_EdsClusterConfig{
-						EdsConfig:   apiconfigsource("contour"), // hard coded by initconfig
+						EdsConfig:   envoy.ConfigSource("contour"),
 						ServiceName: "default/backend/http",
 					},
 					ConnectTimeout: 250 * time.Millisecond,
@@ -778,7 +779,7 @@ func TestClusterVisit(t *testing.T) {
 					Name: "default/kuard/80/da39a3ee5e",
 					Type: v2.Cluster_EDS,
 					EdsClusterConfig: &v2.Cluster_EdsClusterConfig{
-						EdsConfig:   apiconfigsource("contour"), // hard coded by initconfig
+						EdsConfig:   envoy.ConfigSource("contour"),
 						ServiceName: "default/kuard/http",
 					},
 					ConnectTimeout: 250 * time.Millisecond,
@@ -831,7 +832,7 @@ func TestClusterVisit(t *testing.T) {
 					Name: "default/kuard/443/da39a3ee5e",
 					Type: v2.Cluster_EDS,
 					EdsClusterConfig: &v2.Cluster_EdsClusterConfig{
-						EdsConfig:   apiconfigsource("contour"), // hard coded by initconfig
+						EdsConfig:   envoy.ConfigSource("contour"),
 						ServiceName: "default/kuard/https",
 					},
 					ConnectTimeout: 250 * time.Millisecond,

--- a/internal/contour/route.go
+++ b/internal/contour/route.go
@@ -243,7 +243,7 @@ func actionroute(r *dag.Route, services []*dag.Service) *route.Route_Route {
 			RetryOn: r.RetryOn,
 		}
 		if r.NumRetries > 0 {
-			rr.Route.RetryPolicy.NumRetries = &types.UInt32Value{Value: uint32(r.NumRetries)}
+			rr.Route.RetryPolicy.NumRetries = u32(r.NumRetries)
 		}
 		if r.PerTryTimeout > 0 {
 			timeout := r.PerTryTimeout
@@ -265,3 +265,5 @@ func actionroute(r *dag.Route, services []*dag.Service) *route.Route_Route {
 
 	return &rr
 }
+
+func u32(val int) *types.UInt32Value { return &types.UInt32Value{Value: uint32(val)} }

--- a/internal/contour/route_test.go
+++ b/internal/contour/route_test.go
@@ -32,8 +32,6 @@ import (
 )
 
 func TestRouteVisit(t *testing.T) {
-	var infinity = pduration(0)
-
 	tests := map[string]struct {
 		*RouteCache
 		objs []interface{}
@@ -610,7 +608,7 @@ func TestRouteVisit(t *testing.T) {
 						Domains: []string{"*"},
 						Routes: []route.Route{{
 							Match:  prefixmatch("/"),
-							Action: routetimeout("default/kuard/8080/da39a3ee5e", infinity),
+							Action: routetimeout("default/kuard/8080/da39a3ee5e", duration(0)),
 						}},
 					}},
 				},
@@ -658,7 +656,7 @@ func TestRouteVisit(t *testing.T) {
 						Domains: []string{"*"},
 						Routes: []route.Route{{
 							Match:  prefixmatch("/"),
-							Action: routetimeout("default/kuard/8080/da39a3ee5e", infinity),
+							Action: routetimeout("default/kuard/8080/da39a3ee5e", duration(0)),
 						}},
 					}},
 				},
@@ -706,7 +704,7 @@ func TestRouteVisit(t *testing.T) {
 						Domains: []string{"*"},
 						Routes: []route.Route{{
 							Match:  prefixmatch("/"),
-							Action: routetimeout("default/kuard/8080/da39a3ee5e", pduration(90*time.Second)),
+							Action: routetimeout("default/kuard/8080/da39a3ee5e", duration(90*time.Second)),
 						}},
 					}},
 				},
@@ -1421,7 +1419,7 @@ func TestActionRoute(t *testing.T) {
 					ClusterSpecifier: &route.RouteAction_Cluster{
 						Cluster: "default/kuard/8080/da39a3ee5e",
 					},
-					Timeout: pduration(30 * time.Second),
+					Timeout: duration(30 * time.Second),
 				},
 			},
 		},
@@ -1447,7 +1445,7 @@ func TestActionRoute(t *testing.T) {
 					ClusterSpecifier: &route.RouteAction_Cluster{
 						Cluster: "default/kuard/8080/da39a3ee5e",
 					},
-					Timeout: pduration(0),
+					Timeout: duration(0),
 				},
 			},
 		},
@@ -1500,7 +1498,7 @@ func TestActionRoute(t *testing.T) {
 					ClusterSpecifier: &route.RouteAction_Cluster{
 						Cluster: "default/kuard/8080/da39a3ee5e",
 					},
-					Timeout:      pduration(5 * time.Second),
+					Timeout:      duration(5 * time.Second),
 					UseWebsocket: &types.BoolValue{Value: true},
 				},
 			},
@@ -1558,7 +1556,7 @@ func TestActionRoute(t *testing.T) {
 					RetryPolicy: &route.RouteAction_RetryPolicy{
 						RetryOn:       "50x",
 						NumRetries:    u32(7),
-						PerTryTimeout: pduration(10 * time.Second),
+						PerTryTimeout: duration(10 * time.Second),
 					},
 				},
 			},
@@ -1717,9 +1715,3 @@ func TestActionRoute(t *testing.T) {
 		})
 	}
 }
-
-func pduration(d time.Duration) *time.Duration {
-	return &d
-}
-
-func u32(val int) *types.UInt32Value { return &types.UInt32Value{Value: uint32(val)} }

--- a/internal/e2e/cds_test.go
+++ b/internal/e2e/cds_test.go
@@ -20,10 +20,10 @@ import (
 
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	envoy_cluster "github.com/envoyproxy/go-control-plane/envoy/api/v2/cluster"
-	"github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 	envoy_type "github.com/envoyproxy/go-control-plane/envoy/type"
 	"github.com/gogo/protobuf/types"
 	ingressroutev1 "github.com/heptio/contour/apis/contour/v1beta1"
+	"github.com/heptio/contour/internal/envoy"
 	"google.golang.org/grpc"
 	"k8s.io/api/core/v1"
 	"k8s.io/api/extensions/v1beta1"
@@ -515,7 +515,7 @@ func TestClusterCircuitbreakerAnnotations(t *testing.T) {
 				Name: "default/kuard/8080/da39a3ee5e",
 				Type: v2.Cluster_EDS,
 				EdsClusterConfig: &v2.Cluster_EdsClusterConfig{
-					EdsConfig:   apiconfigsource("contour"), // hard coded by initconfig
+					EdsConfig:   envoy.ConfigSource("contour"),
 					ServiceName: "default/kuard",
 				},
 				ConnectTimeout: 250 * time.Millisecond,
@@ -564,7 +564,7 @@ func TestClusterCircuitbreakerAnnotations(t *testing.T) {
 				Name: "default/kuard/8080/da39a3ee5e",
 				Type: v2.Cluster_EDS,
 				EdsClusterConfig: &v2.Cluster_EdsClusterConfig{
-					EdsConfig:   apiconfigsource("contour"), // hard coded by initconfig
+					EdsConfig:   envoy.ConfigSource("contour"),
 					ServiceName: "default/kuard",
 				},
 				ConnectTimeout: 250 * time.Millisecond,
@@ -693,7 +693,7 @@ func TestClusterLoadBalancerStrategyPerRoute(t *testing.T) {
 				Name: "default/kuard/80/58d888c08a",
 				Type: v2.Cluster_EDS,
 				EdsClusterConfig: &v2.Cluster_EdsClusterConfig{
-					EdsConfig:   apiconfigsource("contour"), // hard coded by initconfig
+					EdsConfig:   envoy.ConfigSource("contour"),
 					ServiceName: "default/kuard",
 				},
 				ConnectTimeout: 250 * time.Millisecond,
@@ -708,7 +708,7 @@ func TestClusterLoadBalancerStrategyPerRoute(t *testing.T) {
 				Name: "default/kuard/80/843e4ded8f",
 				Type: v2.Cluster_EDS,
 				EdsClusterConfig: &v2.Cluster_EdsClusterConfig{
-					EdsConfig:   apiconfigsource("contour"), // hard coded by initconfig
+					EdsConfig:   envoy.ConfigSource("contour"),
 					ServiceName: "default/kuard",
 				},
 				ConnectTimeout: 250 * time.Millisecond,
@@ -763,7 +763,7 @@ func cluster(name, servicename string) *v2.Cluster {
 		Name: name,
 		Type: v2.Cluster_EDS,
 		EdsClusterConfig: &v2.Cluster_EdsClusterConfig{
-			EdsConfig:   apiconfigsource("contour"), // hard coded by initconfig
+			EdsConfig:   envoy.ConfigSource("contour"),
 			ServiceName: servicename,
 		},
 		ConnectTimeout: 250 * time.Millisecond,
@@ -771,27 +771,6 @@ func cluster(name, servicename string) *v2.Cluster {
 		CommonLbConfig: &v2.Cluster_CommonLbConfig{
 			HealthyPanicThreshold: &envoy_type.Percent{ // Disable HealthyPanicThreshold
 				Value: 0,
-			},
-		},
-	}
-}
-
-func apiconfigsource(clusters ...string) *core.ConfigSource {
-	services := make([]*core.GrpcService, 0, len(clusters))
-	for _, c := range clusters {
-		services = append(services, &core.GrpcService{
-			TargetSpecifier: &core.GrpcService_EnvoyGrpc_{
-				EnvoyGrpc: &core.GrpcService_EnvoyGrpc{
-					ClusterName: c,
-				},
-			},
-		})
-	}
-	return &core.ConfigSource{
-		ConfigSourceSpecifier: &core.ConfigSource_ApiConfigSource{
-			ApiConfigSource: &core.ApiConfigSource{
-				ApiType:      core.ApiConfigSource_GRPC,
-				GrpcServices: services,
 			},
 		},
 	}

--- a/internal/envoy/config.go
+++ b/internal/envoy/config.go
@@ -19,6 +19,8 @@ package envoy
 import (
 	"io"
 	"text/template"
+
+	"github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 )
 
 // A ConfigWriter knows how to write a bootstap Envoy configuration in YAML format.
@@ -165,4 +167,22 @@ func (c *ConfigWriter) WriteYAML(w io.Writer) error {
 		return err
 	}
 	return t.Execute(w, c)
+}
+
+// ConfigSource returns a *core.ConfigSource for cluster.
+func ConfigSource(cluster string) *core.ConfigSource {
+	return &core.ConfigSource{
+		ConfigSourceSpecifier: &core.ConfigSource_ApiConfigSource{
+			ApiConfigSource: &core.ApiConfigSource{
+				ApiType: core.ApiConfigSource_GRPC,
+				GrpcServices: []*core.GrpcService{{
+					TargetSpecifier: &core.GrpcService_EnvoyGrpc_{
+						EnvoyGrpc: &core.GrpcService_EnvoyGrpc{
+							ClusterName: cluster,
+						},
+					},
+				}},
+			},
+		},
+	}
 }

--- a/internal/envoy/healthcheck.go
+++ b/internal/envoy/healthcheck.go
@@ -1,0 +1,71 @@
+// Copyright © 2018 Heptio
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package envoy
+
+import (
+	"time"
+
+	"github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
+	"github.com/gogo/protobuf/types"
+	ingressroutev1 "github.com/heptio/contour/apis/contour/v1beta1"
+)
+
+const (
+	// Default healthcheck / lb algorithm values
+	hcTimeout            = 2 * time.Second
+	hcInterval           = 10 * time.Second
+	hcUnhealthyThreshold = 3
+	hcHealthyThreshold   = 2
+	hcHost               = "contour-envoy-healthcheck"
+)
+
+// HealthCheck returns a *core.HealthCheck value.
+func HealthCheck(hc *ingressroutev1.HealthCheck) *core.HealthCheck {
+	host := hcHost
+	if hc.Host != "" {
+		host = hc.Host
+	}
+
+	// TODO(dfc) why do we need to specify our own default, what is the default
+	// that envoy applies if these fields are left nil?
+	return &core.HealthCheck{
+		Timeout:            secondsOrDefault(hc.TimeoutSeconds, hcTimeout),
+		Interval:           secondsOrDefault(hc.IntervalSeconds, hcInterval),
+		UnhealthyThreshold: countOrDefault(hc.UnhealthyThresholdCount, hcUnhealthyThreshold),
+		HealthyThreshold:   countOrDefault(hc.HealthyThresholdCount, hcHealthyThreshold),
+		HealthChecker: &core.HealthCheck_HttpHealthCheck_{
+			HttpHealthCheck: &core.HealthCheck_HttpHealthCheck{
+				Path: hc.Path,
+				Host: host,
+			},
+		},
+	}
+}
+
+func secondsOrDefault(seconds int64, def time.Duration) *time.Duration {
+	if seconds != 0 {
+		t := time.Duration(seconds) * time.Second
+		return &t
+	}
+	return &def
+}
+
+func countOrDefault(count uint32, def int) *types.UInt32Value {
+	switch count {
+	case 0:
+		return u32(def)
+	default:
+		return u32(int(count))
+	}
+}

--- a/internal/envoy/healthcheck.go
+++ b/internal/envoy/healthcheck.go
@@ -30,8 +30,8 @@ const (
 	hcHost               = "contour-envoy-healthcheck"
 )
 
-// HealthCheck returns a *core.HealthCheck value.
-func HealthCheck(hc *ingressroutev1.HealthCheck) *core.HealthCheck {
+// healthCheck returns a *core.HealthCheck value.
+func healthCheck(hc *ingressroutev1.HealthCheck) *core.HealthCheck {
 	host := hcHost
 	if hc.Host != "" {
 		host = hc.Host

--- a/internal/envoy/healthcheck_test.go
+++ b/internal/envoy/healthcheck_test.go
@@ -87,7 +87,7 @@ func TestHealthCheck(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			got := HealthCheck(tc.hc)
+			got := healthCheck(tc.hc)
 			if diff := cmp.Diff(tc.want, got); diff != "" {
 				t.Fatal(diff)
 			}

--- a/internal/envoy/healthcheck_test.go
+++ b/internal/envoy/healthcheck_test.go
@@ -1,0 +1,99 @@
+// Copyright © 2018 Heptio
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package envoy
+
+import (
+	"testing"
+	"time"
+
+	"github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
+	"github.com/google/go-cmp/cmp"
+	ingressroutev1 "github.com/heptio/contour/apis/contour/v1beta1"
+)
+
+func TestHealthCheck(t *testing.T) {
+	tests := map[string]struct {
+		hc   *ingressroutev1.HealthCheck
+		want *core.HealthCheck
+	}{
+		// this is an odd case because contour.edshealthcheck will not call envoy.HealthCheck
+		// when hc is nil, so if hc is not nil, at least one of the parameters on it must be set.
+		"blank healthcheck": {
+			hc: new(ingressroutev1.HealthCheck),
+			want: &core.HealthCheck{
+				Timeout:            duration(hcTimeout),
+				Interval:           duration(hcInterval),
+				UnhealthyThreshold: u32(3),
+				HealthyThreshold:   u32(2),
+				HealthChecker: &core.HealthCheck_HttpHealthCheck_{
+					HttpHealthCheck: &core.HealthCheck_HttpHealthCheck{
+						// TODO(dfc) this doesn't seem right
+						Host: "contour-envoy-healthcheck",
+					},
+				},
+			},
+		},
+		"healthcheck path only": {
+			hc: &ingressroutev1.HealthCheck{
+				Path: "/healthy",
+			},
+			want: &core.HealthCheck{
+				Timeout:            duration(hcTimeout),
+				Interval:           duration(hcInterval),
+				UnhealthyThreshold: u32(3),
+				HealthyThreshold:   u32(2),
+				HealthChecker: &core.HealthCheck_HttpHealthCheck_{
+					HttpHealthCheck: &core.HealthCheck_HttpHealthCheck{
+						Path: "/healthy",
+						Host: "contour-envoy-healthcheck",
+					},
+				},
+			},
+		},
+		"explicit healthcheck": {
+			hc: &ingressroutev1.HealthCheck{
+				Host:                    "foo-bar-host",
+				Path:                    "/healthy",
+				TimeoutSeconds:          99,
+				IntervalSeconds:         98,
+				UnhealthyThresholdCount: 97,
+				HealthyThresholdCount:   96,
+			},
+			want: &core.HealthCheck{
+				Timeout:            duration(99 * time.Second),
+				Interval:           duration(98 * time.Second),
+				UnhealthyThreshold: u32(97),
+				HealthyThreshold:   u32(96),
+				HealthChecker: &core.HealthCheck_HttpHealthCheck_{
+					HttpHealthCheck: &core.HealthCheck_HttpHealthCheck{
+						Path: "/healthy",
+						Host: "foo-bar-host",
+					},
+				},
+			},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := HealthCheck(tc.hc)
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Fatal(diff)
+			}
+
+		})
+	}
+}
+
+func duration(d time.Duration) *time.Duration { return &d }

--- a/internal/envoy/route.go
+++ b/internal/envoy/route.go
@@ -58,7 +58,7 @@ func WeightedClusters(services []*dag.Service) *route.WeightedCluster {
 		total += svc.Weight
 		wc.Clusters = append(wc.Clusters, &route.WeightedCluster_ClusterWeight{
 			Name:   Clustername(svc),
-			Weight: &types.UInt32Value{Value: uint32(svc.Weight)},
+			Weight: u32(svc.Weight),
 		})
 	}
 	// Check if no weights were defined, if not default to even distribution
@@ -68,9 +68,7 @@ func WeightedClusters(services []*dag.Service) *route.WeightedCluster {
 		}
 		total = len(services)
 	}
-	wc.TotalWeight = &types.UInt32Value{
-		Value: uint32(total),
-	}
+	wc.TotalWeight = u32(total)
 
 	sort.Stable(clusterWeightByName(wc.Clusters))
 	return &wc
@@ -87,3 +85,5 @@ func (c clusterWeightByName) Less(i, j int) bool {
 	return c[i].Name < c[j].Name
 
 }
+
+func u32(val int) *types.UInt32Value { return &types.UInt32Value{Value: uint32(val)} }

--- a/internal/envoy/route_test.go
+++ b/internal/envoy/route_test.go
@@ -1,0 +1,157 @@
+// Copyright © 2018 Heptio
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package envoy
+
+import (
+	"testing"
+
+	"github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
+	"github.com/google/go-cmp/cmp"
+	"github.com/heptio/contour/internal/dag"
+	"k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestWeightedClusters(t *testing.T) {
+	tests := map[string]struct {
+		services []*dag.Service
+		want     *route.WeightedCluster
+	}{
+		"multiple services w/o weights": {
+			services: []*dag.Service{{
+				Object: &v1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "kuard",
+						Namespace: "default",
+					},
+				},
+				ServicePort: &v1.ServicePort{
+					Port: 8080,
+				},
+			}, {
+				Object: &v1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "nginx",
+						Namespace: "default",
+					},
+				},
+				ServicePort: &v1.ServicePort{
+					Port: 8080,
+				},
+			}},
+			want: &route.WeightedCluster{
+				Clusters: []*route.WeightedCluster_ClusterWeight{{
+					Name:   "default/kuard/8080/da39a3ee5e",
+					Weight: u32(1),
+				}, {
+					Name:   "default/nginx/8080/da39a3ee5e",
+					Weight: u32(1),
+				}},
+				TotalWeight: u32(2),
+			},
+		},
+		"multiple weighted services": {
+			services: []*dag.Service{{
+				Object: &v1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "kuard",
+						Namespace: "default",
+					},
+				},
+				ServicePort: &v1.ServicePort{
+					Port: 8080,
+				},
+				Weight: 80,
+			}, {
+				Object: &v1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "nginx",
+						Namespace: "default",
+					},
+				},
+				ServicePort: &v1.ServicePort{
+					Port: 8080,
+				},
+				Weight: 20,
+			}},
+			want: &route.WeightedCluster{
+				Clusters: []*route.WeightedCluster_ClusterWeight{{
+					Name:   "default/kuard/8080/da39a3ee5e",
+					Weight: u32(80),
+				}, {
+					Name:   "default/nginx/8080/da39a3ee5e",
+					Weight: u32(20),
+				}},
+				TotalWeight: u32(100),
+			},
+		},
+		"multiple weighted services and one with no weight specified": {
+			services: []*dag.Service{{
+				Object: &v1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "kuard",
+						Namespace: "default",
+					},
+				},
+				ServicePort: &v1.ServicePort{
+					Port: 8080,
+				},
+				Weight: 80,
+			}, {
+				Object: &v1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "nginx",
+						Namespace: "default",
+					},
+				},
+				ServicePort: &v1.ServicePort{
+					Port: 8080,
+				},
+				Weight: 20,
+			}, {
+				Object: &v1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "notraffic",
+						Namespace: "default",
+					},
+				},
+				ServicePort: &v1.ServicePort{
+					Port: 8080,
+				},
+			}},
+			want: &route.WeightedCluster{
+				Clusters: []*route.WeightedCluster_ClusterWeight{{
+					Name:   "default/kuard/8080/da39a3ee5e",
+					Weight: u32(80),
+				}, {
+					Name:   "default/nginx/8080/da39a3ee5e",
+					Weight: u32(20),
+				}, {
+					Name:   "default/notraffic/8080/da39a3ee5e",
+					Weight: u32(0),
+				}},
+				TotalWeight: u32(100),
+			},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := WeightedClusters(tc.services)
+			if diff := cmp.Diff(got, tc.want); diff != "" {
+				t.Fatal(diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Update #708

Move more route and healthcheck envoy helpers into the internal/envoy
package. Add tests to prove they work as expected.

Signed-off-by: Dave Cheney <dave@cheney.net>