### PR TITLE
internal/contour: move websocket handling to envoy.RouteRoute

### DIFF
--- a/internal/contour/route.go
+++ b/internal/contour/route.go
@@ -203,8 +203,7 @@ func (l longestRouteFirst) Less(i, j int) bool {
 // action computes the cluster route action, a *route.Route_route for the
 // supplied ingress and backend.
 func actionroute(r *dag.Route, services []*dag.Service) *route.Route_Route {
-	rr := envoy.RouteRoute(services)
-	rr.Route.UseWebsocket = bv(r.Websocket)
+	rr := envoy.RouteRoute(r, services)
 
 	if r.RetryOn != "" {
 		rr.Route.RetryPolicy = &route.RouteAction_RetryPolicy{

--- a/internal/envoy/route_test.go
+++ b/internal/envoy/route_test.go
@@ -17,11 +17,149 @@ import (
 	"testing"
 
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
+	"github.com/gogo/protobuf/types"
 	"github.com/google/go-cmp/cmp"
 	"github.com/heptio/contour/internal/dag"
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 )
+
+func TestRouteRoute(t *testing.T) {
+	s1 := &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "kuard",
+			Namespace: "default",
+		},
+		Spec: v1.ServiceSpec{
+			Ports: []v1.ServicePort{{
+				Name:       "http",
+				Protocol:   "TCP",
+				Port:       8080,
+				TargetPort: intstr.FromInt(8080),
+			}},
+		},
+	}
+	tests := map[string]struct {
+		route    *dag.Route
+		services []*dag.Service
+		want     route.Route_Route
+	}{
+		"simple": {
+			route: &dag.Route{
+				Prefix: "/",
+			},
+			services: []*dag.Service{{
+				Object:      s1,
+				ServicePort: &s1.Spec.Ports[0],
+			}},
+			want: route.Route_Route{
+				Route: &route.RouteAction{
+					ClusterSpecifier: &route.RouteAction_Cluster{
+						Cluster: "default/kuard/8080/da39a3ee5e",
+					},
+					RequestHeadersToAdd: headers(
+						appendHeader("x-request-start", "t=%START_TIME(%s.%3f)%"),
+					),
+				},
+			},
+		},
+		"websocket": {
+			route: &dag.Route{
+				Prefix:    "/",
+				Websocket: true,
+			},
+			services: []*dag.Service{{
+				Object:      s1,
+				ServicePort: &s1.Spec.Ports[0],
+			}},
+			want: route.Route_Route{
+				Route: &route.RouteAction{
+					ClusterSpecifier: &route.RouteAction_Cluster{
+						Cluster: "default/kuard/8080/da39a3ee5e",
+					},
+					RequestHeadersToAdd: headers(
+						appendHeader("x-request-start", "t=%START_TIME(%s.%3f)%"),
+					),
+					UseWebsocket: &types.BoolValue{Value: true},
+				},
+			},
+		},
+		"multiple": {
+			route: &dag.Route{
+				Prefix: "/",
+			},
+			services: []*dag.Service{{
+				Object:      s1,
+				ServicePort: &s1.Spec.Ports[0],
+				Weight:      90,
+			}, {
+				Object:      s1, // it's valid to mention the same service several times per route.
+				ServicePort: &s1.Spec.Ports[0],
+			}},
+			want: route.Route_Route{
+				Route: &route.RouteAction{
+					ClusterSpecifier: &route.RouteAction_WeightedClusters{
+						WeightedClusters: &route.WeightedCluster{
+							Clusters: []*route.WeightedCluster_ClusterWeight{{
+								Name:                "default/kuard/8080/da39a3ee5e",
+								Weight:              u32(0),
+								RequestHeadersToAdd: headers(appendHeader("x-request-start", "t=%START_TIME(%s.%3f)%")),
+							}, {
+								Name:                "default/kuard/8080/da39a3ee5e",
+								Weight:              u32(90),
+								RequestHeadersToAdd: headers(appendHeader("x-request-start", "t=%START_TIME(%s.%3f)%")),
+							}},
+							TotalWeight: u32(90),
+						},
+					},
+				},
+			},
+		},
+		"multiple websocket": {
+			route: &dag.Route{
+				Prefix:    "/",
+				Websocket: true,
+			},
+			services: []*dag.Service{{
+				Object:      s1,
+				ServicePort: &s1.Spec.Ports[0],
+				Weight:      90,
+			}, {
+				Object:      s1, // it's valid to mention the same service several times per route.
+				ServicePort: &s1.Spec.Ports[0],
+			}},
+			want: route.Route_Route{
+				Route: &route.RouteAction{
+					ClusterSpecifier: &route.RouteAction_WeightedClusters{
+						WeightedClusters: &route.WeightedCluster{
+							Clusters: []*route.WeightedCluster_ClusterWeight{{
+								Name:                "default/kuard/8080/da39a3ee5e",
+								Weight:              u32(0),
+								RequestHeadersToAdd: headers(appendHeader("x-request-start", "t=%START_TIME(%s.%3f)%")),
+							}, {
+								Name:                "default/kuard/8080/da39a3ee5e",
+								Weight:              u32(90),
+								RequestHeadersToAdd: headers(appendHeader("x-request-start", "t=%START_TIME(%s.%3f)%")),
+							}},
+							TotalWeight: u32(90),
+						},
+					},
+					UseWebsocket: &types.BoolValue{Value: true},
+				},
+			},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := RouteRoute(tc.route, tc.services)
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Fatal(diff)
+			}
+		})
+	}
+}
 
 func TestWeightedClusters(t *testing.T) {
 	tests := map[string]struct {
@@ -155,7 +293,7 @@ func TestWeightedClusters(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			got := WeightedClusters(tc.services)
+			got := weightedClusters(tc.services)
 			if diff := cmp.Diff(got, tc.want); diff != "" {
 				t.Fatal(diff)
 			}


### PR DESCRIPTION
Updates #708

Move handling of websocket enabled routes from contour.actionroute to
envoy.RouteRoute.

Signed-off-by: Dave Cheney <dave@cheney.net>