### PR TITLE
internal/contour: move http conn manager filter to internal/envoy

### DIFF
--- a/internal/contour/listener_test.go
+++ b/internal/contour/listener_test.go
@@ -60,7 +60,7 @@ func TestListenerVisit(t *testing.T) {
 					Name:    ENVOY_HTTP_LISTENER,
 					Address: socketaddress("0.0.0.0", 8080),
 					FilterChains: []listener.FilterChain{
-						filterchain(false, httpfilter(ENVOY_HTTP_LISTENER, DEFAULT_HTTP_ACCESS_LOG)),
+						filterchain(false, envoy.HTTPConnectionManager(ENVOY_HTTP_LISTENER, DEFAULT_HTTP_ACCESS_LOG)),
 					},
 				},
 			},
@@ -94,7 +94,7 @@ func TestListenerVisit(t *testing.T) {
 					Name:    ENVOY_HTTP_LISTENER,
 					Address: socketaddress("0.0.0.0", 8080),
 					FilterChains: []listener.FilterChain{
-						filterchain(false, httpfilter(ENVOY_HTTP_LISTENER, DEFAULT_HTTP_ACCESS_LOG)),
+						filterchain(false, envoy.HTTPConnectionManager(ENVOY_HTTP_LISTENER, DEFAULT_HTTP_ACCESS_LOG)),
 					},
 				},
 			},
@@ -130,7 +130,7 @@ func TestListenerVisit(t *testing.T) {
 					Name:    ENVOY_HTTP_LISTENER,
 					Address: socketaddress("0.0.0.0", 8080),
 					FilterChains: []listener.FilterChain{
-						filterchain(false, httpfilter(ENVOY_HTTP_LISTENER, DEFAULT_HTTP_ACCESS_LOG)),
+						filterchain(false, envoy.HTTPConnectionManager(ENVOY_HTTP_LISTENER, DEFAULT_HTTP_ACCESS_LOG)),
 					},
 				},
 				ENVOY_HTTPS_LISTENER: {
@@ -142,7 +142,7 @@ func TestListenerVisit(t *testing.T) {
 						},
 						TlsContext: tlscontext(secretdata("certificate", "key"), auth.TlsParameters_TLSv1_1, "h2", "http/1.1"),
 						Filters: []listener.Filter{
-							httpfilter(ENVOY_HTTPS_LISTENER, DEFAULT_HTTPS_ACCESS_LOG),
+							envoy.HTTPConnectionManager(ENVOY_HTTPS_LISTENER, DEFAULT_HTTPS_ACCESS_LOG),
 						},
 					}},
 					ListenerFilters: []listener.ListenerFilter{
@@ -182,7 +182,7 @@ func TestListenerVisit(t *testing.T) {
 					Name:    ENVOY_HTTP_LISTENER,
 					Address: socketaddress("0.0.0.0", 8080),
 					FilterChains: []listener.FilterChain{
-						filterchain(false, httpfilter(ENVOY_HTTP_LISTENER, DEFAULT_HTTP_ACCESS_LOG)),
+						filterchain(false, envoy.HTTPConnectionManager(ENVOY_HTTP_LISTENER, DEFAULT_HTTP_ACCESS_LOG)),
 					},
 				},
 			},
