### PR TITLE
Fix patterns for resource names in CRD schema

### DIFF
--- a/deployment/common/common.yaml
+++ b/deployment/common/common.yaml
@@ -59,7 +59,7 @@ spec:
                   properties:
                     secretName:
                       type: string
-                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$ # DNS-1123
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$ # DNS-1123 subdomain
                     minimumProtocolVersion:
                       type: string
                       enum:
@@ -106,10 +106,10 @@ spec:
                     properties:
                       name:
                         type: string
-                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$ # DNS-1123
+                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$ # DNS-1123 subdomain
                       namespace:
                         type: string
-                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$ # DNS-1123
+                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$ # DNS-1123 label
                   services:
                     type: array
                     items:
@@ -120,7 +120,7 @@ spec:
                       properties:
                         name:
                           type: string
-                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$ # DNS-1123
+                          pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$ # DNS-1035 label
                         port:
                           type: integer
                         weight:

--- a/deployment/render/daemonset-rbac.yaml
+++ b/deployment/render/daemonset-rbac.yaml
@@ -62,7 +62,7 @@ spec:
                   properties:
                     secretName:
                       type: string
-                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$ # DNS-1123
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$ # DNS-1123 subdomain
                     minimumProtocolVersion:
                       type: string
                       enum:
@@ -109,10 +109,10 @@ spec:
                     properties:
                       name:
                         type: string
-                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$ # DNS-1123
+                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$ # DNS-1123 subdomain
                       namespace:
                         type: string
-                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$ # DNS-1123
+                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$ # DNS-1123 label
                   services:
                     type: array
                     items:
@@ -123,7 +123,7 @@ spec:
                       properties:
                         name:
                           type: string
-                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$ # DNS-1123
+                          pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$ # DNS-1035 label
                         port:
                           type: integer
                         weight:

--- a/deployment/render/deployment-rbac.yaml
+++ b/deployment/render/deployment-rbac.yaml
@@ -62,7 +62,7 @@ spec:
                   properties:
                     secretName:
                       type: string
-                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$ # DNS-1123
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$ # DNS-1123 subdomain
                     minimumProtocolVersion:
                       type: string
                       enum:
@@ -109,10 +109,10 @@ spec:
                     properties:
                       name:
                         type: string
-                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$ # DNS-1123
+                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$ # DNS-1123 subdomain
                       namespace:
                         type: string
-                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$ # DNS-1123
+                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$ # DNS-1123 label
                   services:
                     type: array
                     items:
@@ -123,7 +123,7 @@ spec:
                       properties:
                         name:
                           type: string
-                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$ # DNS-1123
+                          pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$ # DNS-1035 label
                         port:
                           type: integer
                         weight:


### PR DESCRIPTION
The regular expressions in the CRD schema aren't consistent with what defines a valid names of the Kubernetes resource they are referring to.

The easiest way to find this out is to create an invalid name and look at the error Kubernetes gives back to you. In order of the changes in this PR, the errors are:

```
The Secret "invalid#name" is invalid: metadata.name: Invalid value: "invalid#name": a DNS-1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')

The IngressRoute "invalid#name" is invalid: metadata.name: Invalid value: "invalid#name": a DNS-1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')

The Namespace "invalid#name" is invalid: metadata.name: Invalid value: "invalid#name": a DNS-1123 label must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?')

The Service "invalid#name" is invalid: metadata.name: Invalid value: "invalid#name": a DNS-1035 label must consist of lower case alphanumeric characters or '-', start with an alphabetic character, and end with an alphanumeric character (e.g. 'my-name',  or 'abc-123', regex used for validation is '[a-z]([-a-z0-9]*[a-z0-9])?')
```

The major change here is a relaxation of ingress routes and secrets to allow dots when referring to the resources. I've tested this and I am able to delegate to ingress routes and load TLS secrets with dots in the resource name, so I haven't found any reason to restrict the pattern further than to names which are valid.