### PR TITLE
internal/envoy: add support for multiple TCPProxy.Services

### DIFF
--- a/internal/contour/visitor_test.go
+++ b/internal/contour/visitor_test.go
@@ -39,7 +39,7 @@ func TestVisitClusters(t *testing.T) {
 					Port: 443,
 					Host: "www.example.com",
 					TCPProxy: &dag.TCPProxy{
-						TCPService: &dag.TCPService{
+						Services: []*dag.TCPService{{
 							Name:      "example",
 							Namespace: "default",
 							ServicePort: &v1.ServicePort{
@@ -47,7 +47,7 @@ func TestVisitClusters(t *testing.T) {
 								Port:       443,
 								TargetPort: intstr.FromInt(8443),
 							},
-						},
+						}},
 					},
 				},
 				Secret: new(dag.Secret),
@@ -80,7 +80,7 @@ func TestVisitClusters(t *testing.T) {
 
 func TestVisitListeners(t *testing.T) {
 	p1 := &dag.TCPProxy{
-		TCPService: &dag.TCPService{
+		Services: []*dag.TCPService{{
 			Name:      "example",
 			Namespace: "default",
 			ServicePort: &v1.ServicePort{
@@ -88,7 +88,7 @@ func TestVisitListeners(t *testing.T) {
 				Port:       443,
 				TargetPort: intstr.FromInt(8443),
 			},
-		},
+		}},
 	}
 
 	tests := map[string]struct {

--- a/internal/dag/builder_test.go
+++ b/internal/dag/builder_test.go
@@ -1716,7 +1716,9 @@ func TestDAGInsert(t *testing.T) {
 						Host: "kuard.example.com",
 						Port: 443,
 						TCPProxy: &TCPProxy{
-							TCPService: tcpService(s1),
+							Services: []*TCPService{
+								tcpService(s1),
+							},
 						},
 					},
 					Secret:          secret(sec1),

--- a/internal/dag/dag.go
+++ b/internal/dag/dag.go
@@ -159,12 +159,14 @@ type Service interface {
 // TCPProxy represents a cluster of TCP endpoints.
 type TCPProxy struct {
 
-	// Service to proxy decrypted traffic to.
-	*TCPService
+	// Services to proxy decrypted traffic to.
+	Services []*TCPService
 }
 
 func (t *TCPProxy) Visit(f func(Vertex)) {
-	f(t.TCPService)
+	for _, s := range t.Services {
+		f(s)
+	}
 }
 
 // TCPService represents a Kuberentes Service that speaks TCP. That's all we know.


### PR DESCRIPTION
Update #787

Support multiple tcpproxy services. We reuse the ingressroute Service
definition so weighting and default weighting is supported.

Signed-off-by: Dave Cheney <dave@cheney.net>