### PR TITLE
internal/envoy: expose ClusterCommonLBConfig

### DIFF
--- a/internal/contour/cluster_test.go
+++ b/internal/contour/cluster_test.go
@@ -20,7 +20,6 @@ import (
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2/cluster"
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
-	envoy_type "github.com/envoyproxy/go-control-plane/envoy/type"
 	"github.com/google/go-cmp/cmp"
 	ingressroutev1 "github.com/heptio/contour/apis/contour/v1beta1"
 	"github.com/heptio/contour/internal/envoy"
@@ -73,11 +72,7 @@ func TestClusterVisit(t *testing.T) {
 					},
 					ConnectTimeout: 250 * time.Millisecond,
 					LbPolicy:       v2.Cluster_ROUND_ROBIN,
-					CommonLbConfig: &v2.Cluster_CommonLbConfig{
-						HealthyPanicThreshold: &envoy_type.Percent{ // Disable HealthyPanicThreshold
-							Value: 0,
-						},
-					},
+					CommonLbConfig: envoy.ClusterCommonLBConfig(),
 				}),
 		},
 		"single named service": {
@@ -113,11 +108,7 @@ func TestClusterVisit(t *testing.T) {
 					},
 					ConnectTimeout: 250 * time.Millisecond,
 					LbPolicy:       v2.Cluster_ROUND_ROBIN,
-					CommonLbConfig: &v2.Cluster_CommonLbConfig{
-						HealthyPanicThreshold: &envoy_type.Percent{ // Disable HealthyPanicThreshold
-							Value: 0,
-						},
-					},
+					CommonLbConfig: envoy.ClusterCommonLBConfig(),
 				}),
 		},
 		"h2c upstream": {
@@ -158,11 +149,7 @@ func TestClusterVisit(t *testing.T) {
 					ConnectTimeout:       250 * time.Millisecond,
 					LbPolicy:             v2.Cluster_ROUND_ROBIN,
 					Http2ProtocolOptions: &core.Http2ProtocolOptions{},
-					CommonLbConfig: &v2.Cluster_CommonLbConfig{
-						HealthyPanicThreshold: &envoy_type.Percent{ // Disable HealthyPanicThreshold
-							Value: 0,
-						},
-					},
+					CommonLbConfig:       envoy.ClusterCommonLBConfig(),
 				},
 			),
 		},
@@ -199,11 +186,7 @@ func TestClusterVisit(t *testing.T) {
 					},
 					ConnectTimeout: 250 * time.Millisecond,
 					LbPolicy:       v2.Cluster_ROUND_ROBIN,
-					CommonLbConfig: &v2.Cluster_CommonLbConfig{
-						HealthyPanicThreshold: &envoy_type.Percent{ // Disable HealthyPanicThreshold
-							Value: 0,
-						},
-					},
+					CommonLbConfig: envoy.ClusterCommonLBConfig(),
 				}),
 		},
 		"two service ports": {
@@ -251,11 +234,7 @@ func TestClusterVisit(t *testing.T) {
 					},
 					ConnectTimeout: 250 * time.Millisecond,
 					LbPolicy:       v2.Cluster_ROUND_ROBIN,
-					CommonLbConfig: &v2.Cluster_CommonLbConfig{
-						HealthyPanicThreshold: &envoy_type.Percent{ // Disable HealthyPanicThreshold
-							Value: 0,
-						},
-					},
+					CommonLbConfig: envoy.ClusterCommonLBConfig(),
 				},
 				&v2.Cluster{
 					Name: "default/backend/8080/da39a3ee5e",
@@ -266,11 +245,7 @@ func TestClusterVisit(t *testing.T) {
 					},
 					ConnectTimeout: 250 * time.Millisecond,
 					LbPolicy:       v2.Cluster_ROUND_ROBIN,
-					CommonLbConfig: &v2.Cluster_CommonLbConfig{
-						HealthyPanicThreshold: &envoy_type.Percent{ // Disable HealthyPanicThreshold
-							Value: 0,
-						},
-					},
+					CommonLbConfig: envoy.ClusterCommonLBConfig(),
 				},
 			),
 		},
