### PR TITLE
docs: Add externalTrafficPolicy to NLB example svc

### DIFF
--- a/deployment/ds-hostnet-split/02-service-envoy.yaml
+++ b/deployment/ds-hostnet-split/02-service-envoy.yaml
@@ -6,6 +6,7 @@ metadata:
  annotations:
    service.beta.kubernetes.io/aws-load-balancer-type: nlb
 spec:
+ externalTrafficPolicy: Local
  ports:
  - port: 80
    name: http


### PR DESCRIPTION
AWS NLB forwards requests source IP to the nodes, but for this to work accordingly we must provide the `externalTrafficPolicy: Local` to the Service resource.

Ref: https://kubernetes.io/docs/concepts/services-networking/service/#network-load-balancer-support-on-aws-alpha

Related to #757