### PR TITLE
internal/e2e: remove context.WithTimeout from steam* helpers

### DIFF
--- a/internal/e2e/cds_test.go
+++ b/internal/e2e/cds_test.go
@@ -745,13 +745,8 @@ func serviceWithAnnotations(ns, name string, annotations map[string]string, port
 func streamCDS(t *testing.T, cc *grpc.ClientConn, rn ...string) *v2.DiscoveryResponse {
 	t.Helper()
 	rds := v2.NewClusterDiscoveryServiceClient(cc)
-	ctx := context.Background()
-	ctx, cancel := context.WithTimeout(ctx, 100*time.Millisecond)
-	defer cancel()
-	st, err := rds.StreamClusters(ctx)
-	if err != nil {
-		t.Fatal(err)
-	}
+	st, err := rds.StreamClusters(context.TODO())
+	check(t, err)
 	return stream(t, st, &v2.DiscoveryRequest{
 		TypeUrl:       clusterType,
 		ResourceNames: rn,

--- a/internal/e2e/eds_test.go
+++ b/internal/e2e/eds_test.go
@@ -16,7 +16,6 @@ package e2e
 import (
 	"context"
 	"testing"
-	"time"
 
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
@@ -259,13 +258,8 @@ func TestIssue602(t *testing.T) {
 func streamEDS(t *testing.T, cc *grpc.ClientConn, rn ...string) *v2.DiscoveryResponse {
 	t.Helper()
 	rds := v2.NewEndpointDiscoveryServiceClient(cc)
-	ctx := context.Background()
-	ctx, cancel := context.WithTimeout(ctx, 100*time.Millisecond)
-	defer cancel()
-	st, err := rds.StreamEndpoints(ctx)
-	if err != nil {
-		t.Fatal(err)
-	}
+	st, err := rds.StreamEndpoints(context.TODO())
+	check(t, err)
 	return stream(t, st, &v2.DiscoveryRequest{
 		TypeUrl:       endpointType,
 		ResourceNames: rn,

--- a/internal/e2e/lds_test.go
+++ b/internal/e2e/lds_test.go
@@ -17,7 +17,6 @@ import (
 	"bytes"
 	"context"
 	"testing"
-	"time"
 
 	ingressroutev1 "github.com/heptio/contour/apis/contour/v1beta1"
 
@@ -993,13 +992,8 @@ func TestIngressRouteHTTPS(t *testing.T) {
 func streamLDS(t *testing.T, cc *grpc.ClientConn, rn ...string) *v2.DiscoveryResponse {
 	t.Helper()
 	rds := v2.NewListenerDiscoveryServiceClient(cc)
-	ctx := context.Background()
-	ctx, cancel := context.WithTimeout(ctx, 100*time.Millisecond)
-	defer cancel()
-	st, err := rds.StreamListeners(ctx)
-	if err != nil {
-		t.Fatal(err)
-	}
+	st, err := rds.StreamListeners(context.TODO())
+	check(t, err)
 	return stream(t, st, &v2.DiscoveryRequest{
 		TypeUrl:       listenerType,
 		ResourceNames: rn,

--- a/internal/e2e/rds_test.go
+++ b/internal/e2e/rds_test.go
@@ -1912,13 +1912,8 @@ func assertRDS(t *testing.T, cc *grpc.ClientConn, ingress_http, ingress_https []
 func streamRDS(t *testing.T, cc *grpc.ClientConn, rn ...string) *v2.DiscoveryResponse {
 	t.Helper()
 	rds := v2.NewRouteDiscoveryServiceClient(cc)
-	ctx := context.Background()
-	ctx, cancel := context.WithTimeout(ctx, 100*time.Millisecond)
-	defer cancel()
-	st, err := rds.StreamRoutes(ctx)
-	if err != nil {
-		t.Fatal(err)
-	}
+	st, err := rds.StreamRoutes(context.TODO())
+	check(t, err)
 	return stream(t, st, &v2.DiscoveryRequest{
 		TypeUrl:       routeType,
 		ResourceNames: rn,


### PR DESCRIPTION
Updates #705

The 100ms timeout was too short in some circumstances; maybe there are
clock skew issues on the CI host.

Rather than playing the "let's increase the timeout and hope" game,
remove the timeout. There are no circumstances where the e2e tests do
not expect a result so if one goes missing this is a serious bug.

Signed-off-by: Dave Cheney <dave@cheney.net>