### PR TITLE
Implement pathRewrite for IngressRoute 

### DIFF
--- a/apis/contour/v1beta1/ingressroute.go
+++ b/apis/contour/v1beta1/ingressroute.go
@@ -61,6 +61,8 @@ type Route struct {
 	// Allow this path to respond to insecure requests over HTTP which are normally
 	// not permitted when a `virtualhost.tls` block is present.
 	PermitInsecure bool `json:"permitInsecure,omitempty"`
+	// Indicates that during forwarding, the matched prefix (or path) should be swapped with this value
+	PrefixRewrite string `json:"prefixRewrite,omitempty"`
 }
 
 // Service defines an upstream to proxy traffic to

--- a/docs/ingressroute.md
+++ b/docs/ingressroute.md
@@ -528,6 +528,31 @@ spec:
           port: 80
 ```
 
+#### Prefix Rewrite Support
+
+Indicates that during forwarding, the matched prefix (or path) should be swapped with this value. This option allows application URLs to be rooted at a different path from those exposed at the reverse proxy layer. TThe original path before rewrite will be placed into the into the `x-envoy-original-path` header.
+
+```yaml
+apiVersion: contour.heptio.com/v1beta1
+kind: IngressRoute
+metadata:
+  name: app
+  namespace: default
+spec:
+  virtualhost:
+    fqdn: app.example.com
+  routes:
+    - match: /
+      services:
+        - name: app
+          port: 80
+    - match: /service2
+      prefixRewrite: "/" # Setting this rewrites the request from `/service2` to `/`
+      services:
+        - name: app-service
+          port: 80
+```
+
 #### Permit Insecure
 
 IngressRoutes support allowing HTTP alongside HTTPS. This way, the path responds to insecure requests over HTTP which are normally not permitted when a `virtualhost.tls` block is present.

--- a/internal/contour/route.go
+++ b/internal/contour/route.go
@@ -263,6 +263,10 @@ func actionroute(r *dag.Route, services []*dag.Service) *route.Route_Route {
 		rr.Route.Timeout = &timeout
 	}
 
+	if len(r.PrefixRewrite) > 0 {
+		rr.Route.PrefixRewrite = r.PrefixRewrite
+	}
+
 	return &rr
 }
 

--- a/internal/dag/builder.go
+++ b/internal/dag/builder.go
@@ -538,10 +538,11 @@ func (b *builder) processIngressRoute(ir *ingressroutev1.IngressRoute, prefixMat
 			enforceTLSRoute := routeEnforceTLS(enforceTLS, route.PermitInsecure)
 
 			r := &Route{
-				Prefix:       route.Match,
-				object:       ir,
-				Websocket:    route.EnableWebsockets,
-				HTTPSUpgrade: enforceTLSRoute,
+				Prefix:        route.Match,
+				object:        ir,
+				Websocket:     route.EnableWebsockets,
+				HTTPSUpgrade:  enforceTLSRoute,
+				PrefixRewrite: route.PrefixRewrite,
 			}
 			for _, s := range route.Services {
 				if s.Port < 1 || s.Port > 65535 {

--- a/internal/dag/dag.go
+++ b/internal/dag/dag.go
@@ -78,6 +78,9 @@ type Route struct {
 	// PerTryTimeout specifies the timeout per retry attempt.
 	// Ignored if RetryOn is blank.
 	PerTryTimeout time.Duration
+
+	// Indicates that during forwarding, the matched prefix (or path) should be swapped with this value
+	PrefixRewrite string
 }
 
 func (r *Route) addService(s *Service) {


### PR DESCRIPTION
Adds a `pathRewrite` parameter to the IngressRoute.Route struct which Indicates that during forwarding, the matched prefix (or path) should be swapped with this value.

Updates #64 

Signed-off-by: Steve Sloka <steves@heptio.com>