@@ -326,11 +301,7 @@ func TestClusterVisit(t *testing.T) {
 							},
 						},
 					}},
-					CommonLbConfig: &v2.Cluster_CommonLbConfig{
-						HealthyPanicThreshold: &envoy_type.Percent{ // Disable HealthyPanicThreshold
-							Value: 0,
-						},
-					},
+					CommonLbConfig: envoy.ClusterCommonLBConfig(),
 				},
 			),
 		},
@@ -391,11 +362,7 @@ func TestClusterVisit(t *testing.T) {
 							},
 						},
 					}},
-					CommonLbConfig: &v2.Cluster_CommonLbConfig{
-						HealthyPanicThreshold: &envoy_type.Percent{ // Disable HealthyPanicThreshold
-							Value: 0,
-						},
-					},
+					CommonLbConfig: envoy.ClusterCommonLBConfig(),
 				},
 			),
 		},
@@ -437,11 +404,7 @@ func TestClusterVisit(t *testing.T) {
 					},
 					ConnectTimeout: 250 * time.Millisecond,
 					LbPolicy:       v2.Cluster_ROUND_ROBIN,
-					CommonLbConfig: &v2.Cluster_CommonLbConfig{
-						HealthyPanicThreshold: &envoy_type.Percent{ // Disable HealthyPanicThreshold
-							Value: 0,
-						},
-					},
+					CommonLbConfig: envoy.ClusterCommonLBConfig(),
 				},
 			),
 		},
@@ -483,11 +446,7 @@ func TestClusterVisit(t *testing.T) {
 					},
 					ConnectTimeout: 250 * time.Millisecond,
 					LbPolicy:       v2.Cluster_LEAST_REQUEST,
-					CommonLbConfig: &v2.Cluster_CommonLbConfig{
-						HealthyPanicThreshold: &envoy_type.Percent{ // Disable HealthyPanicThreshold
-							Value: 0,
-						},
-					},
+					CommonLbConfig: envoy.ClusterCommonLBConfig(),
 				},
 			),
 		},
@@ -529,11 +488,7 @@ func TestClusterVisit(t *testing.T) {
 					},
 					ConnectTimeout: 250 * time.Millisecond,
 					LbPolicy:       v2.Cluster_RING_HASH,
-					CommonLbConfig: &v2.Cluster_CommonLbConfig{
-						HealthyPanicThreshold: &envoy_type.Percent{ // Disable HealthyPanicThreshold
-							Value: 0,
-						},
-					},
+					CommonLbConfig: envoy.ClusterCommonLBConfig(),
 				},
 			),
 		},
@@ -575,11 +530,7 @@ func TestClusterVisit(t *testing.T) {
 					},
 					ConnectTimeout: 250 * time.Millisecond,
 					LbPolicy:       v2.Cluster_MAGLEV,
-					CommonLbConfig: &v2.Cluster_CommonLbConfig{
-						HealthyPanicThreshold: &envoy_type.Percent{ // Disable HealthyPanicThreshold
-							Value: 0,
-						},
-					},
+					CommonLbConfig: envoy.ClusterCommonLBConfig(),
 				},
 			),
 		},
@@ -621,11 +572,7 @@ func TestClusterVisit(t *testing.T) {
 					},
 					ConnectTimeout: 250 * time.Millisecond,
 					LbPolicy:       v2.Cluster_RANDOM,
-					CommonLbConfig: &v2.Cluster_CommonLbConfig{
-						HealthyPanicThreshold: &envoy_type.Percent{ // Disable HealthyPanicThreshold
-							Value: 0,
-						},
-					},
+					CommonLbConfig: envoy.ClusterCommonLBConfig(),
 				},
 			),
 		},
