### PR TITLE
Allow TLS 1.0 as a TLS minimumProtocolVersion version in an IngressRoute.

### DIFF
--- a/deployment/common/common.yaml
+++ b/deployment/common/common.yaml
@@ -66,6 +66,7 @@ spec:
                         - "1.3"
                         - "1.2"
                         - "1.1"
+                        - "1.0"
             strategy:
               type: string
               enum:

--- a/deployment/render/daemonset-rbac.yaml
+++ b/deployment/render/daemonset-rbac.yaml
@@ -69,6 +69,7 @@ spec:
                         - "1.3"
                         - "1.2"
                         - "1.1"
+                        - "1.0"
             strategy:
               type: string
               enum:

--- a/deployment/render/deployment-rbac.yaml
+++ b/deployment/render/deployment-rbac.yaml
@@ -69,6 +69,7 @@ spec:
                         - "1.3"
                         - "1.2"
                         - "1.1"
+                        - "1.0"
             strategy:
               type: string
               enum:

--- a/internal/dag/builder.go
+++ b/internal/dag/builder.go
@@ -394,6 +394,8 @@ func (b *builder) compute() *DAG {
 					svhost.MinProtoVersion = auth.TlsParameters_TLSv1_3
 				case "1.2":
 					svhost.MinProtoVersion = auth.TlsParameters_TLSv1_2
+				case "1.0":
+					svhost.MinProtoVersion = auth.TlsParameters_TLSv1_0
 				default:
 					// any other value is interpreted as TLS/1.1
 					svhost.MinProtoVersion = auth.TlsParameters_TLSv1_1


### PR DESCRIPTION
Legacy software may not support TLS 1.1+.  This allows specifying a route to enable TLS 1.0.  The default behavior does *not* change, and remains TLS 1.1.

Patch to close #808.