@@ -226,7 +226,7 @@ func TestListenerVisit(t *testing.T) {
 					Name:    ENVOY_HTTP_LISTENER,
 					Address: socketaddress("0.0.0.0", 8080),
 					FilterChains: []listener.FilterChain{
-						filterchain(false, httpfilter(ENVOY_HTTP_LISTENER, DEFAULT_HTTP_ACCESS_LOG)),
+						filterchain(false, envoy.HTTPConnectionManager(ENVOY_HTTP_LISTENER, DEFAULT_HTTP_ACCESS_LOG)),
 					},
 				},
 				ENVOY_HTTPS_LISTENER: {
@@ -238,7 +238,7 @@ func TestListenerVisit(t *testing.T) {
 						},
 						TlsContext: tlscontext(secretdata("certificate", "key"), auth.TlsParameters_TLSv1_1, "h2", "http/1.1"),
 						Filters: []listener.Filter{
-							httpfilter(ENVOY_HTTPS_LISTENER, DEFAULT_HTTPS_ACCESS_LOG),
+							envoy.HTTPConnectionManager(ENVOY_HTTPS_LISTENER, DEFAULT_HTTPS_ACCESS_LOG),
 						},
 					}},
 					ListenerFilters: []listener.ListenerFilter{
@@ -306,7 +306,7 @@ func TestListenerVisit(t *testing.T) {
 						},
 						TlsContext: tlscontext(secretdata("certificate", "key"), auth.TlsParameters_TLSv1_1, "h2", "http/1.1"),
 						Filters: []listener.Filter{
-							httpfilter(ENVOY_HTTPS_LISTENER, DEFAULT_HTTPS_ACCESS_LOG),
+							envoy.HTTPConnectionManager(ENVOY_HTTPS_LISTENER, DEFAULT_HTTPS_ACCESS_LOG),
 						},
 					}},
 					ListenerFilters: []listener.ListenerFilter{
@@ -352,7 +352,7 @@ func TestListenerVisit(t *testing.T) {
 					Name:    ENVOY_HTTP_LISTENER,
 					Address: socketaddress("127.0.0.100", 9100),
 					FilterChains: []listener.FilterChain{
-						filterchain(false, httpfilter(ENVOY_HTTP_LISTENER, DEFAULT_HTTP_ACCESS_LOG)),
+						filterchain(false, envoy.HTTPConnectionManager(ENVOY_HTTP_LISTENER, DEFAULT_HTTP_ACCESS_LOG)),
 					},
 				},
 				ENVOY_HTTPS_LISTENER: {
@@ -364,7 +364,7 @@ func TestListenerVisit(t *testing.T) {
 						},
 						TlsContext: tlscontext(secretdata("certificate", "key"), auth.TlsParameters_TLSv1_1, "h2", "http/1.1"),
 						Filters: []listener.Filter{
-							httpfilter(ENVOY_HTTPS_LISTENER, DEFAULT_HTTPS_ACCESS_LOG),
+							envoy.HTTPConnectionManager(ENVOY_HTTPS_LISTENER, DEFAULT_HTTPS_ACCESS_LOG),
 						},
 					}},
 					ListenerFilters: []listener.ListenerFilter{
@@ -407,7 +407,7 @@ func TestListenerVisit(t *testing.T) {
 					Name:    ENVOY_HTTP_LISTENER,
 					Address: socketaddress("0.0.0.0", 8080),
 					FilterChains: []listener.FilterChain{
-						filterchain(true, httpfilter(ENVOY_HTTP_LISTENER, DEFAULT_HTTP_ACCESS_LOG)),
+						filterchain(true, envoy.HTTPConnectionManager(ENVOY_HTTP_LISTENER, DEFAULT_HTTP_ACCESS_LOG)),
 					},
 				},
 				ENVOY_HTTPS_LISTENER: {
@@ -419,7 +419,7 @@ func TestListenerVisit(t *testing.T) {
 						},
 						TlsContext: tlscontext(secretdata("certificate", "key"), auth.TlsParameters_TLSv1_1, "h2", "http/1.1"),
 						Filters: []listener.Filter{
-							httpfilter(ENVOY_HTTPS_LISTENER, DEFAULT_HTTPS_ACCESS_LOG),
+							envoy.HTTPConnectionManager(ENVOY_HTTPS_LISTENER, DEFAULT_HTTPS_ACCESS_LOG),
 						},
 						UseProxyProto: bv(true),
 					}},

--- a/internal/envoy/listener.go
+++ b/internal/envoy/listener.go
@@ -25,3 +25,67 @@ func TLSInspector() listener.ListenerFilter {
 		Config: new(types.Struct),
 	}
 }
+
+// HTTPConnectionManager creates a new HTTP Connection Manager filter
+// for the supplied route and access log.
+func HTTPConnectionManager(routename, accessLogPath string) listener.Filter {
+	return listener.Filter{
+		Name: "envoy.http_connection_manager",
+		Config: &types.Struct{
+			Fields: map[string]*types.Value{
+				"stat_prefix": sv(routename),
+				"rds": st(map[string]*types.Value{
+					"route_config_name": sv(routename),
+					"config_source": st(map[string]*types.Value{
+						"api_config_source": st(map[string]*types.Value{
+							"api_type": sv("GRPC"),
+							"grpc_services": lv(
+								st(map[string]*types.Value{
+									"envoy_grpc": st(map[string]*types.Value{
+										"cluster_name": sv("contour"),
+									}),
+								}),
+							),
+						}),
+					}),
+				}),
+				"http_filters": lv(
+					st(map[string]*types.Value{
+						"name": sv("envoy.gzip"),
+					}),
+					st(map[string]*types.Value{
+						"name": sv("envoy.grpc_web"),
+					}),
+					st(map[string]*types.Value{
+						"name": sv("envoy.router"),
+					}),
+				),
+				"use_remote_address": {Kind: &types.Value_BoolValue{BoolValue: true}}, // TODO(jbeda) should this ever be false?
+				"access_log":         accesslog(accessLogPath),
+			},
+		},
+	}
+}
+
+func accesslog(path string) *types.Value {
+	return lv(
+		st(map[string]*types.Value{
+			"name": sv("envoy.file_access_log"),
+			"config": st(map[string]*types.Value{
+				"path": sv(path),
+			}),
+		}),
+	)
+}
+
+func sv(s string) *types.Value {
+	return &types.Value{Kind: &types.Value_StringValue{StringValue: s}}
+}
+
+func st(m map[string]*types.Value) *types.Value {
+	return &types.Value{Kind: &types.Value_StructValue{StructValue: &types.Struct{Fields: m}}}
+}
+
+func lv(v ...*types.Value) *types.Value {
+	return &types.Value{Kind: &types.Value_ListValue{ListValue: &types.ListValue{Values: v}}}
+}


### PR DESCRIPTION
Updates #537
Updates #708

Move contour.httpfilter to envoy.HTTPConnectionManager.

Signed-off-by: Dave Cheney <dave@cheney.net>