@@ -674,11 +621,7 @@ func TestClusterVisit(t *testing.T) {
 					},
 					ConnectTimeout: 250 * time.Millisecond,
 					LbPolicy:       v2.Cluster_RANDOM,
-					CommonLbConfig: &v2.Cluster_CommonLbConfig{
-						HealthyPanicThreshold: &envoy_type.Percent{ // Disable HealthyPanicThreshold
-							Value: 0,
-						},
-					},
+					CommonLbConfig: envoy.ClusterCommonLBConfig(),
 				},
 				&v2.Cluster{
 					Name: "default/backend/80/843e4ded8f",
@@ -689,11 +632,7 @@ func TestClusterVisit(t *testing.T) {
 					},
 					ConnectTimeout: 250 * time.Millisecond,
 					LbPolicy:       v2.Cluster_MAGLEV,
-					CommonLbConfig: &v2.Cluster_CommonLbConfig{
-						HealthyPanicThreshold: &envoy_type.Percent{ // Disable HealthyPanicThreshold
-							Value: 0,
-						},
-					},
+					CommonLbConfig: envoy.ClusterCommonLBConfig(),
 				},
 			),
 		},
@@ -736,11 +675,7 @@ func TestClusterVisit(t *testing.T) {
 					},
 					ConnectTimeout: 250 * time.Millisecond,
 					LbPolicy:       v2.Cluster_ROUND_ROBIN,
-					CommonLbConfig: &v2.Cluster_CommonLbConfig{
-						HealthyPanicThreshold: &envoy_type.Percent{ // Disable HealthyPanicThreshold
-							Value: 0,
-						},
-					},
+					CommonLbConfig: envoy.ClusterCommonLBConfig(),
 				},
 			),
 		},
@@ -792,11 +727,7 @@ func TestClusterVisit(t *testing.T) {
 							MaxRetries:         u32(7),
 						}},
 					},
-					CommonLbConfig: &v2.Cluster_CommonLbConfig{
-						HealthyPanicThreshold: &envoy_type.Percent{ // Disable HealthyPanicThreshold
-							Value: 0,
-						},
-					},
+					CommonLbConfig: envoy.ClusterCommonLBConfig(),
 				},
 			),
 		},
@@ -837,11 +768,7 @@ func TestClusterVisit(t *testing.T) {
 					},
 					ConnectTimeout: 250 * time.Millisecond,
 					LbPolicy:       v2.Cluster_ROUND_ROBIN,
-					CommonLbConfig: &v2.Cluster_CommonLbConfig{
-						HealthyPanicThreshold: &envoy_type.Percent{ // Disable HealthyPanicThreshold
-							Value: 0,
-						},
-					},
+					CommonLbConfig: envoy.ClusterCommonLBConfig(),
 				}),
 		},
 	}

--- a/internal/e2e/cds_test.go
+++ b/internal/e2e/cds_test.go
@@ -20,7 +20,6 @@ import (
 
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	envoy_cluster "github.com/envoyproxy/go-control-plane/envoy/api/v2/cluster"
-	envoy_type "github.com/envoyproxy/go-control-plane/envoy/type"
 	"github.com/gogo/protobuf/types"
 	ingressroutev1 "github.com/heptio/contour/apis/contour/v1beta1"
 	"github.com/heptio/contour/internal/envoy"
@@ -528,11 +527,7 @@ func TestClusterCircuitbreakerAnnotations(t *testing.T) {
 						MaxRetries:         u32(7),
 					}},
 				},
-				CommonLbConfig: &v2.Cluster_CommonLbConfig{
-					HealthyPanicThreshold: &envoy_type.Percent{ // Disable HealthyPanicThreshold
-						Value: 0,
-					},
-				},
+				CommonLbConfig: envoy.ClusterCommonLBConfig(),
 			}),
 		},
 		TypeUrl: clusterType,
