### PR TITLE
deployment: Added preStop hook to stop Envoy from receiving new requests

### DIFF
--- a/deployment/deployment-grpc-v2/02-contour.yaml
+++ b/deployment/deployment-grpc-v2/02-contour.yaml
@@ -49,6 +49,10 @@ spec:
         volumeMounts:
         - name: contour-config
           mountPath: /config
+        lifecycle:
+          preStop:
+            exec:
+              command: ["wget", "-qO-", "http://localhost:9001/healthcheck/fail"] 
       initContainers:
       - image: gcr.io/heptio-images/contour:master
         imagePullPolicy: Always

--- a/deployment/ds-grpc-v2/02-contour.yaml
+++ b/deployment/ds-grpc-v2/02-contour.yaml
@@ -50,6 +50,10 @@ spec:
         volumeMounts:
         - name: contour-config
           mountPath: /config
+        lifecycle:
+          preStop:
+            exec:
+              command: ["wget", "-qO-", "http://localhost:9001/healthcheck/fail"] 
       initContainers:
       - image: gcr.io/heptio-images/contour:master
         imagePullPolicy: Always

--- a/deployment/ds-hostnet-split/03-envoy.yaml
+++ b/deployment/ds-hostnet-split/03-envoy.yaml
@@ -54,6 +54,10 @@ spec:
         volumeMounts:
           - name: contour-config
             mountPath: /config
+        lifecycle:
+          preStop:
+            exec:
+              command: ["wget", "-qO-", "http://localhost:9001/healthcheck/fail"] 
       dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
       initContainers:

--- a/deployment/ds-hostnet/02-contour.yaml
+++ b/deployment/ds-hostnet/02-contour.yaml
@@ -54,6 +54,10 @@ spec:
         volumeMounts:
         - name: contour-config
           mountPath: /config
+        lifecycle:
+          preStop:
+            exec:
+              command: ["wget", "-qO-", "http://localhost:9001/healthcheck/fail"] 
       initContainers:
       - image: gcr.io/heptio-images/contour:master
         imagePullPolicy: Always

--- a/deployment/render/daemonset-rbac.yaml
+++ b/deployment/render/daemonset-rbac.yaml
@@ -205,6 +205,10 @@ spec:
         volumeMounts:
         - name: contour-config
           mountPath: /config
+        lifecycle:
+          preStop:
+            exec:
+              command: ["wget", "-qO-", "http://localhost:9001/healthcheck/fail"] 
       initContainers:
       - image: gcr.io/heptio-images/contour:master
         imagePullPolicy: Always

--- a/deployment/render/deployment-rbac.yaml
+++ b/deployment/render/deployment-rbac.yaml
@@ -204,6 +204,10 @@ spec:
         volumeMounts:
         - name: contour-config
           mountPath: /config
+        lifecycle:
+          preStop:
+            exec:
+              command: ["wget", "-qO-", "http://localhost:9001/healthcheck/fail"] 
       initContainers:
       - image: gcr.io/heptio-images/contour:master
         imagePullPolicy: Always


### PR DESCRIPTION
Fixes #696 by adding a `preStop` lifecycle hook to the Envoy pod.

The process is as follows:
1. Shutdown is received
2. preStop hook will curl envoy and set its state to unhealthy
3. Envoy healthcheck will fail to stop requests from Kubernetes
4. Kubernetes will wait 30s to terminate (allowing requests to drop)

I ended up adding another container to the pod which includes `curl` since Envoy doesn't have it included in the container. 

@davecheney setting this to `WIP` since this needs a bit of discussion as well as a proper container (i.e. not from my personal account). 

Signed-off-by: Steve Sloka <steves@heptio.com>