### PR TITLE
internal/dag: remove Service.Object field

### DIFF
--- a/internal/dag/builder_test.go
+++ b/internal/dag/builder_test.go
@@ -1,4 +1,4 @@
-// Copyright © 2018 Heptio
+// Copyright © 2017 Heptio
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -2178,7 +2178,8 @@ func TestDAGInsert(t *testing.T) {
 						route("/", i3a, servicemap(
 							&HTTPService{
 								Service: Service{
-									Object:      s3a,
+									Name:        s3a.Name,
+									Namespace:   s3a.Namespace,
 									ServicePort: &s3a.Spec.Ports[0],
 								},
 								Protocol: "h2c",
@@ -2200,7 +2201,8 @@ func TestDAGInsert(t *testing.T) {
 						route("/", i3a, servicemap(
 							&HTTPService{
 								Service: Service{
-									Object:      s3b,
+									Name:        s3b.Name,
+									Namespace:   s3b.Namespace,
 									ServicePort: &s3b.Spec.Ports[0],
 								},
 								Protocol: "h2",
@@ -2223,7 +2225,8 @@ func TestDAGInsert(t *testing.T) {
 						route("/", i1, servicemap(
 							&HTTPService{
 								Service: Service{
-									Object:             s1b,
+									Name:               s1b.Name,
+									Namespace:          s1b.Namespace,
 									ServicePort:        &s1b.Spec.Ports[0],
 									MaxConnections:     9000,
 									MaxPendingRequests: 4096,
@@ -2248,7 +2251,8 @@ func TestDAGInsert(t *testing.T) {
 						route("/a", ir13, servicemap(
 							&HTTPService{
 								Service: Service{
-									Object:      s1,
+									Name:        s1.Name,
+									Namespace:   s1.Namespace,
 									ServicePort: &s1.Spec.Ports[0],
 									Weight:      90,
 								},
@@ -2257,7 +2261,8 @@ func TestDAGInsert(t *testing.T) {
 						route("/b", ir13, servicemap(
 							&HTTPService{
 								Service: Service{
-									Object:      s1,
+									Name:        s1.Name,
+									Namespace:   s1.Namespace,
 									ServicePort: &s1.Spec.Ports[0],
 									Weight:      60,
 								},
@@ -2279,14 +2284,16 @@ func TestDAGInsert(t *testing.T) {
 						route("/a", ir13a, servicemap(
 							&HTTPService{
 								Service: Service{
-									Object:      s1,
+									Name:        s1.Name,
+									Namespace:   s1.Namespace,
 									ServicePort: &s1.Spec.Ports[0],
 									Weight:      90,
 								},
 							},
 							&HTTPService{
 								Service: Service{
-									Object:      s1,
+									Name:        s1.Name,
+									Namespace:   s1.Namespace,
 									ServicePort: &s1.Spec.Ports[0],
 									Weight:      60,
 								},
@@ -3521,7 +3528,11 @@ func route(prefix string, obj interface{}, httpServices ...map[servicemeta]*HTTP
 
 func httpService(s *v1.Service) *HTTPService {
 	return &HTTPService{
-		Service: Service{Object: s, ServicePort: &s.Spec.Ports[0]},
+		Service: Service{
+			Name:        s.Name,
+			Namespace:   s.Namespace,
+			ServicePort: &s.Spec.Ports[0],
+		},
 	}
 }
 

--- a/internal/dag/dag.go
+++ b/internal/dag/dag.go
@@ -158,7 +158,7 @@ type Vertex interface {
 // Service represents a raw Kuberentes Service as a DAG vertex.
 // A Service is a leaf in the DAG.
 type Service struct {
-	Object *v1.Service
+	Name, Namespace string
 
 	*v1.ServicePort
 	Weight int
@@ -185,9 +185,6 @@ type Service struct {
 	// Envoy will allow to the upstream cluster.
 	MaxRetries int
 }
-
-func (s *Service) Name() string      { return s.Object.Name }
-func (s *Service) Namespace() string { return s.Object.Namespace }
 
 // HTTPService represents a Kuberneres Service object which speaks
 // HTTP/1.1 or HTTP/2.0.
@@ -217,8 +214,8 @@ type servicemeta struct {
 
 func (s *HTTPService) toMeta() servicemeta {
 	return servicemeta{
-		name:        s.Object.Name,
-		namespace:   s.Object.Namespace,
+		name:        s.Name,
+		namespace:   s.Namespace,
 		port:        s.Port,
 		weight:      s.Weight,
 		strategy:    s.LoadBalancerStrategy,

--- a/internal/debug/dot.go
+++ b/internal/debug/dot.go
@@ -45,7 +45,7 @@ func (c *ctx) writeVertex(v dag.Vertex) {
 	case *dag.Secret:
 		fmt.Fprintf(c.w, `"%p" [shape=record, label="{secret|%s/%s}"]`+"\n", v, v.Namespace(), v.Name())
 	case *dag.HTTPService:
-		fmt.Fprintf(c.w, `"%p" [shape=record, label="{service|%s/%s:%d}"]`+"\n", v, v.Namespace(), v.Name(), v.Port)
+		fmt.Fprintf(c.w, `"%p" [shape=record, label="{service|%s/%s:%d}"]`+"\n", v, v.Namespace, v.Name, v.Port)
 	case *dag.VirtualHost:
 		fmt.Fprintf(c.w, `"%p" [shape=record, label="{http://%s:%d}"]`+"\n", v, v.Host, v.Port)
 	case *dag.SecureVirtualHost:

--- a/internal/envoy/cluster.go
+++ b/internal/envoy/cluster.go
@@ -71,8 +71,8 @@ func httpCluster(service *dag.HTTPService) *v2.Cluster {
 
 func edsconfig(cluster string, service *dag.Service) *v2.Cluster_EdsClusterConfig {
 	name := []string{
-		service.Namespace(),
-		service.Name(),
+		service.Namespace,
+		service.Name,
 		service.ServicePort.Name,
 	}
 	if name[2] == "" {
@@ -128,8 +128,8 @@ func Clustername(service *dag.HTTPService) string {
 	}
 
 	hash := sha1.Sum([]byte(buf))
-	ns := service.Namespace()
-	name := service.Name()
+	ns := service.Namespace
+	name := service.Name
 	return hashname(60, ns, name, strconv.Itoa(int(service.Port)), fmt.Sprintf("%x", hash[:5]))
 }
 

--- a/internal/envoy/cluster_test.go
+++ b/internal/envoy/cluster_test.go
@@ -51,11 +51,7 @@ func TestCluster(t *testing.T) {
 	}{
 		"simple service": {
 			service: &dag.HTTPService{
-				Service: dag.Service{
-					Name:        s1.Name,
-					Namespace:   s1.Namespace,
-					ServicePort: &s1.Spec.Ports[0],
-				},
+				Service: service(s1),
 			},
 			want: &v2.Cluster{
 				Name: "default/kuard/443/da39a3ee5e",
@@ -396,4 +392,12 @@ func TestU32nil(t *testing.T) {
 
 	assert(nil, u32nil(0))
 	assert(u32(1), u32nil(1))
+}
+
+func service(s *v1.Service) dag.Service {
+	return dag.Service{
+		Name:        s.Name,
+		Namespace:   s.Namespace,
+		ServicePort: &s.Spec.Ports[0],
+	}
 }

--- a/internal/envoy/cluster_test.go
+++ b/internal/envoy/cluster_test.go
@@ -52,7 +52,8 @@ func TestCluster(t *testing.T) {
 		"simple service": {
 			service: &dag.HTTPService{
 				Service: dag.Service{
-					Object:      s1,
+					Name:        s1.Name,
+					Namespace:   s1.Namespace,
 					ServicePort: &s1.Spec.Ports[0],
 				},
 			},
@@ -71,7 +72,7 @@ func TestCluster(t *testing.T) {
 		"h2c upstream": {
 			service: &dag.HTTPService{
 				Service: dag.Service{
-					Object:      s1,
+					Name: s1.Name, Namespace: s1.Namespace,
 					ServicePort: &s1.Spec.Ports[0],
 				},
 				Protocol: "h2c",
@@ -92,7 +93,7 @@ func TestCluster(t *testing.T) {
 		"h2 upstream": {
 			service: &dag.HTTPService{
 				Service: dag.Service{
-					Object:      s1,
+					Name: s1.Name, Namespace: s1.Namespace,
 					ServicePort: &s1.Spec.Ports[0],
 				},
 				Protocol: "h2",
@@ -114,7 +115,7 @@ func TestCluster(t *testing.T) {
 		"contour.heptio.com/max-connections": {
 			service: &dag.HTTPService{
 				Service: dag.Service{
-					Object:         s1,
+					Name: s1.Name, Namespace: s1.Namespace,
 					ServicePort:    &s1.Spec.Ports[0],
 					MaxConnections: 9000,
 				},
@@ -139,7 +140,7 @@ func TestCluster(t *testing.T) {
 		"contour.heptio.com/max-pending-requests": {
 			service: &dag.HTTPService{
 				Service: dag.Service{
-					Object:             s1,
+					Name: s1.Name, Namespace: s1.Namespace,
 					ServicePort:        &s1.Spec.Ports[0],
 					MaxPendingRequests: 4096,
 				},
@@ -164,7 +165,7 @@ func TestCluster(t *testing.T) {
 		"contour.heptio.com/max-requests": {
 			service: &dag.HTTPService{
 				Service: dag.Service{
-					Object:      s1,
+					Name: s1.Name, Namespace: s1.Namespace,
 					ServicePort: &s1.Spec.Ports[0],
 					MaxRequests: 404,
 				},
@@ -189,7 +190,7 @@ func TestCluster(t *testing.T) {
 		"contour.heptio.com/max-retries": {
 			service: &dag.HTTPService{
 				Service: dag.Service{
-					Object:      s1,
+					Name: s1.Name, Namespace: s1.Namespace,
 					ServicePort: &s1.Spec.Ports[0],
 					MaxRetries:  7,
 				},
@@ -231,7 +232,8 @@ func TestClustername(t *testing.T) {
 		"simple": {
 			service: &dag.HTTPService{
 				Service: dag.Service{
-					Object: service("default", "backend"),
+					Name:      "backend",
+					Namespace: "default",
 					ServicePort: &v1.ServicePort{
 						Name:       "http",
 						Protocol:   "TCP",
@@ -245,7 +247,8 @@ func TestClustername(t *testing.T) {
 		"far too long": {
 			service: &dag.HTTPService{
 				Service: dag.Service{
-					Object: service("it-is-a-truth-universally-acknowledged-that-a-single-man-in-possession-of-a-good-fortune", "must-be-in-want-of-a-wife"),
+					Name:      "must-be-in-want-of-a-wife",
+					Namespace: "it-is-a-truth-universally-acknowledged-that-a-single-man-in-possession-of-a-good-fortune",
 					ServicePort: &v1.ServicePort{
 						Name:       "http",
 						Protocol:   "TCP",
@@ -259,7 +262,8 @@ func TestClustername(t *testing.T) {
 		"various healthcheck params": {
 			service: &dag.HTTPService{
 				Service: dag.Service{
-					Object: service("default", "backend"),
+					Name:      "backend",
+					Namespace: "default",
 					ServicePort: &v1.ServicePort{
 						Name:       "http",
 						Protocol:   "TCP",
@@ -392,21 +396,4 @@ func TestU32nil(t *testing.T) {
 
 	assert(nil, u32nil(0))
 	assert(u32(1), u32nil(1))
-}
-
-func service(ns, name string, ports ...v1.ServicePort) *v1.Service {
-	return serviceWithAnnotations(ns, name, nil, ports...)
-}
-
-func serviceWithAnnotations(ns, name string, annotations map[string]string, ports ...v1.ServicePort) *v1.Service {
-	return &v1.Service{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:        name,
-			Namespace:   ns,
-			Annotations: annotations,
-		},
-		Spec: v1.ServiceSpec{
-			Ports: ports,
-		},
-	}
 }

--- a/internal/envoy/route_test.go
+++ b/internal/envoy/route_test.go
@@ -52,7 +52,8 @@ func TestRouteRoute(t *testing.T) {
 			},
 			services: []*dag.HTTPService{{
 				Service: dag.Service{
-					Object: service("default", "kuard"),
+					Name:      "kuard",
+					Namespace: "default",
 					ServicePort: &v1.ServicePort{
 						Port: 8080,
 					},
@@ -75,7 +76,7 @@ func TestRouteRoute(t *testing.T) {
 			},
 			services: []*dag.HTTPService{{
 				Service: dag.Service{
-					Object:      s1,
+					Name: s1.Name, Namespace: s1.Namespace,
 					ServicePort: &s1.Spec.Ports[0],
 				},
 			}},
@@ -97,13 +98,13 @@ func TestRouteRoute(t *testing.T) {
 			},
 			services: []*dag.HTTPService{{
 				Service: dag.Service{
-					Object:      s1,
+					Name: s1.Name, Namespace: s1.Namespace,
 					ServicePort: &s1.Spec.Ports[0],
 					Weight:      90,
 				},
 			}, {
 				Service: dag.Service{
-					Object:      s1, // it's valid to mention the same service several times per route.
+					Name: s1.Name, Namespace: s1.Namespace, // it's valid to mention the same service several times per route.
 					ServicePort: &s1.Spec.Ports[0],
 				},
 			}},
@@ -133,13 +134,13 @@ func TestRouteRoute(t *testing.T) {
 			},
 			services: []*dag.HTTPService{{
 				Service: dag.Service{
-					Object:      s1,
+					Name: s1.Name, Namespace: s1.Namespace,
 					ServicePort: &s1.Spec.Ports[0],
 					Weight:      90,
 				},
 			}, {
 				Service: dag.Service{
-					Object:      s1, // it's valid to mention the same service several times per route.
+					Name: s1.Name, Namespace: s1.Namespace, // it's valid to mention the same service several times per route.
 					ServicePort: &s1.Spec.Ports[0],
 				},
 			}},
@@ -170,7 +171,7 @@ func TestRouteRoute(t *testing.T) {
 			},
 			services: []*dag.HTTPService{{
 				Service: dag.Service{
-					Object:      s1,
+					Name: s1.Name, Namespace: s1.Namespace,
 					ServicePort: &s1.Spec.Ports[0],
 				},
 			}},
@@ -192,7 +193,7 @@ func TestRouteRoute(t *testing.T) {
 			},
 			services: []*dag.HTTPService{{
 				Service: dag.Service{
-					Object:      s1,
+					Name: s1.Name, Namespace: s1.Namespace,
 					ServicePort: &s1.Spec.Ports[0],
 				},
 			}},
@@ -219,7 +220,7 @@ func TestRouteRoute(t *testing.T) {
 			},
 			services: []*dag.HTTPService{{
 				Service: dag.Service{
-					Object:      s1,
+					Name: s1.Name, Namespace: s1.Namespace,
 					ServicePort: &s1.Spec.Ports[0],
 				},
 			}},
@@ -242,7 +243,7 @@ func TestRouteRoute(t *testing.T) {
 			},
 			services: []*dag.HTTPService{{
 				Service: dag.Service{
-					Object:      s1,
+					Name: s1.Name, Namespace: s1.Namespace,
 					ServicePort: &s1.Spec.Ports[0],
 				},
 			}},
@@ -278,14 +279,16 @@ func TestWeightedClusters(t *testing.T) {
 		"multiple services w/o weights": {
 			services: []*dag.HTTPService{{
 				Service: dag.Service{
-					Object: service("default", "kuard"),
+					Name:      "kuard",
+					Namespace: "default",
 					ServicePort: &v1.ServicePort{
 						Port: 8080,
 					},
 				},
 			}, {
 				Service: dag.Service{
-					Object: service("default", "nginx"),
+					Name:      "nginx",
+					Namespace: "default",
 					ServicePort: &v1.ServicePort{
 						Port: 8080,
 					},
@@ -307,7 +310,8 @@ func TestWeightedClusters(t *testing.T) {
 		"multiple weighted services": {
 			services: []*dag.HTTPService{{
 				Service: dag.Service{
-					Object: service("default", "kuard"),
+					Name:      "kuard",
+					Namespace: "default",
 					ServicePort: &v1.ServicePort{
 						Port: 8080,
 					},
@@ -315,7 +319,8 @@ func TestWeightedClusters(t *testing.T) {
 				},
 			}, {
 				Service: dag.Service{
-					Object: service("default", "nginx"),
+					Name:      "nginx",
+					Namespace: "default",
 					ServicePort: &v1.ServicePort{
 						Port: 8080,
 					},
@@ -338,7 +343,8 @@ func TestWeightedClusters(t *testing.T) {
 		"multiple weighted services and one with no weight specified": {
 			services: []*dag.HTTPService{{
 				Service: dag.Service{
-					Object: service("default", "kuard"),
+					Name:      "kuard",
+					Namespace: "default",
 					ServicePort: &v1.ServicePort{
 						Port: 8080,
 					},
@@ -346,7 +352,8 @@ func TestWeightedClusters(t *testing.T) {
 				},
 			}, {
 				Service: dag.Service{
-					Object: service("default", "nginx"),
+					Name:      "nginx",
+					Namespace: "default",
 					ServicePort: &v1.ServicePort{
 						Port: 8080,
 					},
@@ -354,7 +361,8 @@ func TestWeightedClusters(t *testing.T) {
 				},
 			}, {
 				Service: dag.Service{
-					Object: service("default", "notraffic"),
+					Name:      "notraffic",
+					Namespace: "default",
 					ServicePort: &v1.ServicePort{
 						Port: 8080,
 					},

--- a/internal/envoy/route_test.go
+++ b/internal/envoy/route_test.go
@@ -51,13 +51,7 @@ func TestRouteRoute(t *testing.T) {
 				Prefix: "/",
 			},
 			services: []*dag.HTTPService{{
-				Service: dag.Service{
-					Name:      "kuard",
-					Namespace: "default",
-					ServicePort: &v1.ServicePort{
-						Port: 8080,
-					},
-				},
+				Service: service(s1),
 			}},
 			want: &route.Route_Route{
 				Route: &route.RouteAction{
@@ -75,10 +69,7 @@ func TestRouteRoute(t *testing.T) {
 				Websocket: true,
 			},
 			services: []*dag.HTTPService{{
-				Service: dag.Service{
-					Name: s1.Name, Namespace: s1.Namespace,
-					ServicePort: &s1.Spec.Ports[0],
-				},
+				Service: service(s1),
 			}},
 			want: &route.Route_Route{
 				Route: &route.RouteAction{
@@ -98,7 +89,8 @@ func TestRouteRoute(t *testing.T) {
 			},
 			services: []*dag.HTTPService{{
 				Service: dag.Service{
-					Name: s1.Name, Namespace: s1.Namespace,
+					Name:        s1.Name,
+					Namespace:   s1.Namespace,
 					ServicePort: &s1.Spec.Ports[0],
 					Weight:      90,
 				},
@@ -134,15 +126,13 @@ func TestRouteRoute(t *testing.T) {
 			},
 			services: []*dag.HTTPService{{
 				Service: dag.Service{
-					Name: s1.Name, Namespace: s1.Namespace,
+					Name:        s1.Name,
+					Namespace:   s1.Namespace,
 					ServicePort: &s1.Spec.Ports[0],
 					Weight:      90,
 				},
 			}, {
-				Service: dag.Service{
-					Name: s1.Name, Namespace: s1.Namespace, // it's valid to mention the same service several times per route.
-					ServicePort: &s1.Spec.Ports[0],
-				},
+				Service: service(s1), // it's valid to mention the same service several times per route.
 			}},
 			want: &route.Route_Route{
 				Route: &route.RouteAction{
@@ -170,10 +160,7 @@ func TestRouteRoute(t *testing.T) {
 				PerTryTimeout: 10 * time.Second, // ignored
 			},
 			services: []*dag.HTTPService{{
-				Service: dag.Service{
-					Name: s1.Name, Namespace: s1.Namespace,
-					ServicePort: &s1.Spec.Ports[0],
-				},
+				Service: service(s1),
 			}},
 			want: &route.Route_Route{
 				Route: &route.RouteAction{
@@ -192,10 +179,7 @@ func TestRouteRoute(t *testing.T) {
 				PerTryTimeout: 100 * time.Millisecond,
 			},
 			services: []*dag.HTTPService{{
-				Service: dag.Service{
-					Name: s1.Name, Namespace: s1.Namespace,
-					ServicePort: &s1.Spec.Ports[0],
-				},
+				Service: service(s1),
 			}},
 			want: &route.Route_Route{
 				Route: &route.RouteAction{
@@ -219,10 +203,7 @@ func TestRouteRoute(t *testing.T) {
 				Timeout: 90 * time.Second,
 			},
 			services: []*dag.HTTPService{{
-				Service: dag.Service{
-					Name: s1.Name, Namespace: s1.Namespace,
-					ServicePort: &s1.Spec.Ports[0],
-				},
+				Service: service(s1),
 			}},
 			want: &route.Route_Route{
 				Route: &route.RouteAction{
@@ -242,10 +223,7 @@ func TestRouteRoute(t *testing.T) {
 				Timeout: -1,
 			},
 			services: []*dag.HTTPService{{
-				Service: dag.Service{
-					Name: s1.Name, Namespace: s1.Namespace,
-					ServicePort: &s1.Spec.Ports[0],
-				},
+				Service: service(s1),
 			}},
 			want: &route.Route_Route{
 				Route: &route.RouteAction{


### PR DESCRIPTION
Updates #789

The only property of Service.Object we needed was the Metadata.Name and
Namespace fields. Extract these to the dag.Service object.

Signed-off-by: Dave Cheney <dave@cheney.net>