@@ -574,11 +569,7 @@ func TestClusterCircuitbreakerAnnotations(t *testing.T) {
 						MaxPendingRequests: u32(9999),
 					}},
 				},
-				CommonLbConfig: &v2.Cluster_CommonLbConfig{
-					HealthyPanicThreshold: &envoy_type.Percent{ // Disable HealthyPanicThreshold
-						Value: 0,
-					},
-				},
+				CommonLbConfig: envoy.ClusterCommonLBConfig(),
 			}),
 		},
 		TypeUrl: clusterType,
@@ -698,11 +689,7 @@ func TestClusterLoadBalancerStrategyPerRoute(t *testing.T) {
 				},
 				ConnectTimeout: 250 * time.Millisecond,
 				LbPolicy:       v2.Cluster_RANDOM,
-				CommonLbConfig: &v2.Cluster_CommonLbConfig{
-					HealthyPanicThreshold: &envoy_type.Percent{ // Disable HealthyPanicThreshold
-						Value: 0,
-					},
-				},
+				CommonLbConfig: envoy.ClusterCommonLBConfig(),
 			}),
 			any(t, &v2.Cluster{
 				Name: "default/kuard/80/843e4ded8f",
@@ -713,11 +700,7 @@ func TestClusterLoadBalancerStrategyPerRoute(t *testing.T) {
 				},
 				ConnectTimeout: 250 * time.Millisecond,
 				LbPolicy:       v2.Cluster_MAGLEV,
-				CommonLbConfig: &v2.Cluster_CommonLbConfig{
-					HealthyPanicThreshold: &envoy_type.Percent{ // Disable HealthyPanicThreshold
-						Value: 0,
-					},
-				},
+				CommonLbConfig: envoy.ClusterCommonLBConfig(),
 			}),
 		},
 		TypeUrl: clusterType,
@@ -759,10 +742,6 @@ func cluster(name, servicename string) *v2.Cluster {
 		},
 		ConnectTimeout: 250 * time.Millisecond,
 		LbPolicy:       v2.Cluster_ROUND_ROBIN,
-		CommonLbConfig: &v2.Cluster_CommonLbConfig{
-			HealthyPanicThreshold: &envoy_type.Percent{ // Disable HealthyPanicThreshold
-				Value: 0,
-			},
-		},
+		CommonLbConfig: envoy.ClusterCommonLBConfig(),
 	}
 }

--- a/internal/envoy/cluster.go
+++ b/internal/envoy/cluster.go
@@ -60,7 +60,7 @@ func cluster(service *dag.TCPService) *v2.Cluster {
 		EdsClusterConfig: edsconfig("contour", service),
 		ConnectTimeout:   250 * time.Millisecond,
 		LbPolicy:         lbPolicy(service.LoadBalancerStrategy),
-		CommonLbConfig:   clusterCommonLBConfig(),
+		CommonLbConfig:   ClusterCommonLBConfig(),
 		HealthChecks:     edshealthcheck(service),
 	}
 	if anyPositive(service.MaxConnections, service.MaxPendingRequests, service.MaxRequests, service.MaxRetries) {
@@ -212,7 +212,7 @@ func u32nil(val int) *types.UInt32Value {
 	}
 }
 
