### PR TITLE
Changing StatsAddress flag from Int to String to prevent Init container crash loop.

### DIFF
--- a/cmd/contour/contour.go
+++ b/cmd/contour/contour.go
@@ -53,7 +53,7 @@ func main() {
 	path := bootstrap.Arg("path", "Configuration file.").Required().String()
 	bootstrap.Flag("admin-address", "Envoy admin interface address").StringVar(&config.AdminAddress)
 	bootstrap.Flag("admin-port", "Envoy admin interface port").IntVar(&config.AdminPort)
-	bootstrap.Flag("stats-address", "Envoy /stats interface address").IntVar(&config.StatsAddress)
+	bootstrap.Flag("stats-address", "Envoy /stats interface address").StringVar(&config.StatsAddress)
 	bootstrap.Flag("stats-port", "Envoy /stats interface port").IntVar(&config.StatsPort)
 	bootstrap.Flag("xds-address", "xDS gRPC API address").StringVar(&config.XDSAddress)
 	bootstrap.Flag("xds-port", "xDS gRPC API port").IntVar(&config.XDSGRPCPort)

--- a/deployment/deployment-grpc-v2/02-contour.yaml
+++ b/deployment/deployment-grpc-v2/02-contour.yaml
@@ -16,7 +16,7 @@ spec:
         app: contour
       annotations:
         prometheus.io/scrape: "true"
-        prometheus.io/port: "9001"
+        prometheus.io/port: "8002"
         prometheus.io/path: "/stats"
         prometheus.io/format: "prometheus"
     spec:
@@ -48,7 +48,14 @@ spec:
         imagePullPolicy: Always
         name: envoy-initconfig
         command: ["contour"]
-        args: ["bootstrap", "/config/contour.yaml"]
+        args:
+        - bootstrap
+        # Uncomment the statsd-enable to enable prometheus metrics
+        #- --statsd-enable
+        # Uncomment to set a custom stats emission address and port
+        #- --stats-address=0.0.0.0
+        #- --stats-port=8002
+        - /config/contour.yaml
         volumeMounts:
         - name: contour-config
           mountPath: /config

--- a/deployment/render/deployment-rbac.yaml
+++ b/deployment/render/deployment-rbac.yaml
@@ -171,7 +171,7 @@ spec:
         app: contour
       annotations:
         prometheus.io/scrape: "true"
-        prometheus.io/port: "9001"
+        prometheus.io/port: "8002"
         prometheus.io/path: "/stats"
         prometheus.io/format: "prometheus"
     spec:
@@ -203,7 +203,14 @@ spec:
         imagePullPolicy: Always
         name: envoy-initconfig
         command: ["contour"]
-        args: ["bootstrap", "/config/contour.yaml"]
+        args:
+        - bootstrap
+        # Uncomment the statsd-enable to enable prometheus metrics
+        #- --statsd-enable
+        # Uncomment to set a custom stats emission address and port
+        #- --stats-address=0.0.0.0
+        #- --stats-port=8002
+        - /config/contour.yaml
         volumeMounts:
         - name: contour-config
           mountPath: /config

--- a/internal/envoy/config.go
+++ b/internal/envoy/config.go
@@ -39,7 +39,7 @@ type ConfigWriter struct {
 
 	// StatsAddress is the address that the /stats path will listen on.
 	// Defaults to 0.0.0.0 and is only enabled if StatsdEnabled is true.
-	StatsAddress int
+	StatsAddress string
 
 	// StatsPort is the port that the /stats path will listen on.
 	// Defaults to 8002 and is only enabled if StatsdEnabled is true.

--- a/internal/envoy/config_test.go
+++ b/internal/envoy/config_test.go
@@ -18,7 +18,6 @@ import (
 	"testing"
 )
 
-
 func TestConfigWriter_WriteYAML(t *testing.T) {
 	tests := map[string]struct {
 		ConfigWriter
@@ -169,102 +168,11 @@ admin:
       port_value: 9001
 `,
 		},
-		"stats address": {
+		"stats address and port defined": {
 			ConfigWriter: ConfigWriter{
 				StatsdEnabled: true,
-				StatsAddress: "1.2.3.4",
-			},
-			want: `dynamic_resources:
-  lds_config:
-    api_config_source:
-      api_type: GRPC
-      grpc_services:
-      - envoy_grpc:
-          cluster_name: contour
-  cds_config:
-    api_config_source:
-      api_type: GRPC
-      grpc_services:
-      - envoy_grpc:
-          cluster_name: contour
-static_resources:
-  clusters:
-  - name: contour
-    connect_timeout: { seconds: 5 }
-    type: STRICT_DNS
-    hosts:
-    - socket_address:
-        address: 127.0.0.1
-        port_value: 8001
-    lb_policy: ROUND_ROBIN
-    http2_protocol_options: {}
-    circuit_breakers:
-      thresholds:
-        - priority: high
-          max_connections: 100000
-          max_pending_requests: 100000
-          max_requests: 60000000
-          max_retries: 50
-        - priority: default
-          max_connections: 100000
-          max_pending_requests: 100000
-          max_requests: 60000000
-          max_retries: 50
-  - name: service_stats
-    connect_timeout: 0.250s
-    type: LOGICAL_DNS
-    lb_policy: ROUND_ROBIN
-    hosts:
-      - socket_address:
-          protocol: TCP
-          address: 127.0.0.1
-          port_value: 9001
-  listeners:
-    - address:
-        socket_address:
-          protocol: TCP
-          address: 1.2.3.4
-          port_value: 8002
-      filter_chains:
-        - filters:
-            - name: envoy.http_connection_manager
-              config:
-                codec_type: AUTO
-                stat_prefix: stats
-                route_config:
-                  virtual_hosts:
-                    - name: backend
-                      domains:
-                        - "*"
-                      routes:
-                        - match:
-                            prefix: /stats
-                          route:
-                            cluster: service_stats
-                http_filters:
-                  - name: envoy.router
-                    config:
-stats_sinks:
-  - name: envoy.statsd
-    config:
-      address:
-        socket_address:
-          protocol: UDP
-          address: 127.0.0.1
-          port_value: 9125
-admin:
-  access_log_path: /dev/null
-  address:
-    socket_address:
-      address: 127.0.0.1
-      port_value: 9001
-`,
-		},
-		"stats port": {
-			ConfigWriter: ConfigWriter{
-				StatsdEnabled: true,
-				StatsAddress: "1.2.3.4",
-				StatsPort: 1234,
+				StatsAddress:  "1.2.3.4",
+				StatsPort:     1234,
 			},
 			want: `dynamic_resources:
   lds_config:

--- a/internal/envoy/config_test.go
+++ b/internal/envoy/config_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 )
 
+
 func TestConfigWriter_WriteYAML(t *testing.T) {
 	tests := map[string]struct {
 		ConfigWriter
@@ -78,7 +79,7 @@ admin:
       port_value: 9001
 `,
 		},
-		"statsd endabled": {
+		"statsd enabled": {
 			ConfigWriter: ConfigWriter{
 				StatsdEnabled: true,
 			},
@@ -133,6 +134,189 @@ static_resources:
           protocol: TCP
           address: 0.0.0.0
           port_value: 8002
+      filter_chains:
+        - filters:
+            - name: envoy.http_connection_manager
+              config:
+                codec_type: AUTO
+                stat_prefix: stats
+                route_config:
+                  virtual_hosts:
+                    - name: backend
+                      domains:
+                        - "*"
+                      routes:
+                        - match:
+                            prefix: /stats
+                          route:
+                            cluster: service_stats
+                http_filters:
+                  - name: envoy.router
+                    config:
+stats_sinks:
+  - name: envoy.statsd
+    config:
+      address:
+        socket_address:
+          protocol: UDP
+          address: 127.0.0.1
+          port_value: 9125
+admin:
+  access_log_path: /dev/null
+  address:
+    socket_address:
+      address: 127.0.0.1
+      port_value: 9001
+`,
+		},
+		"stats address": {
+			ConfigWriter: ConfigWriter{
+				StatsdEnabled: true,
+				StatsAddress: "1.2.3.4",
+			},
+			want: `dynamic_resources:
+  lds_config:
+    api_config_source:
+      api_type: GRPC
+      grpc_services:
+      - envoy_grpc:
+          cluster_name: contour
+  cds_config:
+    api_config_source:
+      api_type: GRPC
+      grpc_services:
+      - envoy_grpc:
+          cluster_name: contour
+static_resources:
+  clusters:
+  - name: contour
+    connect_timeout: { seconds: 5 }
+    type: STRICT_DNS
+    hosts:
+    - socket_address:
+        address: 127.0.0.1
+        port_value: 8001
+    lb_policy: ROUND_ROBIN
+    http2_protocol_options: {}
+    circuit_breakers:
+      thresholds:
+        - priority: high
+          max_connections: 100000
+          max_pending_requests: 100000
+          max_requests: 60000000
+          max_retries: 50
+        - priority: default
+          max_connections: 100000
+          max_pending_requests: 100000
+          max_requests: 60000000
+          max_retries: 50
+  - name: service_stats
+    connect_timeout: 0.250s
+    type: LOGICAL_DNS
+    lb_policy: ROUND_ROBIN
+    hosts:
+      - socket_address:
+          protocol: TCP
+          address: 127.0.0.1
+          port_value: 9001
+  listeners:
+    - address:
+        socket_address:
+          protocol: TCP
+          address: 1.2.3.4
+          port_value: 8002
+      filter_chains:
+        - filters:
+            - name: envoy.http_connection_manager
+              config:
+                codec_type: AUTO
+                stat_prefix: stats
+                route_config:
+                  virtual_hosts:
+                    - name: backend
+                      domains:
+                        - "*"
+                      routes:
+                        - match:
+                            prefix: /stats
+                          route:
+                            cluster: service_stats
+                http_filters:
+                  - name: envoy.router
+                    config:
+stats_sinks:
+  - name: envoy.statsd
+    config:
+      address:
+        socket_address:
+          protocol: UDP
+          address: 127.0.0.1
+          port_value: 9125
+admin:
+  access_log_path: /dev/null
+  address:
+    socket_address:
+      address: 127.0.0.1
+      port_value: 9001
+`,
+		},
+		"stats port": {
+			ConfigWriter: ConfigWriter{
+				StatsdEnabled: true,
+				StatsAddress: "1.2.3.4",
+				StatsPort: 1234,
+			},
+			want: `dynamic_resources:
+  lds_config:
+    api_config_source:
+      api_type: GRPC
+      grpc_services:
+      - envoy_grpc:
+          cluster_name: contour
+  cds_config:
+    api_config_source:
+      api_type: GRPC
+      grpc_services:
+      - envoy_grpc:
+          cluster_name: contour
+static_resources:
+  clusters:
+  - name: contour
+    connect_timeout: { seconds: 5 }
+    type: STRICT_DNS
+    hosts:
+    - socket_address:
+        address: 127.0.0.1
+        port_value: 8001
+    lb_policy: ROUND_ROBIN
+    http2_protocol_options: {}
+    circuit_breakers:
+      thresholds:
+        - priority: high
+          max_connections: 100000
+          max_pending_requests: 100000
+          max_requests: 60000000
+          max_retries: 50
+        - priority: default
+          max_connections: 100000
+          max_pending_requests: 100000
+          max_requests: 60000000
+          max_retries: 50
+  - name: service_stats
+    connect_timeout: 0.250s
+    type: LOGICAL_DNS
+    lb_policy: ROUND_ROBIN
+    hosts:
+      - socket_address:
+          protocol: TCP
+          address: 127.0.0.1
+          port_value: 9001
+  listeners:
+    - address:
+        socket_address:
+          protocol: TCP
+          address: 1.2.3.4
+          port_value: 1234
       filter_chains:
         - filters:
             - name: envoy.http_connection_manager


### PR DESCRIPTION
And fixing deployment defaults for prometheus scraping to match reality.

This is a small bugfix, so didn't file an issue. Let me know if that's not appropriate.

All tests pass. Built and tested via docker and confirmed that:
- init container is no longer crash looping with the '--stats-address=0.0.0.0' flag set (it did previously, even though 0.0.0.0 is the default)
- the generated contour.yaml file produces the correct output.
- prometheus when configured with port 8002 can scrap metrics.