### PR TITLE
internal/contour: refactor visitors

### DIFF
--- a/internal/contour/cachehandler.go
+++ b/internal/contour/cachehandler.go
@@ -59,29 +59,19 @@ func (ch *CacheHandler) setIngressRouteStatus(st statusable) {
 	}
 }
 
-func (ch *CacheHandler) updateListeners(v dag.Visitable) {
-	lv := listenerVisitor{
-		ListenerCache: &ch.ListenerCache,
-		Visitable:     v,
-	}
-	ch.ListenerCache.Update(lv.Visit())
+func (ch *CacheHandler) updateListeners(root dag.Visitable) {
+	listeners := visitListeners(root, &ch.ListenerCache)
+	ch.ListenerCache.Update(listeners)
 }
 
-func (ch *CacheHandler) updateRoutes(v dag.Visitable) {
-	rv := routeVisitor{
-		RouteCache: &ch.RouteCache,
-		Visitable:  v,
-	}
-	routes := rv.Visit()
+func (ch *CacheHandler) updateRoutes(root dag.Visitable) {
+	routes := visitRoutes(root)
 	ch.RouteCache.Update(routes)
 }
 
-func (ch *CacheHandler) updateClusters(v dag.Visitable) {
-	cv := clusterVisitor{
-		ClusterCache: &ch.ClusterCache,
-		Visitable:    v,
-	}
-	ch.clusterCache.Update(cv.Visit())
+func (ch *CacheHandler) updateClusters(root dag.Visitable) {
+	clusters := visitClusters(root)
+	ch.clusterCache.Update(clusters)
 }
 
 func (ch *CacheHandler) updateIngressRouteMetric(st statusable) {

--- a/internal/contour/cachehandler.go
+++ b/internal/contour/cachehandler.go
@@ -26,6 +26,7 @@ import (
 
 // CacheHandler manages the state of xDS caches.
 type CacheHandler struct {
+	ListenerVisitorConfig
 	ListenerCache
 	RouteCache
 	ClusterCache
@@ -60,7 +61,7 @@ func (ch *CacheHandler) setIngressRouteStatus(st statusable) {
 }
 
 func (ch *CacheHandler) updateListeners(root dag.Visitable) {
-	listeners := visitListeners(root, &ch.ListenerCache)
+	listeners := visitListeners(root, &ch.ListenerVisitorConfig)
 	ch.ListenerCache.Update(listeners)
 }
 
@@ -71,7 +72,7 @@ func (ch *CacheHandler) updateRoutes(root dag.Visitable) {
 
 func (ch *CacheHandler) updateClusters(root dag.Visitable) {
 	clusters := visitClusters(root)
-	ch.clusterCache.Update(clusters)
+	ch.ClusterCache.Update(clusters)
 }
 
 func (ch *CacheHandler) updateIngressRouteMetric(st statusable) {

--- a/internal/contour/cluster.go
+++ b/internal/contour/cluster.go
@@ -86,18 +86,17 @@ func (c *clusterCache) Values(filter func(string) bool) []proto.Message {
 	return values
 }
 
-// clusterVisitor walks a *dag.DAG and produces a map of *v2.Clusters.
 type clusterVisitor struct {
-	*ClusterCache
-	dag.Visitable
-
 	clusters map[string]*v2.Cluster
 }
 
-func (v *clusterVisitor) Visit() map[string]*v2.Cluster {
-	v.clusters = make(map[string]*v2.Cluster)
-	v.Visitable.Visit(v.visit)
-	return v.clusters
+// visitCluster produces a map of *v2.Clusters.
+func visitClusters(root dag.Vertex) map[string]*v2.Cluster {
+	cv := clusterVisitor{
+		clusters: make(map[string]*v2.Cluster),
+	}
+	cv.visit(root)
+	return cv.clusters
 }
 
 func (v *clusterVisitor) visit(vertex dag.Vertex) {

--- a/internal/contour/cluster.go
+++ b/internal/contour/cluster.go
@@ -24,10 +24,6 @@ import (
 
 // ClusterCache manages the contents of the gRPC CDS cache.
 type ClusterCache struct {
-	clusterCache
-}
-
-type clusterCache struct {
 	mu      sync.Mutex
 	values  map[string]*v2.Cluster
 	waiters []chan int
@@ -42,7 +38,7 @@ type clusterCache struct {
 //
 // Sends by the broadcaster to ch must not block, therefor ch must have a capacity
 // of at least 1.
-func (c *clusterCache) Register(ch chan int, last int) {
+func (c *ClusterCache) Register(ch chan int, last int) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
@@ -55,7 +51,7 @@ func (c *clusterCache) Register(ch chan int, last int) {
 }
 
 // Update replaces the contents of the cache with the supplied map.
-func (c *clusterCache) Update(v map[string]*v2.Cluster) {
+func (c *ClusterCache) Update(v map[string]*v2.Cluster) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
@@ -64,7 +60,7 @@ func (c *clusterCache) Update(v map[string]*v2.Cluster) {
 }
 
 // notify notifies all registered waiters that an event has occurred.
-func (c *clusterCache) notify() {
+func (c *ClusterCache) notify() {
 	c.last++
 
 	for _, ch := range c.waiters {
@@ -74,7 +70,7 @@ func (c *clusterCache) notify() {
 }
 
 // Values returns a slice of the value stored in the cache.
-func (c *clusterCache) Values(filter func(string) bool) []proto.Message {
+func (c *ClusterCache) Values(filter func(string) bool) []proto.Message {
 	c.mu.Lock()
 	values := make([]proto.Message, 0, len(c.values))
 	for _, v := range c.values {

--- a/internal/contour/cluster_test.go
+++ b/internal/contour/cluster_test.go
@@ -782,11 +782,8 @@ func TestClusterVisit(t *testing.T) {
 			for _, o := range tc.objs {
 				reh.OnAdd(o)
 			}
-			v := clusterVisitor{
-				ClusterCache: new(ClusterCache),
-				Visitable:    reh.Build(),
-			}
-			got := v.Visit()
+			root := reh.Build()
+			got := visitClusters(root)
 			if diff := cmp.Diff(tc.want, got); diff != "" {
 				t.Fatal(diff)
 			}

--- a/internal/contour/listener_test.go
+++ b/internal/contour/listener_test.go
@@ -55,15 +55,13 @@ func TestListenerVisit(t *testing.T) {
 					},
 				},
 			},
-			want: map[string]*v2.Listener{
-				ENVOY_HTTP_LISTENER: {
-					Name:    ENVOY_HTTP_LISTENER,
-					Address: envoy.SocketAddress("0.0.0.0", 8080),
-					FilterChains: []listener.FilterChain{
-						filterchain(false, envoy.HTTPConnectionManager(ENVOY_HTTP_LISTENER, DEFAULT_HTTP_ACCESS_LOG)),
-					},
+			want: listenermap(&v2.Listener{
+				Name:    ENVOY_HTTP_LISTENER,
+				Address: envoy.SocketAddress("0.0.0.0", 8080),
+				FilterChains: []listener.FilterChain{
+					filterchain(false, envoy.HTTPConnectionManager(ENVOY_HTTP_LISTENER, DEFAULT_HTTP_ACCESS_LOG)),
 				},
-			},
+			}),
 		},
 		"one http only ingressroute": {
 			objs: []interface{}{
@@ -89,15 +87,13 @@ func TestListenerVisit(t *testing.T) {
 					},
 				},
 			},
-			want: map[string]*v2.Listener{
-				ENVOY_HTTP_LISTENER: {
-					Name:    ENVOY_HTTP_LISTENER,
-					Address: envoy.SocketAddress("0.0.0.0", 8080),
-					FilterChains: []listener.FilterChain{
-						filterchain(false, envoy.HTTPConnectionManager(ENVOY_HTTP_LISTENER, DEFAULT_HTTP_ACCESS_LOG)),
-					},
+			want: listenermap(&v2.Listener{
+				Name:    ENVOY_HTTP_LISTENER,
+				Address: envoy.SocketAddress("0.0.0.0", 8080),
+				FilterChains: []listener.FilterChain{
+					filterchain(false, envoy.HTTPConnectionManager(ENVOY_HTTP_LISTENER, DEFAULT_HTTP_ACCESS_LOG)),
 				},
-			},
+			}),
 		},
 		"simple ingress with secret": {
 			objs: []interface{}{
@@ -125,29 +121,26 @@ func TestListenerVisit(t *testing.T) {
 					Data: secretdata("certificate", "key"),
 				},
 			},
-			want: map[string]*v2.Listener{
-				ENVOY_HTTP_LISTENER: {
-					Name:    ENVOY_HTTP_LISTENER,
-					Address: envoy.SocketAddress("0.0.0.0", 8080),
-					FilterChains: []listener.FilterChain{
-						filterchain(false, envoy.HTTPConnectionManager(ENVOY_HTTP_LISTENER, DEFAULT_HTTP_ACCESS_LOG)),
-					},
+			want: listenermap(&v2.Listener{
+				Name:    ENVOY_HTTP_LISTENER,
+				Address: envoy.SocketAddress("0.0.0.0", 8080),
+				FilterChains: []listener.FilterChain{
+					filterchain(false, envoy.HTTPConnectionManager(ENVOY_HTTP_LISTENER, DEFAULT_HTTP_ACCESS_LOG)),
 				},
-				ENVOY_HTTPS_LISTENER: {
-					Name:    ENVOY_HTTPS_LISTENER,
-					Address: envoy.SocketAddress("0.0.0.0", 8443),
-					FilterChains: []listener.FilterChain{{
-						FilterChainMatch: &listener.FilterChainMatch{
-							ServerNames: []string{"whatever.example.com"},
-						},
-						TlsContext: tlscontext(auth.TlsParameters_TLSv1_1, "h2", "http/1.1"),
-						Filters:    filters(envoy.HTTPConnectionManager(ENVOY_HTTPS_LISTENER, DEFAULT_HTTPS_ACCESS_LOG)),
-					}},
-					ListenerFilters: []listener.ListenerFilter{
-						envoy.TLSInspector(),
+			}, &v2.Listener{
+				Name:    ENVOY_HTTPS_LISTENER,
+				Address: envoy.SocketAddress("0.0.0.0", 8443),
+				FilterChains: []listener.FilterChain{{
+					FilterChainMatch: &listener.FilterChainMatch{
+						ServerNames: []string{"whatever.example.com"},
 					},
+					TlsContext: tlscontext(auth.TlsParameters_TLSv1_1, "h2", "http/1.1"),
+					Filters:    filters(envoy.HTTPConnectionManager(ENVOY_HTTPS_LISTENER, DEFAULT_HTTPS_ACCESS_LOG)),
+				}},
+				ListenerFilters: []listener.ListenerFilter{
+					envoy.TLSInspector(),
 				},
-			},
+			}),
 		},
 		"simple ingress with missing secret": {
 			objs: []interface{}{
@@ -175,15 +168,13 @@ func TestListenerVisit(t *testing.T) {
 					Data: secretdata("certificate", "key"),
 				},
 			},
-			want: map[string]*v2.Listener{
-				ENVOY_HTTP_LISTENER: {
-					Name:    ENVOY_HTTP_LISTENER,
-					Address: envoy.SocketAddress("0.0.0.0", 8080),
-					FilterChains: []listener.FilterChain{
-						filterchain(false, envoy.HTTPConnectionManager(ENVOY_HTTP_LISTENER, DEFAULT_HTTP_ACCESS_LOG)),
-					},
+			want: listenermap(&v2.Listener{
+				Name:    ENVOY_HTTP_LISTENER,
+				Address: envoy.SocketAddress("0.0.0.0", 8080),
+				FilterChains: []listener.FilterChain{
+					filterchain(false, envoy.HTTPConnectionManager(ENVOY_HTTP_LISTENER, DEFAULT_HTTP_ACCESS_LOG)),
 				},
-			},
+			}),
 		},
 		"simple ingressroute with secret": {
 			objs: []interface{}{
@@ -219,29 +210,26 @@ func TestListenerVisit(t *testing.T) {
 					Data: secretdata("certificate", "key"),
 				},
 			},
-			want: map[string]*v2.Listener{
-				ENVOY_HTTP_LISTENER: {
-					Name:    ENVOY_HTTP_LISTENER,
-					Address: envoy.SocketAddress("0.0.0.0", 8080),
-					FilterChains: []listener.FilterChain{
-						filterchain(false, envoy.HTTPConnectionManager(ENVOY_HTTP_LISTENER, DEFAULT_HTTP_ACCESS_LOG)),
-					},
+			want: listenermap(&v2.Listener{
+				Name:    ENVOY_HTTP_LISTENER,
+				Address: envoy.SocketAddress("0.0.0.0", 8080),
+				FilterChains: []listener.FilterChain{
+					filterchain(false, envoy.HTTPConnectionManager(ENVOY_HTTP_LISTENER, DEFAULT_HTTP_ACCESS_LOG)),
 				},
-				ENVOY_HTTPS_LISTENER: {
-					Name:    ENVOY_HTTPS_LISTENER,
-					Address: envoy.SocketAddress("0.0.0.0", 8443),
-					FilterChains: []listener.FilterChain{{
-						FilterChainMatch: &listener.FilterChainMatch{
-							ServerNames: []string{"www.example.com"},
-						},
-						TlsContext: tlscontext(auth.TlsParameters_TLSv1_1, "h2", "http/1.1"),
-						Filters:    filters(envoy.HTTPConnectionManager(ENVOY_HTTPS_LISTENER, DEFAULT_HTTPS_ACCESS_LOG)),
-					}},
-					ListenerFilters: []listener.ListenerFilter{
-						envoy.TLSInspector(),
+			}, &v2.Listener{
+				Name:    ENVOY_HTTPS_LISTENER,
+				Address: envoy.SocketAddress("0.0.0.0", 8443),
+				FilterChains: []listener.FilterChain{{
+					FilterChainMatch: &listener.FilterChainMatch{
+						ServerNames: []string{"www.example.com"},
 					},
+					TlsContext: tlscontext(auth.TlsParameters_TLSv1_1, "h2", "http/1.1"),
+					Filters:    filters(envoy.HTTPConnectionManager(ENVOY_HTTPS_LISTENER, DEFAULT_HTTPS_ACCESS_LOG)),
+				}},
+				ListenerFilters: []listener.ListenerFilter{
+					envoy.TLSInspector(),
 				},
-			},
+			}),
 		},
 		"ingress with allow-http: false": {
 			objs: []interface{}{
@@ -292,22 +280,20 @@ func TestListenerVisit(t *testing.T) {
 					Data: secretdata("certificate", "key"),
 				},
 			},
-			want: map[string]*v2.Listener{
-				ENVOY_HTTPS_LISTENER: {
-					Name:    ENVOY_HTTPS_LISTENER,
-					Address: envoy.SocketAddress("0.0.0.0", 8443),
-					FilterChains: []listener.FilterChain{{
-						FilterChainMatch: &listener.FilterChainMatch{
-							ServerNames: []string{"www.example.com"},
-						},
-						TlsContext: tlscontext(auth.TlsParameters_TLSv1_1, "h2", "http/1.1"),
-						Filters:    filters(envoy.HTTPConnectionManager(ENVOY_HTTPS_LISTENER, DEFAULT_HTTPS_ACCESS_LOG)),
-					}},
-					ListenerFilters: []listener.ListenerFilter{
-						envoy.TLSInspector(),
+			want: listenermap(&v2.Listener{
+				Name:    ENVOY_HTTPS_LISTENER,
+				Address: envoy.SocketAddress("0.0.0.0", 8443),
+				FilterChains: []listener.FilterChain{{
+					FilterChainMatch: &listener.FilterChainMatch{
+						ServerNames: []string{"www.example.com"},
 					},
+					TlsContext: tlscontext(auth.TlsParameters_TLSv1_1, "h2", "http/1.1"),
+					Filters:    filters(envoy.HTTPConnectionManager(ENVOY_HTTPS_LISTENER, DEFAULT_HTTPS_ACCESS_LOG)),
+				}},
+				ListenerFilters: []listener.ListenerFilter{
+					envoy.TLSInspector(),
 				},
-			},
+			}),
 		},
 		"http listener on non default port": { // issue 72
 			ListenerCache: &ListenerCache{
@@ -341,29 +327,26 @@ func TestListenerVisit(t *testing.T) {
 					Data: secretdata("certificate", "key"),
 				},
 			},
-			want: map[string]*v2.Listener{
-				ENVOY_HTTP_LISTENER: {
-					Name:    ENVOY_HTTP_LISTENER,
-					Address: envoy.SocketAddress("127.0.0.100", 9100),
-					FilterChains: []listener.FilterChain{
-						filterchain(false, envoy.HTTPConnectionManager(ENVOY_HTTP_LISTENER, DEFAULT_HTTP_ACCESS_LOG)),
-					},
+			want: listenermap(&v2.Listener{
+				Name:    ENVOY_HTTP_LISTENER,
+				Address: envoy.SocketAddress("127.0.0.100", 9100),
+				FilterChains: []listener.FilterChain{
+					filterchain(false, envoy.HTTPConnectionManager(ENVOY_HTTP_LISTENER, DEFAULT_HTTP_ACCESS_LOG)),
 				},
-				ENVOY_HTTPS_LISTENER: {
-					Name:    ENVOY_HTTPS_LISTENER,
-					Address: envoy.SocketAddress("127.0.0.200", 9200),
-					FilterChains: []listener.FilterChain{{
-						FilterChainMatch: &listener.FilterChainMatch{
-							ServerNames: []string{"whatever.example.com"},
-						},
-						TlsContext: tlscontext(auth.TlsParameters_TLSv1_1, "h2", "http/1.1"),
-						Filters:    filters(envoy.HTTPConnectionManager(ENVOY_HTTPS_LISTENER, DEFAULT_HTTPS_ACCESS_LOG)),
-					}},
-					ListenerFilters: []listener.ListenerFilter{
-						envoy.TLSInspector(),
+			}, &v2.Listener{
+				Name:    ENVOY_HTTPS_LISTENER,
+				Address: envoy.SocketAddress("127.0.0.200", 9200),
+				FilterChains: []listener.FilterChain{{
+					FilterChainMatch: &listener.FilterChainMatch{
+						ServerNames: []string{"whatever.example.com"},
 					},
+					TlsContext: tlscontext(auth.TlsParameters_TLSv1_1, "h2", "http/1.1"),
+					Filters:    filters(envoy.HTTPConnectionManager(ENVOY_HTTPS_LISTENER, DEFAULT_HTTPS_ACCESS_LOG)),
+				}},
+				ListenerFilters: []listener.ListenerFilter{
+					envoy.TLSInspector(),
 				},
-			},
+			}),
 		},
 		"use proxy proto": {
 			ListenerCache: &ListenerCache{
@@ -394,30 +377,27 @@ func TestListenerVisit(t *testing.T) {
 					Data: secretdata("certificate", "key"),
 				},
 			},
-			want: map[string]*v2.Listener{
-				ENVOY_HTTP_LISTENER: {
-					Name:    ENVOY_HTTP_LISTENER,
-					Address: envoy.SocketAddress("0.0.0.0", 8080),
-					FilterChains: []listener.FilterChain{
-						filterchain(true, envoy.HTTPConnectionManager(ENVOY_HTTP_LISTENER, DEFAULT_HTTP_ACCESS_LOG)),
-					},
+			want: listenermap(&v2.Listener{
+				Name:    ENVOY_HTTP_LISTENER,
+				Address: envoy.SocketAddress("0.0.0.0", 8080),
+				FilterChains: []listener.FilterChain{
+					filterchain(true, envoy.HTTPConnectionManager(ENVOY_HTTP_LISTENER, DEFAULT_HTTP_ACCESS_LOG)),
 				},
-				ENVOY_HTTPS_LISTENER: {
-					Name:    ENVOY_HTTPS_LISTENER,
-					Address: envoy.SocketAddress("0.0.0.0", 8443),
-					FilterChains: []listener.FilterChain{{
-						FilterChainMatch: &listener.FilterChainMatch{
-							ServerNames: []string{"whatever.example.com"},
-						},
-						TlsContext:    tlscontext(auth.TlsParameters_TLSv1_1, "h2", "http/1.1"),
-						Filters:       filters(envoy.HTTPConnectionManager(ENVOY_HTTPS_LISTENER, DEFAULT_HTTPS_ACCESS_LOG)),
-						UseProxyProto: bv(true),
-					}},
-					ListenerFilters: []listener.ListenerFilter{
-						envoy.TLSInspector(),
+			}, &v2.Listener{
+				Name:    ENVOY_HTTPS_LISTENER,
+				Address: envoy.SocketAddress("0.0.0.0", 8443),
+				FilterChains: []listener.FilterChain{{
+					FilterChainMatch: &listener.FilterChainMatch{
+						ServerNames: []string{"whatever.example.com"},
 					},
+					TlsContext:    tlscontext(auth.TlsParameters_TLSv1_1, "h2", "http/1.1"),
+					Filters:       filters(envoy.HTTPConnectionManager(ENVOY_HTTPS_LISTENER, DEFAULT_HTTPS_ACCESS_LOG)),
+					UseProxyProto: bv(true),
+				}},
+				ListenerFilters: []listener.ListenerFilter{
+					envoy.TLSInspector(),
 				},
-			},
+			}),
 		},
 	}
 
@@ -434,11 +414,8 @@ func TestListenerVisit(t *testing.T) {
 			if lc == nil {
 				lc = new(ListenerCache)
 			}
-			v := listenerVisitor{
-				ListenerCache: lc,
-				Visitable:     reh.Build(),
-			}
-			got := v.Visit()
+			root := reh.Build()
+			got := visitListeners(root, lc)
 			if !reflect.DeepEqual(tc.want, got) {
 				t.Fatalf("expected:\n%+v\ngot:\n%+v", tc.want, got)
 			}
@@ -468,4 +445,12 @@ func secretdata(cert, key string) map[string][]byte {
 		v1.TLSCertKey:       []byte(cert),
 		v1.TLSPrivateKeyKey: []byte(key),
 	}
+}
+
+func listenermap(listeners ...*v2.Listener) map[string]*v2.Listener {
+	m := make(map[string]*v2.Listener)
+	for _, l := range listeners {
+		m[l.Name] = l
+	}
+	return m
 }

--- a/internal/contour/listener_test.go
+++ b/internal/contour/listener_test.go
@@ -32,7 +32,7 @@ import (
 
 func TestListenerVisit(t *testing.T) {
 	tests := map[string]struct {
-		*ListenerCache
+		ListenerVisitorConfig
 		objs []interface{}
 		want map[string]*v2.Listener
 	}{
@@ -296,7 +296,7 @@ func TestListenerVisit(t *testing.T) {
 			}),
 		},
 		"http listener on non default port": { // issue 72
-			ListenerCache: &ListenerCache{
+			ListenerVisitorConfig: ListenerVisitorConfig{
 				HTTPAddress:  "127.0.0.100",
 				HTTPPort:     9100,
 				HTTPSAddress: "127.0.0.200",
@@ -349,7 +349,7 @@ func TestListenerVisit(t *testing.T) {
 			}),
 		},
 		"use proxy proto": {
-			ListenerCache: &ListenerCache{
+			ListenerVisitorConfig: ListenerVisitorConfig{
 				UseProxyProto: true,
 			},
 			objs: []interface{}{
@@ -410,12 +410,8 @@ func TestListenerVisit(t *testing.T) {
 			for _, o := range tc.objs {
 				reh.OnAdd(o)
 			}
-			lc := tc.ListenerCache
-			if lc == nil {
-				lc = new(ListenerCache)
-			}
 			root := reh.Build()
-			got := visitListeners(root, lc)
+			got := visitListeners(root, &tc.ListenerVisitorConfig)
 			if !reflect.DeepEqual(tc.want, got) {
 				t.Fatalf("expected:\n%+v\ngot:\n%+v", tc.want, got)
 			}

--- a/internal/contour/route.go
+++ b/internal/contour/route.go
@@ -27,10 +27,6 @@ import (
 
 // RouteCache manages the contents of the gRPC RDS cache.
 type RouteCache struct {
-	routeCache
-}
-
-type routeCache struct {
 	mu      sync.Mutex
 	values  map[string]*v2.RouteConfiguration
 	waiters []chan int
@@ -45,7 +41,7 @@ type routeCache struct {
 //
 // Sends by the broadcaster to ch must not block, therefor ch must have a capacity
 // of at least 1.
-func (c *routeCache) Register(ch chan int, last int) {
+func (c *RouteCache) Register(ch chan int, last int) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
@@ -58,7 +54,7 @@ func (c *routeCache) Register(ch chan int, last int) {
 }
 
 // Update replaces the contents of the cache with the supplied map.
-func (c *routeCache) Update(v map[string]*v2.RouteConfiguration) {
+func (c *RouteCache) Update(v map[string]*v2.RouteConfiguration) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
@@ -67,7 +63,7 @@ func (c *routeCache) Update(v map[string]*v2.RouteConfiguration) {
 }
 
 // notify notifies all registered waiters that an event has occurred.
-func (c *routeCache) notify() {
+func (c *RouteCache) notify() {
 	c.last++
 
 	for _, ch := range c.waiters {
@@ -77,7 +73,7 @@ func (c *routeCache) notify() {
 }
 
 // Values returns a slice of the value stored in the cache.
-func (c *routeCache) Values(filter func(string) bool) []proto.Message {
+func (c *RouteCache) Values(filter func(string) bool) []proto.Message {
 	c.mu.Lock()
 	values := make([]proto.Message, 0, len(c.values))
 	for _, v := range c.values {

--- a/internal/contour/route.go
+++ b/internal/contour/route.go
@@ -90,87 +90,90 @@ func (c *routeCache) Values(filter func(string) bool) []proto.Message {
 }
 
 type routeVisitor struct {
-	*RouteCache
-	dag.Visitable
+	routes map[string]*v2.RouteConfiguration
 }
 
-func (v *routeVisitor) Visit() map[string]*v2.RouteConfiguration {
-	ingress_http := &v2.RouteConfiguration{
-		Name: "ingress_http",
+func visitRoutes(root dag.Vertex) map[string]*v2.RouteConfiguration {
+	rv := routeVisitor{
+		routes: map[string]*v2.RouteConfiguration{
+			"ingress_http": {
+				Name: "ingress_http",
+			},
+			"ingress_https": {
+				Name: "ingress_https",
+			},
+		},
 	}
-	ingress_https := &v2.RouteConfiguration{
-		Name: "ingress_https",
-	}
-	m := map[string]*v2.RouteConfiguration{
-		ingress_http.Name:  ingress_http,
-		ingress_https.Name: ingress_https,
-	}
-	v.Visitable.Visit(func(vh dag.Vertex) {
-		switch vh := vh.(type) {
-		case *dag.VirtualHost:
-			vhost := envoy.VirtualHost(vh.Host, 80)
-			vh.Visit(func(r dag.Vertex) {
-				switch r := r.(type) {
-				case *dag.Route:
-					var svcs []*dag.HTTPService
-					r.Visit(func(s dag.Vertex) {
-						if s, ok := s.(*dag.HTTPService); ok {
-							svcs = append(svcs, s)
-						}
-					})
-					if len(svcs) < 1 {
-						// no services for this route, skip it.
-						return
-					}
-					rr := route.Route{
-						Match:  envoy.PrefixMatch(r.Prefix),
-						Action: envoy.RouteRoute(r, svcs),
-					}
-
-					if r.HTTPSUpgrade {
-						rr.Action = envoy.UpgradeHTTPS()
-					}
-					vhost.Routes = append(vhost.Routes, rr)
-				}
-			})
-			if len(vhost.Routes) < 1 {
-				return
-			}
-			sort.Stable(sort.Reverse(longestRouteFirst(vhost.Routes)))
-			ingress_http.VirtualHosts = append(ingress_http.VirtualHosts, vhost)
-		case *dag.SecureVirtualHost:
-			vhost := envoy.VirtualHost(vh.Host, 443)
-			vh.Visit(func(r dag.Vertex) {
-				switch r := r.(type) {
-				case *dag.Route:
-					var svcs []*dag.HTTPService
-					r.Visit(func(s dag.Vertex) {
-						if s, ok := s.(*dag.HTTPService); ok {
-							svcs = append(svcs, s)
-						}
-					})
-					if len(svcs) < 1 {
-						// no services for this route, skip it.
-						return
-					}
-					vhost.Routes = append(vhost.Routes, route.Route{
-						Match:  envoy.PrefixMatch(r.Prefix),
-						Action: envoy.RouteRoute(r, svcs),
-					})
-				}
-			})
-			if len(vhost.Routes) < 1 {
-				return
-			}
-			sort.Stable(sort.Reverse(longestRouteFirst(vhost.Routes)))
-			ingress_https.VirtualHosts = append(ingress_https.VirtualHosts, vhost)
-		}
-	})
-
-	for _, v := range m {
+	rv.visit(root)
+	for _, v := range rv.routes {
 		sort.Stable(virtualHostsByName(v.VirtualHosts))
 	}
-	return m
+	return rv.routes
+}
+
+func (v *routeVisitor) visit(vertex dag.Vertex) {
+	switch vh := vertex.(type) {
+	case *dag.VirtualHost:
+		vhost := envoy.VirtualHost(vh.Host, 80)
+		vh.Visit(func(r dag.Vertex) {
+			switch r := r.(type) {
+			case *dag.Route:
+				var svcs []*dag.HTTPService
+				r.Visit(func(s dag.Vertex) {
+					if s, ok := s.(*dag.HTTPService); ok {
+						svcs = append(svcs, s)
+					}
+				})
+				if len(svcs) < 1 {
+					// no services for this route, skip it.
+					return
+				}
+				rr := route.Route{
+					Match:  envoy.PrefixMatch(r.Prefix),
+					Action: envoy.RouteRoute(r, svcs),
+				}
+
+				if r.HTTPSUpgrade {
+					rr.Action = envoy.UpgradeHTTPS()
+				}
+				vhost.Routes = append(vhost.Routes, rr)
+			}
+		})
+		if len(vhost.Routes) < 1 {
+			return
+		}
+		sort.Stable(sort.Reverse(longestRouteFirst(vhost.Routes)))
+		v.routes["ingress_http"].VirtualHosts = append(v.routes["ingress_http"].VirtualHosts, vhost)
+	case *dag.SecureVirtualHost:
+		vhost := envoy.VirtualHost(vh.Host, 443)
+		vh.Visit(func(r dag.Vertex) {
+			switch r := r.(type) {
+			case *dag.Route:
+				var svcs []*dag.HTTPService
+				r.Visit(func(s dag.Vertex) {
+					if s, ok := s.(*dag.HTTPService); ok {
+						svcs = append(svcs, s)
+					}
+				})
+				if len(svcs) < 1 {
+					// no services for this route, skip it.
+					return
+				}
+				vhost.Routes = append(vhost.Routes, route.Route{
+					Match:  envoy.PrefixMatch(r.Prefix),
+					Action: envoy.RouteRoute(r, svcs),
+				})
+			}
+		})
+		if len(vhost.Routes) < 1 {
+			return
+		}
+		sort.Stable(sort.Reverse(longestRouteFirst(vhost.Routes)))
+		v.routes["ingress_https"].VirtualHosts = append(v.routes["ingress_https"].VirtualHosts, vhost)
+	default:
+		// recurse
+		vertex.Visit(v.visit)
+	}
 }
 
 type virtualHostsByName []route.VirtualHost

--- a/internal/contour/route_test.go
+++ b/internal/contour/route_test.go
@@ -33,7 +33,6 @@ import (
 
 func TestRouteVisit(t *testing.T) {
 	tests := map[string]struct {
-		*RouteCache
 		objs []interface{}
 		want map[string]*v2.RouteConfiguration
 	}{
@@ -1701,15 +1700,8 @@ func TestRouteVisit(t *testing.T) {
 			for _, o := range tc.objs {
 				reh.OnAdd(o)
 			}
-			rc := tc.RouteCache
-			if rc == nil {
-				rc = new(RouteCache)
-			}
-			v := routeVisitor{
-				RouteCache: rc,
-				Visitable:  reh.Build(),
-			}
-			got := v.Visit()
+			root := reh.Build()
+			got := visitRoutes(root)
 			if diff := cmp.Diff(tc.want, got); diff != "" {
 				t.Fatal(diff)
 			}

--- a/internal/dag/builder.go
+++ b/internal/dag/builder.go
@@ -242,7 +242,7 @@ func (b *builder) lookupSecret(m meta) *Secret {
 		return nil
 	}
 	s := &Secret{
-		object: sec,
+		Object: sec,
 	}
 	if b.secrets == nil {
 		b.secrets = make(map[meta]*Secret)

--- a/internal/dag/builder_test.go
+++ b/internal/dag/builder_test.go
@@ -3526,6 +3526,6 @@ func (s statusByNamespaceAndName) Less(i, j int) bool {
 
 func secret(s *v1.Secret) *Secret {
 	return &Secret{
-		object: s,
+		Object: s,
 	}
 }

--- a/internal/dag/dag.go
+++ b/internal/dag/dag.go
@@ -223,21 +223,21 @@ type HTTPService struct {
 // Secret represents a K8s Secret for TLS usage as a DAG Vertex. A Secret is
 // a leaf in the DAG.
 type Secret struct {
-	object *v1.Secret
+	Object *v1.Secret
 }
 
-func (s *Secret) Name() string       { return s.object.Name }
-func (s *Secret) Namespace() string  { return s.object.Namespace }
+func (s *Secret) Name() string       { return s.Object.Name }
+func (s *Secret) Namespace() string  { return s.Object.Namespace }
 func (s *Secret) Visit(func(Vertex)) {}
 
 // Data returns the contents of the backing secret's map.
 func (s *Secret) Data() map[string][]byte {
-	return s.object.Data
+	return s.Object.Data
 }
 
 func (s *Secret) toMeta() meta {
 	return meta{
-		name:      s.object.Name,
-		namespace: s.object.Namespace,
+		name:      s.Name(),
+		namespace: s.Namespace(),
 	}
 }


### PR DESCRIPTION
Updates #787

While adding TCPForwarding to internal/contour I noticed the way the
vistors worked was very fragile. ListenerVisitor in particular expected
to be called with a visitor which delegated to a
VirtualHost/SecureVirtualHost. This PR fixes this and refactors the
visitors in general to be more robust.

Signed-off-by: Dave Cheney <dave@cheney.net>