-func clusterCommonLBConfig() *v2.Cluster_CommonLbConfig {
+func ClusterCommonLBConfig() *v2.Cluster_CommonLbConfig {
 	return &v2.Cluster_CommonLbConfig{
 		HealthyPanicThreshold: &envoy_type.Percent{ // Disable HealthyPanicThreshold
 			Value: 0,

--- a/internal/envoy/cluster_test.go
+++ b/internal/envoy/cluster_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	envoy_cluster "github.com/envoyproxy/go-control-plane/envoy/api/v2/cluster"
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
+	envoy_type "github.com/envoyproxy/go-control-plane/envoy/type"
 	"github.com/gogo/protobuf/types"
 	"github.com/google/go-cmp/cmp"
 	ingressroutev1 "github.com/heptio/contour/apis/contour/v1beta1"
@@ -62,7 +63,7 @@ func TestCluster(t *testing.T) {
 				},
 				ConnectTimeout: 250 * time.Millisecond,
 				LbPolicy:       v2.Cluster_ROUND_ROBIN,
-				CommonLbConfig: clusterCommonLBConfig(),
+				CommonLbConfig: ClusterCommonLBConfig(),
 			},
 		},
 		"h2c upstream": {
@@ -80,7 +81,7 @@ func TestCluster(t *testing.T) {
 				ConnectTimeout:       250 * time.Millisecond,
 				LbPolicy:             v2.Cluster_ROUND_ROBIN,
 				Http2ProtocolOptions: &core.Http2ProtocolOptions{},
-				CommonLbConfig:       clusterCommonLBConfig(),
+				CommonLbConfig:       ClusterCommonLBConfig(),
 			},
 		},
 		"h2 upstream": {
@@ -99,7 +100,7 @@ func TestCluster(t *testing.T) {
 				LbPolicy:             v2.Cluster_ROUND_ROBIN,
 				Http2ProtocolOptions: &core.Http2ProtocolOptions{},
 				TlsContext:           UpstreamTLSContext(),
-				CommonLbConfig:       clusterCommonLBConfig(),
+				CommonLbConfig:       ClusterCommonLBConfig(),
 			},
 		},
 		"contour.heptio.com/max-connections": {
@@ -124,7 +125,7 @@ func TestCluster(t *testing.T) {
 						MaxConnections: u32(9000),
 					}},
 				},
-				CommonLbConfig: clusterCommonLBConfig(),
+				CommonLbConfig: ClusterCommonLBConfig(),
 			},
 		},
 		"contour.heptio.com/max-pending-requests": {
@@ -149,7 +150,7 @@ func TestCluster(t *testing.T) {
 						MaxPendingRequests: u32(4096),
 					}},
 				},
-				CommonLbConfig: clusterCommonLBConfig(),
+				CommonLbConfig: ClusterCommonLBConfig(),
 			},
 		},
 		"contour.heptio.com/max-requests": {
@@ -174,7 +175,7 @@ func TestCluster(t *testing.T) {
 						MaxRequests: u32(404),
 					}},
 				},
-				CommonLbConfig: clusterCommonLBConfig(),
+				CommonLbConfig: ClusterCommonLBConfig(),
 			},
 		},
 		"contour.heptio.com/max-retries": {
@@ -199,7 +200,7 @@ func TestCluster(t *testing.T) {
 						MaxRetries: u32(7),
 					}},
 				},
-				CommonLbConfig: clusterCommonLBConfig(),
+				CommonLbConfig: ClusterCommonLBConfig(),
 			},
 		},
 		"tcp service": {
@@ -216,7 +217,7 @@ func TestCluster(t *testing.T) {
 				},
 				ConnectTimeout: 250 * time.Millisecond,
 				LbPolicy:       v2.Cluster_ROUND_ROBIN,
-				CommonLbConfig: clusterCommonLBConfig(),
+				CommonLbConfig: ClusterCommonLBConfig(),
 			},
 		},
 	}
@@ -397,6 +398,18 @@ func TestU32nil(t *testing.T) {
 
 	assert(nil, u32nil(0))
 	assert(u32(1), u32nil(1))
+}
+
+func TestClusterCommonLBConfig(t *testing.T) {
+	got := ClusterCommonLBConfig()
+	want := &v2.Cluster_CommonLbConfig{
+		HealthyPanicThreshold: &envoy_type.Percent{ // Disable HealthyPanicThreshold
+			Value: 0,
+		},
+	}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Fatal(diff)
+	}
 }
 
 func service(s *v1.Service) dag.TCPService {


### PR DESCRIPTION
Move common factory to internal/envoy and use throughout codebase.

Signed-off-by: Dave Cheney <dave@cheney.net>