### PR TITLE
CRD fqdn regex is too strict

### DIFF
--- a/deployment/common/common.yaml
+++ b/deployment/common/common.yaml
@@ -54,7 +54,7 @@ spec:
               properties:
                 fqdn:
                   type: string
-                  pattern: ^([a-zA-Z0-9]+(-[a-zA-Z0-9]+)*\.)+[a-z]{2,}$
+                  pattern: ^([a-zA-Z0-9]+(-[a-zA-Z0-9]+)*\.)+[a-z0-9]{2,}$
                 tls:
                   properties:
                     secretName:

--- a/deployment/render/daemonset-rbac.yaml
+++ b/deployment/render/daemonset-rbac.yaml
@@ -57,7 +57,7 @@ spec:
               properties:
                 fqdn:
                   type: string
-                  pattern: ^([a-zA-Z0-9]+(-[a-zA-Z0-9]+)*\.)+[a-z]{2,}$
+                  pattern: ^([a-zA-Z0-9]+(-[a-zA-Z0-9]+)*\.)+[a-z0-9]{2,}$
                 tls:
                   properties:
                     secretName:

--- a/deployment/render/deployment-rbac.yaml
+++ b/deployment/render/deployment-rbac.yaml
@@ -57,7 +57,7 @@ spec:
               properties:
                 fqdn:
                   type: string
-                  pattern: ^([a-zA-Z0-9]+(-[a-zA-Z0-9]+)*\.)+[a-z]{2,}$
+                  pattern: ^([a-zA-Z0-9]+(-[a-zA-Z0-9]+)*\.)+[a-z0-9]{2,}$
                 tls:
                   properties:
                     secretName:


### PR DESCRIPTION
Fixes #821 

Allow numbers in TLD. 

Example:   `my.domain.k8s`