### PR TITLE
internal/envoy: enable HTTP/1.0 support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,3 +2,4 @@
 /vendor
 /_integration
 /hack
+/contour

--- a/internal/e2e/lds_test.go
+++ b/internal/e2e/lds_test.go
@@ -1084,6 +1084,9 @@ func httpfilter(routename string) listener.Filter {
 					RouteConfigName: routename,
 				},
 			},
+			HttpProtocolOptions: &core.Http1ProtocolOptions{
+				AcceptHttp_10: true,
+			},
 			AccessLog: []*accesslog.AccessLog{{
 				Name:   "envoy.file_access_log",
 				Config: messageToStruct(fileAccessLog("/dev/stdout")),

--- a/internal/envoy/listener.go
+++ b/internal/envoy/listener.go
@@ -60,8 +60,11 @@ func HTTPConnectionManager(routename, accessLogPath string) listener.Filter {
 						"name": sv("envoy.router"),
 					}),
 				),
-				"use_remote_address": {Kind: &types.Value_BoolValue{BoolValue: true}}, // TODO(jbeda) should this ever be false?
+				"http_protocol_options": st(map[string]*types.Value{
+					"accept_http_10": {Kind: &types.Value_BoolValue{BoolValue: true}},
+				}),
 				"access_log":         accesslog(accessLogPath),
+				"use_remote_address": {Kind: &types.Value_BoolValue{BoolValue: true}}, // TODO(jbeda) should this ever be false?
 			},
 		},
 	}


### PR DESCRIPTION
Fixes #537

This PR enables Envoy's support for HTTP/1.0 requests, with limitations.

The limitations are:

- There is no support for HTTP/1.0 requests which lack a Host: header.
- There is no support for backend clusters which only talk HTTP/1.0

Signed-off-by: Dave Cheney <dave@cheney.net>