### PR TITLE
internal/dag: embed dag.Service in dag.HTTPService

### DIFF
--- a/internal/contour/cluster.go
+++ b/internal/contour/cluster.go
@@ -101,12 +101,15 @@ func (v *clusterVisitor) Visit() map[string]*v2.Cluster {
 }
 
 func (v *clusterVisitor) visit(vertex dag.Vertex) {
-	if service, ok := vertex.(*dag.HTTPService); ok {
+	switch service := vertex.(type) {
+	case *dag.HTTPService:
 		name := envoy.Clustername(service)
 		if _, ok := v.clusters[name]; !ok {
 			c := envoy.Cluster(service)
 			v.clusters[c.Name] = c
 		}
+	default:
+		// nothing
 	}
 
 	// recurse into children of v

--- a/internal/contour/cluster.go
+++ b/internal/contour/cluster.go
@@ -101,7 +101,7 @@ func (v *clusterVisitor) Visit() map[string]*v2.Cluster {
 }
 
 func (v *clusterVisitor) visit(vertex dag.Vertex) {
-	if service, ok := vertex.(*dag.Service); ok {
+	if service, ok := vertex.(*dag.HTTPService); ok {
 		name := envoy.Clustername(service)
 		if _, ok := v.clusters[name]; !ok {
 			c := envoy.Cluster(service)

--- a/internal/contour/route.go
+++ b/internal/contour/route.go
@@ -112,9 +112,9 @@ func (v *routeVisitor) Visit() map[string]*v2.RouteConfiguration {
 			vh.Visit(func(r dag.Vertex) {
 				switch r := r.(type) {
 				case *dag.Route:
-					var svcs []*dag.Service
+					var svcs []*dag.HTTPService
 					r.Visit(func(s dag.Vertex) {
-						if s, ok := s.(*dag.Service); ok {
+						if s, ok := s.(*dag.HTTPService); ok {
 							svcs = append(svcs, s)
 						}
 					})
@@ -143,9 +143,9 @@ func (v *routeVisitor) Visit() map[string]*v2.RouteConfiguration {
 			vh.Visit(func(r dag.Vertex) {
 				switch r := r.(type) {
 				case *dag.Route:
-					var svcs []*dag.Service
+					var svcs []*dag.HTTPService
 					r.Visit(func(s dag.Vertex) {
-						if s, ok := s.(*dag.Service); ok {
+						if s, ok := s.(*dag.HTTPService); ok {
 							svcs = append(svcs, s)
 						}
 					})

--- a/internal/dag/builder_test.go
+++ b/internal/dag/builder_test.go
@@ -1091,10 +1091,7 @@ func TestDAGInsert(t *testing.T) {
 					Port: 80,
 					routes: routemap(
 						route("/", i1, servicemap(
-							&Service{
-								Object:      s1,
-								ServicePort: &s1.Spec.Ports[0],
-							},
+							httpService(s1),
 						)),
 					),
 				},
@@ -1111,10 +1108,7 @@ func TestDAGInsert(t *testing.T) {
 					Port: 80,
 					routes: routemap(
 						route("/", i1, servicemap(
-							&Service{
-								Object:      s1,
-								ServicePort: &s1.Spec.Ports[0],
-							},
+							httpService(s1),
 						)),
 					),
 				},
@@ -1206,10 +1200,7 @@ func TestDAGInsert(t *testing.T) {
 					Port: 80,
 					routes: routemap(
 						route("/", i4, servicemap(
-							&Service{
-								Object:      s1,
-								ServicePort: &s1.Spec.Ports[0],
-							},
+							httpService(s1),
 						)),
 					),
 				},
@@ -1226,10 +1217,7 @@ func TestDAGInsert(t *testing.T) {
 					Port: 80,
 					routes: routemap(
 						route("/", i4, servicemap(
-							&Service{
-								Object:      s1,
-								ServicePort: &s1.Spec.Ports[0],
-							},
+							httpService(s1),
 						)),
 					),
 				},
@@ -1246,10 +1234,7 @@ func TestDAGInsert(t *testing.T) {
 					Port: 80,
 					routes: routemap(
 						route("/", i5, servicemap(
-							&Service{
-								Object:      s1,
-								ServicePort: &s1.Spec.Ports[0],
-							},
+							httpService(s1),
 						)),
 					),
 				},
@@ -1266,10 +1251,7 @@ func TestDAGInsert(t *testing.T) {
 					Port: 80,
 					routes: routemap(
 						route("/", i5, servicemap(
-							&Service{
-								Object:      s1,
-								ServicePort: &s1.Spec.Ports[0],
-							},
+							httpService(s1),
 						)),
 					),
 				},
@@ -1383,10 +1365,7 @@ func TestDAGInsert(t *testing.T) {
 					Port: 80,
 					routes: routemap(
 						route("/", i6, servicemap(
-							&Service{
-								Object:      s1,
-								ServicePort: &s1.Spec.Ports[0],
-							},
+							httpService(s1),
 						)),
 					),
 				},
@@ -1395,10 +1374,7 @@ func TestDAGInsert(t *testing.T) {
 					Port: 80,
 					routes: routemap(
 						route("/", i6, servicemap(
-							&Service{
-								Object:      s1,
-								ServicePort: &s1.Spec.Ports[0],
-							},
+							httpService(s1),
 						)),
 					),
 				},
@@ -1415,10 +1391,7 @@ func TestDAGInsert(t *testing.T) {
 					Port: 80,
 					routes: routemap(
 						route("/", i6, servicemap(
-							&Service{
-								Object:      s1,
-								ServicePort: &s1.Spec.Ports[0],
-							},
+							httpService(s1),
 						)),
 					),
 				},
@@ -1427,10 +1400,7 @@ func TestDAGInsert(t *testing.T) {
 					Port: 80,
 					routes: routemap(
 						route("/", i6, servicemap(
-							&Service{
-								Object:      s1,
-								ServicePort: &s1.Spec.Ports[0],
-							},
+							httpService(s1),
 						)),
 					),
 				},
@@ -1448,10 +1418,7 @@ func TestDAGInsert(t *testing.T) {
 					Port: 80,
 					routes: routemap(
 						route("/", i6, servicemap(
-							&Service{
-								Object:      s1,
-								ServicePort: &s1.Spec.Ports[0],
-							},
+							httpService(s1),
 						)),
 					),
 				},
@@ -1460,10 +1427,7 @@ func TestDAGInsert(t *testing.T) {
 					Port: 80,
 					routes: routemap(
 						route("/", i6, servicemap(
-							&Service{
-								Object:      s1,
-								ServicePort: &s1.Spec.Ports[0],
-							},
+							httpService(s1),
 						)),
 					),
 				}, &SecureVirtualHost{
@@ -1472,10 +1436,7 @@ func TestDAGInsert(t *testing.T) {
 						Port: 443,
 						routes: routemap(
 							route("/", i6, servicemap(
-								&Service{
-									Object:      s1,
-									ServicePort: &s1.Spec.Ports[0],
-								},
+								httpService(s1),
 							)),
 						),
 					},
@@ -1498,10 +1459,7 @@ func TestDAGInsert(t *testing.T) {
 					Port: 80,
 					routes: routemap(
 						route("/", i6, servicemap(
-							&Service{
-								Object:      s1,
-								ServicePort: &s1.Spec.Ports[0],
-							},
+							httpService(s1),
 						)),
 					),
 				}, &VirtualHost{
@@ -1509,10 +1467,7 @@ func TestDAGInsert(t *testing.T) {
 					Port: 80,
 					routes: routemap(
 						route("/", i6, servicemap(
-							&Service{
-								Object:      s1,
-								ServicePort: &s1.Spec.Ports[0],
-							},
+							httpService(s1),
 						)),
 					),
 				}, &SecureVirtualHost{
@@ -1521,10 +1476,7 @@ func TestDAGInsert(t *testing.T) {
 						Port: 443,
 						routes: routemap(
 							route("/", i6, servicemap(
-								&Service{
-									Object:      s1,
-									ServicePort: &s1.Spec.Ports[0],
-								},
+								httpService(s1),
 							)),
 						),
 					},
@@ -1561,16 +1513,10 @@ func TestDAGInsert(t *testing.T) {
 					Port: 80,
 					routes: routemap(
 						route("/", i7, servicemap(
-							&Service{
-								Object:      s1,
-								ServicePort: &s1.Spec.Ports[0],
-							},
+							httpService(s1),
 						)),
 						route("/kuarder", i7, servicemap(
-							&Service{
-								Object:      s2,
-								ServicePort: &s1.Spec.Ports[0],
-							},
+							httpService(s2),
 						)),
 					),
 				},
@@ -1586,16 +1532,10 @@ func TestDAGInsert(t *testing.T) {
 					Port: 80,
 					routes: routemap(
 						route("/", i8, servicemap(
-							&Service{
-								Object:      s1,
-								ServicePort: &s1.Spec.Ports[0],
-							},
+							httpService(s1),
 						)),
 						route("/kuarder", i8, servicemap(
-							&Service{
-								Object:      s2,
-								ServicePort: &s2.Spec.Ports[0],
-							},
+							httpService(s2),
 						)),
 					),
 				},
@@ -1620,16 +1560,10 @@ func TestDAGInsert(t *testing.T) {
 						Port: 443,
 						routes: routemap(
 							route("/", i9, servicemap(
-								&Service{
-									Object:      s1,
-									ServicePort: &s1.Spec.Ports[0],
-								},
+								httpService(s1),
 							)),
 							route("/kuarder", i9, servicemap(
-								&Service{
-									Object:      s2,
-									ServicePort: &s2.Spec.Ports[0],
-								},
+								httpService(s2),
 							)),
 						),
 					},
@@ -1669,10 +1603,7 @@ func TestDAGInsert(t *testing.T) {
 						Port: 443,
 						routes: routemap(
 							route("/", i6a, servicemap(
-								&Service{
-									Object:      s1,
-									ServicePort: &s1.Spec.Ports[0],
-								},
+								httpService(s1),
 							)),
 						),
 					},
@@ -1696,10 +1627,7 @@ func TestDAGInsert(t *testing.T) {
 							Prefix: "/",
 							object: i6b,
 							services: servicemap(
-								&Service{
-									Object:      s1,
-									ServicePort: &s1.Spec.Ports[0],
-								},
+								httpService(s1),
 							),
 							HTTPSUpgrade: true,
 						},
@@ -1714,10 +1642,7 @@ func TestDAGInsert(t *testing.T) {
 								Prefix: "/",
 								object: i6b,
 								services: servicemap(
-									&Service{
-										Object:      s1,
-										ServicePort: &s1.Spec.Ports[0],
-									},
+									httpService(s1),
 								),
 								HTTPSUpgrade: true,
 							},
@@ -1753,19 +1678,13 @@ func TestDAGInsert(t *testing.T) {
 					Port: 80,
 					routes: routemap(
 						route("/", ir11, servicemap(
-							&Service{
-								Object:      s1,
-								ServicePort: &s1.Spec.Ports[0],
-							},
+							httpService(s1),
 						)),
 						&Route{
 							Prefix: "/websocket",
 							object: ir11,
 							services: servicemap(
-								&Service{
-									Object:      s1,
-									ServicePort: &s1.Spec.Ports[0],
-								},
+								httpService(s1),
 							),
 							PrefixRewrite: "/",
 						},
@@ -1782,19 +1701,13 @@ func TestDAGInsert(t *testing.T) {
 					Port: 80,
 					routes: routemap(
 						route("/", ir10, servicemap(
-							&Service{
-								Object:      s1,
-								ServicePort: &s1.Spec.Ports[0],
-							},
+							httpService(s1),
 						)),
 						&Route{
 							Prefix: "/websocket",
 							object: ir10,
 							services: servicemap(
-								&Service{
-									Object:      s1,
-									ServicePort: &s1.Spec.Ports[0],
-								},
+								httpService(s1),
 							),
 							Websocket: true,
 						},
@@ -1811,10 +1724,7 @@ func TestDAGInsert(t *testing.T) {
 					Port: 80,
 					routes: routemap(
 						route("/", ir1, servicemap(
-							&Service{
-								Object:      s1,
-								ServicePort: &s1.Spec.Ports[0],
-							},
+							httpService(s1),
 						)),
 					),
 				}},
@@ -1832,10 +1742,7 @@ func TestDAGInsert(t *testing.T) {
 							Prefix: "/",
 							object: ir6,
 							services: servicemap(
-								&Service{
-									Object:      s1,
-									ServicePort: &s1.Spec.Ports[0],
-								},
+								httpService(s1),
 							),
 							HTTPSUpgrade: true,
 						},
@@ -1851,10 +1758,7 @@ func TestDAGInsert(t *testing.T) {
 								Prefix: "/",
 								object: ir6,
 								services: servicemap(
-									&Service{
-										Object:      s1,
-										ServicePort: &s1.Spec.Ports[0],
-									},
+									httpService(s1),
 								),
 								HTTPSUpgrade: true,
 							}),
@@ -1877,10 +1781,7 @@ func TestDAGInsert(t *testing.T) {
 							Prefix: "/",
 							object: ir14,
 							services: servicemap(
-								&Service{
-									Object:      s1,
-									ServicePort: &s1.Spec.Ports[0],
-								},
+								httpService(s1),
 							),
 						},
 					),
@@ -1895,10 +1796,7 @@ func TestDAGInsert(t *testing.T) {
 								Prefix: "/",
 								object: ir14,
 								services: servicemap(
-									&Service{
-										Object:      s1,
-										ServicePort: &s1.Spec.Ports[0],
-									},
+									httpService(s1),
 								),
 							}),
 					},
@@ -1920,10 +1818,7 @@ func TestDAGInsert(t *testing.T) {
 							Prefix: "/",
 							object: ir7,
 							services: servicemap(
-								&Service{
-									Object:      s1,
-									ServicePort: &s1.Spec.Ports[0],
-								},
+								httpService(s1),
 							),
 							HTTPSUpgrade: true,
 						},
@@ -1938,10 +1833,7 @@ func TestDAGInsert(t *testing.T) {
 								Prefix: "/",
 								object: ir7,
 								services: servicemap(
-									&Service{
-										Object:      s1,
-										ServicePort: &s1.Spec.Ports[0],
-									},
+									httpService(s1),
 								),
 								HTTPSUpgrade: true,
 							},
@@ -1965,10 +1857,7 @@ func TestDAGInsert(t *testing.T) {
 						Prefix: "/",
 						object: ir8,
 						services: servicemap(
-							&Service{
-								Object:      s1,
-								ServicePort: &s1.Spec.Ports[0],
-							},
+							httpService(s1),
 						),
 						HTTPSUpgrade: true,
 					}),
@@ -1982,10 +1871,7 @@ func TestDAGInsert(t *testing.T) {
 								Prefix: "/",
 								object: ir8,
 								services: servicemap(
-									&Service{
-										Object:      s1,
-										ServicePort: &s1.Spec.Ports[0],
-									},
+									httpService(s1),
 								),
 								HTTPSUpgrade: true,
 							},
@@ -2010,10 +1896,7 @@ func TestDAGInsert(t *testing.T) {
 							Prefix: "/",
 							object: ir9,
 							services: servicemap(
-								&Service{
-									Object:      s1,
-									ServicePort: &s1.Spec.Ports[0],
-								},
+								httpService(s1),
 							),
 							HTTPSUpgrade: true,
 						}),
@@ -2027,10 +1910,7 @@ func TestDAGInsert(t *testing.T) {
 								Prefix: "/",
 								object: ir9,
 								services: servicemap(
-									&Service{
-										Object:      s1,
-										ServicePort: &s1.Spec.Ports[0],
-									},
+									httpService(s1),
 								),
 								HTTPSUpgrade: true,
 							}),
@@ -2051,10 +1931,7 @@ func TestDAGInsert(t *testing.T) {
 					Port: 80,
 					routes: routemap(
 						route("/", ir2, servicemap(
-							&Service{
-								Object:      s2,
-								ServicePort: &s2.Spec.Ports[0],
-							},
+							httpService(s2),
 						)),
 					),
 				}},
@@ -2069,14 +1946,8 @@ func TestDAGInsert(t *testing.T) {
 					Port: 80,
 					routes: routemap(
 						route("/", ir2, servicemap(
-							&Service{
-								Object:      s1,
-								ServicePort: &s1.Spec.Ports[0],
-							},
-							&Service{
-								Object:      s2,
-								ServicePort: &s2.Spec.Ports[0],
-							},
+							httpService(s1),
+							httpService(s2),
 						)),
 					),
 				}},
@@ -2093,10 +1964,7 @@ func TestDAGInsert(t *testing.T) {
 					Port: 80,
 					routes: routemap(
 						route("/", i10, servicemap(
-							&Service{
-								Object:      s1,
-								ServicePort: &s1.Spec.Ports[0],
-							},
+							httpService(s1),
 						)),
 					),
 				},
@@ -2106,10 +1974,7 @@ func TestDAGInsert(t *testing.T) {
 						Port: 443,
 						routes: routemap(
 							route("/", i10, servicemap(
-								&Service{
-									Object:      s1,
-									ServicePort: &s1.Spec.Ports[0],
-								},
+								httpService(s1),
 							)),
 						),
 					},
@@ -2131,19 +1996,13 @@ func TestDAGInsert(t *testing.T) {
 					Port: 80,
 					routes: routemap(
 						route("/", i11, servicemap(
-							&Service{
-								Object:      s1,
-								ServicePort: &s1.Spec.Ports[0],
-							},
+							httpService(s1),
 						)),
 						&Route{
 							Prefix: "/ws1",
 							object: i11,
 							services: servicemap(
-								&Service{
-									Object:      s1,
-									ServicePort: &s1.Spec.Ports[0],
-								},
+								httpService(s1),
 							),
 							Websocket: true,
 						},
@@ -2165,10 +2024,7 @@ func TestDAGInsert(t *testing.T) {
 							Prefix: "/",
 							object: i12a,
 							services: servicemap(
-								&Service{
-									Object:      s1,
-									ServicePort: &s1.Spec.Ports[0],
-								},
+								httpService(s1),
 							),
 							Timeout: -1, // invalid timeout equals infinity ¯\_(ツ)_/¯.
 						},
@@ -2190,10 +2046,7 @@ func TestDAGInsert(t *testing.T) {
 							Prefix: "/",
 							object: i12b,
 							services: servicemap(
-								&Service{
-									Object:      s1,
-									ServicePort: &s1.Spec.Ports[0],
-								},
+								httpService(s1),
 							),
 							Timeout: 90 * time.Second,
 						},
@@ -2215,10 +2068,7 @@ func TestDAGInsert(t *testing.T) {
 							Prefix: "/",
 							object: i12c,
 							services: servicemap(
-								&Service{
-									Object:      s1,
-									ServicePort: &s1.Spec.Ports[0],
-								},
+								httpService(s1),
 							),
 							Timeout: -1,
 						},
@@ -2236,16 +2086,10 @@ func TestDAGInsert(t *testing.T) {
 					Port: 80,
 					routes: routemap(
 						route("/blog", ir4, servicemap(
-							&Service{
-								Object:      s4,
-								ServicePort: &s4.Spec.Ports[0],
-							},
+							httpService(s4),
 						)),
 						route("/blog/admin", ir5, servicemap(
-							&Service{
-								Object:      s5,
-								ServicePort: &s5.Spec.Ports[0],
-							},
+							httpService(s5),
 						)),
 					),
 				},
@@ -2265,10 +2109,7 @@ func TestDAGInsert(t *testing.T) {
 							Prefix: "/",
 							object: i14,
 							services: servicemap(
-								&Service{
-									Object:      s1,
-									ServicePort: &s1.Spec.Ports[0],
-								},
+								httpService(s1),
 							),
 							RetryOn:       "gateway-error",
 							NumRetries:    6,
@@ -2291,18 +2132,12 @@ func TestDAGInsert(t *testing.T) {
 							Prefix: "/",
 							object: i13a,
 							services: servicemap(
-								&Service{
-									Object:      s13a,
-									ServicePort: &s13a.Spec.Ports[0],
-								},
+								httpService(s13a),
 							),
 							HTTPSUpgrade: true,
 						},
 						route("/.well-known/acme-challenge/gVJl5NWL2owUqZekjHkt_bo3OHYC2XNDURRRgLI5JTk", i13b, servicemap(
-							&Service{
-								Object:      s13b,
-								ServicePort: &s13b.Spec.Ports[0],
-							},
+							httpService(s13b),
 						)),
 					),
 				},
@@ -2315,18 +2150,12 @@ func TestDAGInsert(t *testing.T) {
 								Prefix: "/",
 								object: i13a,
 								services: servicemap(
-									&Service{
-										Object:      s13a,
-										ServicePort: &s13a.Spec.Ports[0],
-									},
+									httpService(s13a),
 								),
 								HTTPSUpgrade: true,
 							},
 							route("/.well-known/acme-challenge/gVJl5NWL2owUqZekjHkt_bo3OHYC2XNDURRRgLI5JTk", i13b, servicemap(
-								&Service{
-									Object:      s13b,
-									ServicePort: &s13b.Spec.Ports[0],
-								},
+								httpService(s13b),
 							)),
 						),
 					},
@@ -3686,6 +3515,10 @@ func route(prefix string, obj interface{}, services ...map[servicemeta]*Service)
 		panic("only pass one servicemap to route")
 	}
 	return &route
+}
+
+func httpService(s *v1.Service) *Service {
+	return &Service{Object: s, ServicePort: &s.Spec.Ports[0]}
 }
 
 func servicemap(services ...*Service) map[servicemeta]*Service {

--- a/internal/dag/builder_test.go
+++ b/internal/dag/builder_test.go
@@ -1626,7 +1626,7 @@ func TestDAGInsert(t *testing.T) {
 						&Route{
 							Prefix: "/",
 							object: i6b,
-							services: servicemap(
+							httpServices: servicemap(
 								httpService(s1),
 							),
 							HTTPSUpgrade: true,
@@ -1641,7 +1641,7 @@ func TestDAGInsert(t *testing.T) {
 							&Route{
 								Prefix: "/",
 								object: i6b,
-								services: servicemap(
+								httpServices: servicemap(
 									httpService(s1),
 								),
 								HTTPSUpgrade: true,
@@ -1683,7 +1683,7 @@ func TestDAGInsert(t *testing.T) {
 						&Route{
 							Prefix: "/websocket",
 							object: ir11,
-							services: servicemap(
+							httpServices: servicemap(
 								httpService(s1),
 							),
 							PrefixRewrite: "/",
@@ -1706,7 +1706,7 @@ func TestDAGInsert(t *testing.T) {
 						&Route{
 							Prefix: "/websocket",
 							object: ir10,
-							services: servicemap(
+							httpServices: servicemap(
 								httpService(s1),
 							),
 							Websocket: true,
@@ -1741,7 +1741,7 @@ func TestDAGInsert(t *testing.T) {
 						&Route{
 							Prefix: "/",
 							object: ir6,
-							services: servicemap(
+							httpServices: servicemap(
 								httpService(s1),
 							),
 							HTTPSUpgrade: true,
@@ -1757,7 +1757,7 @@ func TestDAGInsert(t *testing.T) {
 							&Route{
 								Prefix: "/",
 								object: ir6,
-								services: servicemap(
+								httpServices: servicemap(
 									httpService(s1),
 								),
 								HTTPSUpgrade: true,
@@ -1780,7 +1780,7 @@ func TestDAGInsert(t *testing.T) {
 						&Route{
 							Prefix: "/",
 							object: ir14,
-							services: servicemap(
+							httpServices: servicemap(
 								httpService(s1),
 							),
 						},
@@ -1795,7 +1795,7 @@ func TestDAGInsert(t *testing.T) {
 							&Route{
 								Prefix: "/",
 								object: ir14,
-								services: servicemap(
+								httpServices: servicemap(
 									httpService(s1),
 								),
 							}),
@@ -1817,7 +1817,7 @@ func TestDAGInsert(t *testing.T) {
 						&Route{
 							Prefix: "/",
 							object: ir7,
-							services: servicemap(
+							httpServices: servicemap(
 								httpService(s1),
 							),
 							HTTPSUpgrade: true,
@@ -1832,7 +1832,7 @@ func TestDAGInsert(t *testing.T) {
 							&Route{
 								Prefix: "/",
 								object: ir7,
-								services: servicemap(
+								httpServices: servicemap(
 									httpService(s1),
 								),
 								HTTPSUpgrade: true,
@@ -1856,7 +1856,7 @@ func TestDAGInsert(t *testing.T) {
 					routes: routemap(&Route{
 						Prefix: "/",
 						object: ir8,
-						services: servicemap(
+						httpServices: servicemap(
 							httpService(s1),
 						),
 						HTTPSUpgrade: true,
@@ -1870,7 +1870,7 @@ func TestDAGInsert(t *testing.T) {
 							&Route{
 								Prefix: "/",
 								object: ir8,
-								services: servicemap(
+								httpServices: servicemap(
 									httpService(s1),
 								),
 								HTTPSUpgrade: true,
@@ -1895,7 +1895,7 @@ func TestDAGInsert(t *testing.T) {
 						&Route{
 							Prefix: "/",
 							object: ir9,
-							services: servicemap(
+							httpServices: servicemap(
 								httpService(s1),
 							),
 							HTTPSUpgrade: true,
@@ -1909,7 +1909,7 @@ func TestDAGInsert(t *testing.T) {
 							&Route{
 								Prefix: "/",
 								object: ir9,
-								services: servicemap(
+								httpServices: servicemap(
 									httpService(s1),
 								),
 								HTTPSUpgrade: true,
@@ -2001,7 +2001,7 @@ func TestDAGInsert(t *testing.T) {
 						&Route{
 							Prefix: "/ws1",
 							object: i11,
-							services: servicemap(
+							httpServices: servicemap(
 								httpService(s1),
 							),
 							Websocket: true,
@@ -2023,7 +2023,7 @@ func TestDAGInsert(t *testing.T) {
 						&Route{
 							Prefix: "/",
 							object: i12a,
-							services: servicemap(
+							httpServices: servicemap(
 								httpService(s1),
 							),
 							Timeout: -1, // invalid timeout equals infinity ¯\_(ツ)_/¯.
@@ -2045,7 +2045,7 @@ func TestDAGInsert(t *testing.T) {
 						&Route{
 							Prefix: "/",
 							object: i12b,
-							services: servicemap(
+							httpServices: servicemap(
 								httpService(s1),
 							),
 							Timeout: 90 * time.Second,
@@ -2067,7 +2067,7 @@ func TestDAGInsert(t *testing.T) {
 						&Route{
 							Prefix: "/",
 							object: i12c,
-							services: servicemap(
+							httpServices: servicemap(
 								httpService(s1),
 							),
 							Timeout: -1,
@@ -2108,7 +2108,7 @@ func TestDAGInsert(t *testing.T) {
 						&Route{
 							Prefix: "/",
 							object: i14,
-							services: servicemap(
+							httpServices: servicemap(
 								httpService(s1),
 							),
 							RetryOn:       "gateway-error",
@@ -2131,7 +2131,7 @@ func TestDAGInsert(t *testing.T) {
 						&Route{
 							Prefix: "/",
 							object: i13a,
-							services: servicemap(
+							httpServices: servicemap(
 								httpService(s13a),
 							),
 							HTTPSUpgrade: true,
@@ -2149,7 +2149,7 @@ func TestDAGInsert(t *testing.T) {
 							&Route{
 								Prefix: "/",
 								object: i13a,
-								services: servicemap(
+								httpServices: servicemap(
 									httpService(s13a),
 								),
 								HTTPSUpgrade: true,
@@ -2176,10 +2176,12 @@ func TestDAGInsert(t *testing.T) {
 					Port: 80,
 					routes: routemap(
 						route("/", i3a, servicemap(
-							&Service{
-								Object:      s3a,
-								Protocol:    "h2c",
-								ServicePort: &s3a.Spec.Ports[0],
+							&HTTPService{
+								Service: Service{
+									Object:      s3a,
+									ServicePort: &s3a.Spec.Ports[0],
+								},
+								Protocol: "h2c",
 							},
 						)),
 					),
@@ -2196,10 +2198,12 @@ func TestDAGInsert(t *testing.T) {
 					Port: 80,
 					routes: routemap(
 						route("/", i3a, servicemap(
-							&Service{
-								Object:      s3b,
-								Protocol:    "h2",
-								ServicePort: &s3b.Spec.Ports[0],
+							&HTTPService{
+								Service: Service{
+									Object:      s3b,
+									ServicePort: &s3b.Spec.Ports[0],
+								},
+								Protocol: "h2",
 							},
 						)),
 					),
@@ -2217,13 +2221,15 @@ func TestDAGInsert(t *testing.T) {
 					Port: 80,
 					routes: routemap(
 						route("/", i1, servicemap(
-							&Service{
-								Object:             s1b,
-								ServicePort:        &s1b.Spec.Ports[0],
-								MaxConnections:     9000,
-								MaxPendingRequests: 4096,
-								MaxRequests:        404,
-								MaxRetries:         7,
+							&HTTPService{
+								Service: Service{
+									Object:             s1b,
+									ServicePort:        &s1b.Spec.Ports[0],
+									MaxConnections:     9000,
+									MaxPendingRequests: 4096,
+									MaxRequests:        404,
+									MaxRetries:         7,
+								},
 							},
 						)),
 					),
@@ -2240,17 +2246,21 @@ func TestDAGInsert(t *testing.T) {
 					Port: 80,
 					routes: routemap(
 						route("/a", ir13, servicemap(
-							&Service{
-								Object:      s1,
-								ServicePort: &s1.Spec.Ports[0],
-								Weight:      90,
+							&HTTPService{
+								Service: Service{
+									Object:      s1,
+									ServicePort: &s1.Spec.Ports[0],
+									Weight:      90,
+								},
 							}),
 						),
 						route("/b", ir13, servicemap(
-							&Service{
-								Object:      s1,
-								ServicePort: &s1.Spec.Ports[0],
-								Weight:      60,
+							&HTTPService{
+								Service: Service{
+									Object:      s1,
+									ServicePort: &s1.Spec.Ports[0],
+									Weight:      60,
+								},
 							}),
 						),
 					),
@@ -2267,15 +2277,19 @@ func TestDAGInsert(t *testing.T) {
 					Port: 80,
 					routes: routemap(
 						route("/a", ir13a, servicemap(
-							&Service{
-								Object:      s1,
-								ServicePort: &s1.Spec.Ports[0],
-								Weight:      90,
+							&HTTPService{
+								Service: Service{
+									Object:      s1,
+									ServicePort: &s1.Spec.Ports[0],
+									Weight:      90,
+								},
 							},
-							&Service{
-								Object:      s1,
-								ServicePort: &s1.Spec.Ports[0],
-								Weight:      60,
+							&HTTPService{
+								Service: Service{
+									Object:      s1,
+									ServicePort: &s1.Spec.Ports[0],
+									Weight:      60,
+								},
 							}),
 						),
 					),
@@ -2371,39 +2385,27 @@ func TestBuilderLookupService(t *testing.T) {
 		weight      int
 		strategy    string
 		healthcheck *ingressroutev1.HealthCheck
-		want        *Service
+		want        *HTTPService
 	}{
 		"lookup service by port number": {
 			meta: meta{name: "service1", namespace: "default"},
 			port: intstr.FromInt(8080),
-			want: &Service{
-				Object:      s1,
-				ServicePort: &s1.Spec.Ports[0],
-			},
+			want: httpService(s1),
 		},
 		"lookup service by port name": {
 			meta: meta{name: "service1", namespace: "default"},
 			port: intstr.FromString("http"),
-			want: &Service{
-				Object:      s1,
-				ServicePort: &s1.Spec.Ports[0],
-			},
+			want: httpService(s1),
 		},
 		"lookup service by port number (as string)": {
 			meta: meta{name: "service1", namespace: "default"},
 			port: intstr.Parse("8080"),
-			want: &Service{
-				Object:      s1,
-				ServicePort: &s1.Spec.Ports[0],
-			},
+			want: httpService(s1),
 		},
 		"lookup service by port number (from string)": {
 			meta: meta{name: "service1", namespace: "default"},
 			port: intstr.FromString("8080"),
-			want: &Service{
-				Object:      s1,
-				ServicePort: &s1.Spec.Ports[0],
-			},
+			want: httpService(s1),
 		},
 	}
 
@@ -3501,28 +3503,30 @@ func routemap(routes ...*Route) map[string]*Route {
 	return m
 }
 
-func route(prefix string, obj interface{}, services ...map[servicemeta]*Service) *Route {
+func route(prefix string, obj interface{}, httpServices ...map[servicemeta]*HTTPService) *Route {
 	route := Route{
 		Prefix: prefix,
 		object: obj,
 	}
-	switch len(services) {
+	switch len(httpServices) {
 	case 0:
 		// nothing to do
 	case 1:
-		route.services = services[0]
+		route.httpServices = httpServices[0]
 	default:
 		panic("only pass one servicemap to route")
 	}
 	return &route
 }
 
-func httpService(s *v1.Service) *Service {
-	return &Service{Object: s, ServicePort: &s.Spec.Ports[0]}
+func httpService(s *v1.Service) *HTTPService {
+	return &HTTPService{
+		Service: Service{Object: s, ServicePort: &s.Spec.Ports[0]},
+	}
 }
 
-func servicemap(services ...*Service) map[servicemeta]*Service {
-	m := make(map[servicemeta]*Service)
+func servicemap(services ...*HTTPService) map[servicemeta]*HTTPService {
+	m := make(map[servicemeta]*HTTPService)
 	for _, s := range services {
 		m[s.toMeta()] = s
 	}

--- a/internal/dag/dag.go
+++ b/internal/dag/dag.go
@@ -88,11 +88,11 @@ type ServiceVertex interface {
 	toMeta() servicemeta
 }
 
-func (r *Route) addService(sv ServiceVertex) {
+func (r *Route) addHTTPService(s *HTTPService) {
 	if r.httpServices == nil {
 		r.httpServices = make(map[servicemeta]*HTTPService)
 	}
-	r.httpServices[sv.toMeta()] = sv.(*HTTPService)
+	r.httpServices[s.toMeta()] = s
 }
 
 func (r *Route) Visit(f func(Vertex)) {

--- a/internal/debug/dot.go
+++ b/internal/debug/dot.go
@@ -44,7 +44,7 @@ func (c *ctx) writeVertex(v dag.Vertex) {
 	switch v := v.(type) {
 	case *dag.Secret:
 		fmt.Fprintf(c.w, `"%p" [shape=record, label="{secret|%s/%s}"]`+"\n", v, v.Namespace(), v.Name())
-	case *dag.Service:
+	case *dag.HTTPService:
 		fmt.Fprintf(c.w, `"%p" [shape=record, label="{service|%s/%s:%d}"]`+"\n", v, v.Namespace(), v.Name(), v.Port)
 	case *dag.VirtualHost:
 		fmt.Fprintf(c.w, `"%p" [shape=record, label="{http://%s:%d}"]`+"\n", v, v.Host, v.Port)

--- a/internal/envoy/cluster_test.go
+++ b/internal/envoy/cluster_test.go
@@ -46,13 +46,15 @@ func TestCluster(t *testing.T) {
 	}
 
 	tests := map[string]struct {
-		service *dag.Service
+		service *dag.HTTPService
 		want    *v2.Cluster
 	}{
 		"simple service": {
-			service: &dag.Service{
-				Object:      s1,
-				ServicePort: &s1.Spec.Ports[0],
+			service: &dag.HTTPService{
+				Service: dag.Service{
+					Object:      s1,
+					ServicePort: &s1.Spec.Ports[0],
+				},
 			},
 			want: &v2.Cluster{
 				Name: "default/kuard/443/da39a3ee5e",
@@ -67,10 +69,12 @@ func TestCluster(t *testing.T) {
 			},
 		},
 		"h2c upstream": {
-			service: &dag.Service{
-				Object:      s1,
-				ServicePort: &s1.Spec.Ports[0],
-				Protocol:    "h2c",
+			service: &dag.HTTPService{
+				Service: dag.Service{
+					Object:      s1,
+					ServicePort: &s1.Spec.Ports[0],
+				},
+				Protocol: "h2c",
 			},
 			want: &v2.Cluster{
 				Name: "default/kuard/443/da39a3ee5e",
@@ -86,10 +90,12 @@ func TestCluster(t *testing.T) {
 			},
 		},
 		"h2 upstream": {
-			service: &dag.Service{
-				Object:      s1,
-				ServicePort: &s1.Spec.Ports[0],
-				Protocol:    "h2",
+			service: &dag.HTTPService{
+				Service: dag.Service{
+					Object:      s1,
+					ServicePort: &s1.Spec.Ports[0],
+				},
+				Protocol: "h2",
 			},
 			want: &v2.Cluster{
 				Name: "default/kuard/443/da39a3ee5e",
@@ -106,10 +112,12 @@ func TestCluster(t *testing.T) {
 			},
 		},
 		"contour.heptio.com/max-connections": {
-			service: &dag.Service{
-				Object:         s1,
-				ServicePort:    &s1.Spec.Ports[0],
-				MaxConnections: 9000,
+			service: &dag.HTTPService{
+				Service: dag.Service{
+					Object:         s1,
+					ServicePort:    &s1.Spec.Ports[0],
+					MaxConnections: 9000,
+				},
 			},
 			want: &v2.Cluster{
 				Name: "default/kuard/443/da39a3ee5e",
@@ -129,10 +137,12 @@ func TestCluster(t *testing.T) {
 			},
 		},
 		"contour.heptio.com/max-pending-requests": {
-			service: &dag.Service{
-				Object:             s1,
-				ServicePort:        &s1.Spec.Ports[0],
-				MaxPendingRequests: 4096,
+			service: &dag.HTTPService{
+				Service: dag.Service{
+					Object:             s1,
+					ServicePort:        &s1.Spec.Ports[0],
+					MaxPendingRequests: 4096,
+				},
 			},
 			want: &v2.Cluster{
 				Name: "default/kuard/443/da39a3ee5e",
@@ -152,10 +162,12 @@ func TestCluster(t *testing.T) {
 			},
 		},
 		"contour.heptio.com/max-requests": {
-			service: &dag.Service{
-				Object:      s1,
-				ServicePort: &s1.Spec.Ports[0],
-				MaxRequests: 404,
+			service: &dag.HTTPService{
+				Service: dag.Service{
+					Object:      s1,
+					ServicePort: &s1.Spec.Ports[0],
+					MaxRequests: 404,
+				},
 			},
 			want: &v2.Cluster{
 				Name: "default/kuard/443/da39a3ee5e",
@@ -175,10 +187,12 @@ func TestCluster(t *testing.T) {
 			},
 		},
 		"contour.heptio.com/max-retries": {
-			service: &dag.Service{
-				Object:      s1,
-				ServicePort: &s1.Spec.Ports[0],
-				MaxRetries:  7,
+			service: &dag.HTTPService{
+				Service: dag.Service{
+					Object:      s1,
+					ServicePort: &s1.Spec.Ports[0],
+					MaxRetries:  7,
+				},
 			},
 			want: &v2.Cluster{
 				Name: "default/kuard/443/da39a3ee5e",
@@ -211,43 +225,49 @@ func TestCluster(t *testing.T) {
 
 func TestClustername(t *testing.T) {
 	tests := map[string]struct {
-		service *dag.Service
+		service *dag.HTTPService
 		want    string
 	}{
 		"simple": {
-			service: &dag.Service{
-				Object: service("default", "backend"),
-				ServicePort: &v1.ServicePort{
-					Name:       "http",
-					Protocol:   "TCP",
-					Port:       80,
-					TargetPort: intstr.FromInt(6502),
+			service: &dag.HTTPService{
+				Service: dag.Service{
+					Object: service("default", "backend"),
+					ServicePort: &v1.ServicePort{
+						Name:       "http",
+						Protocol:   "TCP",
+						Port:       80,
+						TargetPort: intstr.FromInt(6502),
+					},
 				},
 			},
 			want: "default/backend/80/da39a3ee5e",
 		},
 		"far too long": {
-			service: &dag.Service{
-				Object: service("it-is-a-truth-universally-acknowledged-that-a-single-man-in-possession-of-a-good-fortune", "must-be-in-want-of-a-wife"),
-				ServicePort: &v1.ServicePort{
-					Name:       "http",
-					Protocol:   "TCP",
-					Port:       9999,
-					TargetPort: intstr.FromString("http-alt"),
+			service: &dag.HTTPService{
+				Service: dag.Service{
+					Object: service("it-is-a-truth-universally-acknowledged-that-a-single-man-in-possession-of-a-good-fortune", "must-be-in-want-of-a-wife"),
+					ServicePort: &v1.ServicePort{
+						Name:       "http",
+						Protocol:   "TCP",
+						Port:       9999,
+						TargetPort: intstr.FromString("http-alt"),
+					},
 				},
 			},
 			want: "it-is-a--dea8b0/must-be--dea8b0/9999/da39a3ee5e",
 		},
 		"various healthcheck params": {
-			service: &dag.Service{
-				Object: service("default", "backend"),
-				ServicePort: &v1.ServicePort{
-					Name:       "http",
-					Protocol:   "TCP",
-					Port:       80,
-					TargetPort: intstr.FromInt(6502),
+			service: &dag.HTTPService{
+				Service: dag.Service{
+					Object: service("default", "backend"),
+					ServicePort: &v1.ServicePort{
+						Name:       "http",
+						Protocol:   "TCP",
+						Port:       80,
+						TargetPort: intstr.FromInt(6502),
+					},
+					LoadBalancerStrategy: "Maglev",
 				},
-				LoadBalancerStrategy: "Maglev",
 				HealthCheck: &ingressroutev1.HealthCheck{
 					Path:                    "/healthz",
 					IntervalSeconds:         5,

--- a/internal/envoy/route.go
+++ b/internal/envoy/route.go
@@ -26,7 +26,7 @@ import (
 // RouteRoute creates a route.Route_Route for the services supplied.
 // If len(services) is greater than one, the route's action will be a
 // weighted cluster.
-func RouteRoute(r *dag.Route, services []*dag.Service) *route.Route_Route {
+func RouteRoute(r *dag.Route, services []*dag.HTTPService) *route.Route_Route {
 	ra := route.RouteAction{
 		UseWebsocket:  bv(r.Websocket),
 		RetryPolicy:   retryPolicy(r),
@@ -93,7 +93,7 @@ func UpgradeHTTPS() *route.Route_Redirect {
 }
 
 // weightedClusters returns a route.WeightedCluster for multiple services.
-func weightedClusters(services []*dag.Service) *route.WeightedCluster {
+func weightedClusters(services []*dag.HTTPService) *route.WeightedCluster {
 	var wc route.WeightedCluster
 	var total int
 	for _, svc := range services {

--- a/internal/envoy/route_test.go
+++ b/internal/envoy/route_test.go
@@ -43,26 +43,21 @@ func TestRouteRoute(t *testing.T) {
 	}
 	tests := map[string]struct {
 		route    *dag.Route
-		services []*dag.Service
+		services []*dag.HTTPService
 		want     *route.Route_Route
 	}{
 		"single service": {
 			route: &dag.Route{
 				Prefix: "/",
 			},
-			services: []*dag.Service{
-				{
-					Object: &v1.Service{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "kuard",
-							Namespace: "default",
-						},
-					},
+			services: []*dag.HTTPService{{
+				Service: dag.Service{
+					Object: service("default", "kuard"),
 					ServicePort: &v1.ServicePort{
 						Port: 8080,
 					},
 				},
-			},
+			}},
 			want: &route.Route_Route{
 				Route: &route.RouteAction{
 					ClusterSpecifier: &route.RouteAction_Cluster{
@@ -78,9 +73,11 @@ func TestRouteRoute(t *testing.T) {
 				Prefix:    "/",
 				Websocket: true,
 			},
-			services: []*dag.Service{{
-				Object:      s1,
-				ServicePort: &s1.Spec.Ports[0],
+			services: []*dag.HTTPService{{
+				Service: dag.Service{
+					Object:      s1,
+					ServicePort: &s1.Spec.Ports[0],
+				},
 			}},
 			want: &route.Route_Route{
 				Route: &route.RouteAction{
@@ -98,13 +95,17 @@ func TestRouteRoute(t *testing.T) {
 			route: &dag.Route{
 				Prefix: "/",
 			},
-			services: []*dag.Service{{
-				Object:      s1,
-				ServicePort: &s1.Spec.Ports[0],
-				Weight:      90,
+			services: []*dag.HTTPService{{
+				Service: dag.Service{
+					Object:      s1,
+					ServicePort: &s1.Spec.Ports[0],
+					Weight:      90,
+				},
 			}, {
-				Object:      s1, // it's valid to mention the same service several times per route.
-				ServicePort: &s1.Spec.Ports[0],
+				Service: dag.Service{
+					Object:      s1, // it's valid to mention the same service several times per route.
+					ServicePort: &s1.Spec.Ports[0],
+				},
 			}},
 			want: &route.Route_Route{
 				Route: &route.RouteAction{
@@ -130,13 +131,17 @@ func TestRouteRoute(t *testing.T) {
 				Prefix:    "/",
 				Websocket: true,
 			},
-			services: []*dag.Service{{
-				Object:      s1,
-				ServicePort: &s1.Spec.Ports[0],
-				Weight:      90,
+			services: []*dag.HTTPService{{
+				Service: dag.Service{
+					Object:      s1,
+					ServicePort: &s1.Spec.Ports[0],
+					Weight:      90,
+				},
 			}, {
-				Object:      s1, // it's valid to mention the same service several times per route.
-				ServicePort: &s1.Spec.Ports[0],
+				Service: dag.Service{
+					Object:      s1, // it's valid to mention the same service several times per route.
+					ServicePort: &s1.Spec.Ports[0],
+				},
 			}},
 			want: &route.Route_Route{
 				Route: &route.RouteAction{
@@ -163,9 +168,11 @@ func TestRouteRoute(t *testing.T) {
 				NumRetries:    7,                // ignored
 				PerTryTimeout: 10 * time.Second, // ignored
 			},
-			services: []*dag.Service{{
-				Object:      s1,
-				ServicePort: &s1.Spec.Ports[0],
+			services: []*dag.HTTPService{{
+				Service: dag.Service{
+					Object:      s1,
+					ServicePort: &s1.Spec.Ports[0],
+				},
 			}},
 			want: &route.Route_Route{
 				Route: &route.RouteAction{
@@ -183,9 +190,11 @@ func TestRouteRoute(t *testing.T) {
 				NumRetries:    6,
 				PerTryTimeout: 100 * time.Millisecond,
 			},
-			services: []*dag.Service{{
-				Object:      s1,
-				ServicePort: &s1.Spec.Ports[0],
+			services: []*dag.HTTPService{{
+				Service: dag.Service{
+					Object:      s1,
+					ServicePort: &s1.Spec.Ports[0],
+				},
 			}},
 			want: &route.Route_Route{
 				Route: &route.RouteAction{
@@ -208,9 +217,11 @@ func TestRouteRoute(t *testing.T) {
 				Prefix:  "/",
 				Timeout: 90 * time.Second,
 			},
-			services: []*dag.Service{{
-				Object:      s1,
-				ServicePort: &s1.Spec.Ports[0],
+			services: []*dag.HTTPService{{
+				Service: dag.Service{
+					Object:      s1,
+					ServicePort: &s1.Spec.Ports[0],
+				},
 			}},
 			want: &route.Route_Route{
 				Route: &route.RouteAction{
@@ -229,9 +240,11 @@ func TestRouteRoute(t *testing.T) {
 				Prefix:  "/",
 				Timeout: -1,
 			},
-			services: []*dag.Service{{
-				Object:      s1,
-				ServicePort: &s1.Spec.Ports[0],
+			services: []*dag.HTTPService{{
+				Service: dag.Service{
+					Object:      s1,
+					ServicePort: &s1.Spec.Ports[0],
+				},
 			}},
 			want: &route.Route_Route{
 				Route: &route.RouteAction{
@@ -259,29 +272,23 @@ func TestRouteRoute(t *testing.T) {
 
 func TestWeightedClusters(t *testing.T) {
 	tests := map[string]struct {
-		services []*dag.Service
+		services []*dag.HTTPService
 		want     *route.WeightedCluster
 	}{
 		"multiple services w/o weights": {
-			services: []*dag.Service{{
-				Object: &v1.Service{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "kuard",
-						Namespace: "default",
+			services: []*dag.HTTPService{{
+				Service: dag.Service{
+					Object: service("default", "kuard"),
+					ServicePort: &v1.ServicePort{
+						Port: 8080,
 					},
-				},
-				ServicePort: &v1.ServicePort{
-					Port: 8080,
 				},
 			}, {
-				Object: &v1.Service{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "nginx",
-						Namespace: "default",
+				Service: dag.Service{
+					Object: service("default", "nginx"),
+					ServicePort: &v1.ServicePort{
+						Port: 8080,
 					},
-				},
-				ServicePort: &v1.ServicePort{
-					Port: 8080,
 				},
 			}},
 			want: &route.WeightedCluster{
@@ -298,28 +305,22 @@ func TestWeightedClusters(t *testing.T) {
 			},
 		},
 		"multiple weighted services": {
-			services: []*dag.Service{{
-				Object: &v1.Service{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "kuard",
-						Namespace: "default",
+			services: []*dag.HTTPService{{
+				Service: dag.Service{
+					Object: service("default", "kuard"),
+					ServicePort: &v1.ServicePort{
+						Port: 8080,
 					},
+					Weight: 80,
 				},
-				ServicePort: &v1.ServicePort{
-					Port: 8080,
-				},
-				Weight: 80,
 			}, {
-				Object: &v1.Service{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "nginx",
-						Namespace: "default",
+				Service: dag.Service{
+					Object: service("default", "nginx"),
+					ServicePort: &v1.ServicePort{
+						Port: 8080,
 					},
+					Weight: 20,
 				},
-				ServicePort: &v1.ServicePort{
-					Port: 8080,
-				},
-				Weight: 20,
 			}},
 			want: &route.WeightedCluster{
 				Clusters: []*route.WeightedCluster_ClusterWeight{{
@@ -335,37 +336,28 @@ func TestWeightedClusters(t *testing.T) {
 			},
 		},
 		"multiple weighted services and one with no weight specified": {
-			services: []*dag.Service{{
-				Object: &v1.Service{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "kuard",
-						Namespace: "default",
+			services: []*dag.HTTPService{{
+				Service: dag.Service{
+					Object: service("default", "kuard"),
+					ServicePort: &v1.ServicePort{
+						Port: 8080,
 					},
+					Weight: 80,
 				},
-				ServicePort: &v1.ServicePort{
-					Port: 8080,
-				},
-				Weight: 80,
 			}, {
-				Object: &v1.Service{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "nginx",
-						Namespace: "default",
+				Service: dag.Service{
+					Object: service("default", "nginx"),
+					ServicePort: &v1.ServicePort{
+						Port: 8080,
 					},
+					Weight: 20,
 				},
-				ServicePort: &v1.ServicePort{
-					Port: 8080,
-				},
-				Weight: 20,
 			}, {
-				Object: &v1.Service{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "notraffic",
-						Namespace: "default",
+				Service: dag.Service{
+					Object: service("default", "notraffic"),
+					ServicePort: &v1.ServicePort{
+						Port: 8080,
 					},
-				},
-				ServicePort: &v1.ServicePort{
-					Port: 8080,
 				},
 			}},
 			want: &route.WeightedCluster{


### PR DESCRIPTION
Updates #785 

Create a new `dag.HTTPService` type to represent k8s services providing an L7 HTTP endpoint.