### PR TITLE
interna/dag: refactor dag.Service to dag.TCPService

### DIFF
--- a/internal/contour/cluster.go
+++ b/internal/contour/cluster.go
@@ -103,7 +103,7 @@ func (v *clusterVisitor) Visit() map[string]*v2.Cluster {
 func (v *clusterVisitor) visit(vertex dag.Vertex) {
 	switch service := vertex.(type) {
 	case *dag.HTTPService:
-		name := envoy.Clustername(&service.Service)
+		name := envoy.Clustername(&service.TCPService)
 		if _, ok := v.clusters[name]; !ok {
 			c := envoy.Cluster(service)
 			v.clusters[c.Name] = c

--- a/internal/dag/builder.go
+++ b/internal/dag/builder.go
@@ -142,7 +142,7 @@ func (b *Builder) Build() *DAG {
 type builder struct {
 	source *Builder
 
-	services map[servicemeta]ServiceVertex
+	services map[servicemeta]Service
 	secrets  map[meta]*Secret
 	vhosts   map[hostport]*VirtualHost
 	svhosts  map[hostport]*SecureVirtualHost
@@ -179,7 +179,7 @@ func (b *builder) lookupHTTPService(m meta, port intstr.IntOrString, weight int,
 	}
 }
 
-func (b *builder) lookupService(m meta, port intstr.IntOrString, weight int, strategy string, hc *ingressroutev1.HealthCheck) ServiceVertex {
+func (b *builder) lookupService(m meta, port intstr.IntOrString, weight int, strategy string, hc *ingressroutev1.HealthCheck) Service {
 	if port.Type != intstr.Int {
 		// can't handle, give up
 		return nil
@@ -205,7 +205,7 @@ func healthcheckToString(hc *ingressroutev1.HealthCheck) string {
 
 func (b *builder) addHTTPService(svc *v1.Service, port *v1.ServicePort, weight int, strategy string, hc *ingressroutev1.HealthCheck) *HTTPService {
 	if b.services == nil {
-		b.services = make(map[servicemeta]ServiceVertex)
+		b.services = make(map[servicemeta]Service)
 	}
 	up := parseUpstreamProtocols(svc.Annotations, annotationUpstreamProtocol, "h2", "h2c")
 	protocol := up[port.Name]
@@ -214,7 +214,7 @@ func (b *builder) addHTTPService(svc *v1.Service, port *v1.ServicePort, weight i
 	}
 
 	s := &HTTPService{
-		Service: Service{
+		TCPService: TCPService{
 			Name:                 svc.Name,
 			Namespace:            svc.Namespace,
 			ServicePort:          port,

--- a/internal/dag/builder_test.go
+++ b/internal/dag/builder_test.go
@@ -2177,7 +2177,7 @@ func TestDAGInsert(t *testing.T) {
 					routes: routemap(
 						route("/", i3a, servicemap(
 							&HTTPService{
-								Service: Service{
+								TCPService: TCPService{
 									Name:        s3a.Name,
 									Namespace:   s3a.Namespace,
 									ServicePort: &s3a.Spec.Ports[0],
@@ -2200,7 +2200,7 @@ func TestDAGInsert(t *testing.T) {
 					routes: routemap(
 						route("/", i3a, servicemap(
 							&HTTPService{
-								Service: Service{
+								TCPService: TCPService{
 									Name:        s3b.Name,
 									Namespace:   s3b.Namespace,
 									ServicePort: &s3b.Spec.Ports[0],
@@ -2224,7 +2224,7 @@ func TestDAGInsert(t *testing.T) {
 					routes: routemap(
 						route("/", i1, servicemap(
 							&HTTPService{
-								Service: Service{
+								TCPService: TCPService{
 									Name:               s1b.Name,
 									Namespace:          s1b.Namespace,
 									ServicePort:        &s1b.Spec.Ports[0],
@@ -2250,7 +2250,7 @@ func TestDAGInsert(t *testing.T) {
 					routes: routemap(
 						route("/a", ir13, servicemap(
 							&HTTPService{
-								Service: Service{
+								TCPService: TCPService{
 									Name:        s1.Name,
 									Namespace:   s1.Namespace,
 									ServicePort: &s1.Spec.Ports[0],
@@ -2260,7 +2260,7 @@ func TestDAGInsert(t *testing.T) {
 						),
 						route("/b", ir13, servicemap(
 							&HTTPService{
-								Service: Service{
+								TCPService: TCPService{
 									Name:        s1.Name,
 									Namespace:   s1.Namespace,
 									ServicePort: &s1.Spec.Ports[0],
@@ -2283,7 +2283,7 @@ func TestDAGInsert(t *testing.T) {
 					routes: routemap(
 						route("/a", ir13a, servicemap(
 							&HTTPService{
-								Service: Service{
+								TCPService: TCPService{
 									Name:        s1.Name,
 									Namespace:   s1.Namespace,
 									ServicePort: &s1.Spec.Ports[0],
@@ -2291,7 +2291,7 @@ func TestDAGInsert(t *testing.T) {
 								},
 							},
 							&HTTPService{
-								Service: Service{
+								TCPService: TCPService{
 									Name:        s1.Name,
 									Namespace:   s1.Namespace,
 									ServicePort: &s1.Spec.Ports[0],
@@ -3528,7 +3528,7 @@ func route(prefix string, obj interface{}, httpServices ...map[servicemeta]*HTTP
 
 func httpService(s *v1.Service) *HTTPService {
 	return &HTTPService{
-		Service: Service{
+		TCPService: TCPService{
 			Name:        s.Name,
 			Namespace:   s.Namespace,
 			ServicePort: &s.Spec.Ports[0],

--- a/internal/envoy/cluster_test.go
+++ b/internal/envoy/cluster_test.go
@@ -46,12 +46,12 @@ func TestCluster(t *testing.T) {
 	}
 
 	tests := map[string]struct {
-		service dag.ServiceVertex
+		service dag.Service
 		want    *v2.Cluster
 	}{
 		"simple service": {
 			service: &dag.HTTPService{
-				Service: service(s1),
+				TCPService: service(s1),
 			},
 			want: &v2.Cluster{
 				Name: "default/kuard/443/da39a3ee5e",
@@ -67,11 +67,8 @@ func TestCluster(t *testing.T) {
 		},
 		"h2c upstream": {
 			service: &dag.HTTPService{
-				Service: dag.Service{
-					Name: s1.Name, Namespace: s1.Namespace,
-					ServicePort: &s1.Spec.Ports[0],
-				},
-				Protocol: "h2c",
+				TCPService: service(s1),
+				Protocol:   "h2c",
 			},
 			want: &v2.Cluster{
 				Name: "default/kuard/443/da39a3ee5e",
@@ -88,11 +85,8 @@ func TestCluster(t *testing.T) {
 		},
 		"h2 upstream": {
 			service: &dag.HTTPService{
-				Service: dag.Service{
-					Name: s1.Name, Namespace: s1.Namespace,
-					ServicePort: &s1.Spec.Ports[0],
-				},
-				Protocol: "h2",
+				TCPService: service(s1),
+				Protocol:   "h2",
 			},
 			want: &v2.Cluster{
 				Name: "default/kuard/443/da39a3ee5e",
@@ -110,7 +104,7 @@ func TestCluster(t *testing.T) {
 		},
 		"contour.heptio.com/max-connections": {
 			service: &dag.HTTPService{
-				Service: dag.Service{
+				TCPService: dag.TCPService{
 					Name: s1.Name, Namespace: s1.Namespace,
 					ServicePort:    &s1.Spec.Ports[0],
 					MaxConnections: 9000,
@@ -135,7 +129,7 @@ func TestCluster(t *testing.T) {
 		},
 		"contour.heptio.com/max-pending-requests": {
 			service: &dag.HTTPService{
-				Service: dag.Service{
+				TCPService: dag.TCPService{
 					Name: s1.Name, Namespace: s1.Namespace,
 					ServicePort:        &s1.Spec.Ports[0],
 					MaxPendingRequests: 4096,
@@ -160,7 +154,7 @@ func TestCluster(t *testing.T) {
 		},
 		"contour.heptio.com/max-requests": {
 			service: &dag.HTTPService{
-				Service: dag.Service{
+				TCPService: dag.TCPService{
 					Name: s1.Name, Namespace: s1.Namespace,
 					ServicePort: &s1.Spec.Ports[0],
 					MaxRequests: 404,
@@ -185,7 +179,7 @@ func TestCluster(t *testing.T) {
 		},
 		"contour.heptio.com/max-retries": {
 			service: &dag.HTTPService{
-				Service: dag.Service{
+				TCPService: dag.TCPService{
 					Name: s1.Name, Namespace: s1.Namespace,
 					ServicePort: &s1.Spec.Ports[0],
 					MaxRetries:  7,
@@ -210,7 +204,8 @@ func TestCluster(t *testing.T) {
 		},
 		"tcp service": {
 			service: &dag.TCPService{
-				Service: service(s1),
+				Name: s1.Name, Namespace: s1.Namespace,
+				ServicePort: &s1.Spec.Ports[0],
 			},
 			want: &v2.Cluster{
 				Name: "default/kuard/443/da39a3ee5e",
@@ -238,11 +233,11 @@ func TestCluster(t *testing.T) {
 
 func TestClustername(t *testing.T) {
 	tests := map[string]struct {
-		service *dag.Service
+		service *dag.TCPService
 		want    string
 	}{
 		"simple": {
-			service: &dag.Service{
+			service: &dag.TCPService{
 				Name:      "backend",
 				Namespace: "default",
 				ServicePort: &v1.ServicePort{
@@ -255,7 +250,7 @@ func TestClustername(t *testing.T) {
 			want: "default/backend/80/da39a3ee5e",
 		},
 		"far too long": {
-			service: &dag.Service{
+			service: &dag.TCPService{
 				Name:      "must-be-in-want-of-a-wife",
 				Namespace: "it-is-a-truth-universally-acknowledged-that-a-single-man-in-possession-of-a-good-fortune",
 				ServicePort: &v1.ServicePort{
@@ -268,7 +263,7 @@ func TestClustername(t *testing.T) {
 			want: "it-is-a--dea8b0/must-be--dea8b0/9999/da39a3ee5e",
 		},
 		"various healthcheck params": {
-			service: &dag.Service{
+			service: &dag.TCPService{
 				Name:      "backend",
 				Namespace: "default",
 				ServicePort: &v1.ServicePort{
@@ -404,8 +399,8 @@ func TestU32nil(t *testing.T) {
 	assert(u32(1), u32nil(1))
 }
 
-func service(s *v1.Service) dag.Service {
-	return dag.Service{
+func service(s *v1.Service) dag.TCPService {
+	return dag.TCPService{
 		Name:        s.Name,
 		Namespace:   s.Namespace,
 		ServicePort: &s.Spec.Ports[0],

--- a/internal/envoy/healthcheck.go
+++ b/internal/envoy/healthcheck.go
@@ -31,7 +31,7 @@ const (
 )
 
 // healthCheck returns a *core.HealthCheck value.
-func healthCheck(service *dag.Service) *core.HealthCheck {
+func healthCheck(service *dag.TCPService) *core.HealthCheck {
 	hc := service.HealthCheck
 	host := hcHost
 	if hc.Host != "" {

--- a/internal/envoy/healthcheck_test.go
+++ b/internal/envoy/healthcheck_test.go
@@ -25,13 +25,13 @@ import (
 
 func TestHealthCheck(t *testing.T) {
 	tests := map[string]struct {
-		service *dag.Service
+		service *dag.TCPService
 		want    *core.HealthCheck
 	}{
 		// this is an odd case because contour.edshealthcheck will not call envoy.HealthCheck
 		// when hc is nil, so if hc is not nil, at least one of the parameters on it must be set.
 		"blank healthcheck": {
-			service: &dag.Service{
+			service: &dag.TCPService{
 				HealthCheck: new(ingressroutev1.HealthCheck),
 			},
 			want: &core.HealthCheck{
@@ -48,7 +48,7 @@ func TestHealthCheck(t *testing.T) {
 			},
 		},
 		"healthcheck path only": {
-			service: &dag.Service{
+			service: &dag.TCPService{
 				HealthCheck: &ingressroutev1.HealthCheck{
 					Path: "/healthy",
 				},
@@ -67,7 +67,7 @@ func TestHealthCheck(t *testing.T) {
 			},
 		},
 		"explicit healthcheck": {
-			service: &dag.Service{
+			service: &dag.TCPService{
 				HealthCheck: &ingressroutev1.HealthCheck{
 					Host:                    "foo-bar-host",
 					Path:                    "/healthy",

--- a/internal/envoy/route.go
+++ b/internal/envoy/route.go
@@ -37,7 +37,7 @@ func RouteRoute(r *dag.Route, services []*dag.HTTPService) *route.Route_Route {
 	switch len(services) {
 	case 1:
 		ra.ClusterSpecifier = &route.RouteAction_Cluster{
-			Cluster: Clustername(&services[0].Service),
+			Cluster: Clustername(&services[0].TCPService),
 		}
 		ra.RequestHeadersToAdd = headers(
 			appendHeader("x-request-start", "t=%START_TIME(%s.%3f)%"),
@@ -99,7 +99,7 @@ func weightedClusters(services []*dag.HTTPService) *route.WeightedCluster {
 	for _, service := range services {
 		total += service.Weight
 		wc.Clusters = append(wc.Clusters, &route.WeightedCluster_ClusterWeight{
-			Name:   Clustername(&service.Service),
+			Name:   Clustername(&service.TCPService),
 			Weight: u32(service.Weight),
 			RequestHeadersToAdd: headers(
 				appendHeader("x-request-start", "t=%START_TIME(%s.%3f)%"),

--- a/internal/envoy/route_test.go
+++ b/internal/envoy/route_test.go
@@ -51,7 +51,7 @@ func TestRouteRoute(t *testing.T) {
 				Prefix: "/",
 			},
 			services: []*dag.HTTPService{{
-				Service: service(s1),
+				TCPService: service(s1),
 			}},
 			want: &route.Route_Route{
 				Route: &route.RouteAction{
@@ -69,7 +69,7 @@ func TestRouteRoute(t *testing.T) {
 				Websocket: true,
 			},
 			services: []*dag.HTTPService{{
-				Service: service(s1),
+				TCPService: service(s1),
 			}},
 			want: &route.Route_Route{
 				Route: &route.RouteAction{
@@ -88,14 +88,14 @@ func TestRouteRoute(t *testing.T) {
 				Prefix: "/",
 			},
 			services: []*dag.HTTPService{{
-				Service: dag.Service{
+				TCPService: dag.TCPService{
 					Name:        s1.Name,
 					Namespace:   s1.Namespace,
 					ServicePort: &s1.Spec.Ports[0],
 					Weight:      90,
 				},
 			}, {
-				Service: dag.Service{
+				TCPService: dag.TCPService{
 					Name: s1.Name, Namespace: s1.Namespace, // it's valid to mention the same service several times per route.
 					ServicePort: &s1.Spec.Ports[0],
 				},
@@ -125,14 +125,14 @@ func TestRouteRoute(t *testing.T) {
 				Websocket: true,
 			},
 			services: []*dag.HTTPService{{
-				Service: dag.Service{
+				TCPService: dag.TCPService{
 					Name:        s1.Name,
 					Namespace:   s1.Namespace,
 					ServicePort: &s1.Spec.Ports[0],
 					Weight:      90,
 				},
 			}, {
-				Service: service(s1), // it's valid to mention the same service several times per route.
+				TCPService: service(s1), // it's valid to mention the same service several times per route.
 			}},
 			want: &route.Route_Route{
 				Route: &route.RouteAction{
@@ -160,7 +160,7 @@ func TestRouteRoute(t *testing.T) {
 				PerTryTimeout: 10 * time.Second, // ignored
 			},
 			services: []*dag.HTTPService{{
-				Service: service(s1),
+				TCPService: service(s1),
 			}},
 			want: &route.Route_Route{
 				Route: &route.RouteAction{
@@ -179,7 +179,7 @@ func TestRouteRoute(t *testing.T) {
 				PerTryTimeout: 100 * time.Millisecond,
 			},
 			services: []*dag.HTTPService{{
-				Service: service(s1),
+				TCPService: service(s1),
 			}},
 			want: &route.Route_Route{
 				Route: &route.RouteAction{
@@ -203,7 +203,7 @@ func TestRouteRoute(t *testing.T) {
 				Timeout: 90 * time.Second,
 			},
 			services: []*dag.HTTPService{{
-				Service: service(s1),
+				TCPService: service(s1),
 			}},
 			want: &route.Route_Route{
 				Route: &route.RouteAction{
@@ -223,7 +223,7 @@ func TestRouteRoute(t *testing.T) {
 				Timeout: -1,
 			},
 			services: []*dag.HTTPService{{
-				Service: service(s1),
+				TCPService: service(s1),
 			}},
 			want: &route.Route_Route{
 				Route: &route.RouteAction{
@@ -256,7 +256,7 @@ func TestWeightedClusters(t *testing.T) {
 	}{
 		"multiple services w/o weights": {
 			services: []*dag.HTTPService{{
-				Service: dag.Service{
+				TCPService: dag.TCPService{
 					Name:      "kuard",
 					Namespace: "default",
 					ServicePort: &v1.ServicePort{
@@ -264,7 +264,7 @@ func TestWeightedClusters(t *testing.T) {
 					},
 				},
 			}, {
-				Service: dag.Service{
+				TCPService: dag.TCPService{
 					Name:      "nginx",
 					Namespace: "default",
 					ServicePort: &v1.ServicePort{
@@ -287,7 +287,7 @@ func TestWeightedClusters(t *testing.T) {
 		},
 		"multiple weighted services": {
 			services: []*dag.HTTPService{{
-				Service: dag.Service{
+				TCPService: dag.TCPService{
 					Name:      "kuard",
 					Namespace: "default",
 					ServicePort: &v1.ServicePort{
@@ -296,7 +296,7 @@ func TestWeightedClusters(t *testing.T) {
 					Weight: 80,
 				},
 			}, {
-				Service: dag.Service{
+				TCPService: dag.TCPService{
 					Name:      "nginx",
 					Namespace: "default",
 					ServicePort: &v1.ServicePort{
@@ -320,7 +320,7 @@ func TestWeightedClusters(t *testing.T) {
 		},
 		"multiple weighted services and one with no weight specified": {
 			services: []*dag.HTTPService{{
-				Service: dag.Service{
+				TCPService: dag.TCPService{
 					Name:      "kuard",
 					Namespace: "default",
 					ServicePort: &v1.ServicePort{
@@ -329,7 +329,7 @@ func TestWeightedClusters(t *testing.T) {
 					Weight: 80,
 				},
 			}, {
-				Service: dag.Service{
+				TCPService: dag.TCPService{
 					Name:      "nginx",
 					Namespace: "default",
 					ServicePort: &v1.ServicePort{
@@ -338,7 +338,7 @@ func TestWeightedClusters(t *testing.T) {
 					Weight: 20,
 				},
 			}, {
-				Service: dag.Service{
+				TCPService: dag.TCPService{
 					Name:      "notraffic",
 					Namespace: "default",
 					ServicePort: &v1.ServicePort{


### PR DESCRIPTION
Updates #787

This PR rearranges and renames dag.ServiceVector, dag.Service, and
dag.HTTPService.

By recognising that dag.HTTPService represents a L7 service on top of a
L4 dag.TCPService we free up dag.Service as a descriptive name for an
interface which both L4 TCPService and L7 HTTPServices represent.

Signed-off-by: Dave Cheney <dave@cheney.net>