### PR TITLE
Add support for Cluster.AltStatName

### DIFF
--- a/internal/contour/cluster_test.go
+++ b/internal/contour/cluster_test.go
@@ -64,8 +64,9 @@ func TestClusterVisit(t *testing.T) {
 			},
 			want: clustermap(
 				&v2.Cluster{
-					Name: "default/kuard/443/da39a3ee5e",
-					Type: v2.Cluster_EDS,
+					Name:        "default/kuard/443/da39a3ee5e",
+					AltStatName: "default_kuard_443",
+					Type:        v2.Cluster_EDS,
 					EdsClusterConfig: &v2.Cluster_EdsClusterConfig{
 						EdsConfig:   envoy.ConfigSource("contour"),
 						ServiceName: "default/kuard",
@@ -100,8 +101,9 @@ func TestClusterVisit(t *testing.T) {
 			},
 			want: clustermap(
 				&v2.Cluster{
-					Name: "default/kuard/443/da39a3ee5e",
-					Type: v2.Cluster_EDS,
+					Name:        "default/kuard/443/da39a3ee5e",
+					AltStatName: "default_kuard_443",
+					Type:        v2.Cluster_EDS,
 					EdsClusterConfig: &v2.Cluster_EdsClusterConfig{
 						EdsConfig:   envoy.ConfigSource("contour"),
 						ServiceName: "default/kuard/https",
@@ -140,8 +142,9 @@ func TestClusterVisit(t *testing.T) {
 			},
 			want: clustermap(
 				&v2.Cluster{
-					Name: "default/kuard/80/da39a3ee5e",
-					Type: v2.Cluster_EDS,
+					Name:        "default/kuard/80/da39a3ee5e",
+					AltStatName: "default_kuard_80",
+					Type:        v2.Cluster_EDS,
 					EdsClusterConfig: &v2.Cluster_EdsClusterConfig{
 						EdsConfig:   envoy.ConfigSource("contour"),
 						ServiceName: "default/kuard/http",
@@ -178,8 +181,9 @@ func TestClusterVisit(t *testing.T) {
 			},
 			want: clustermap(
 				&v2.Cluster{
-					Name: "beurocra-7fe4b4/tiny-cog-7fe4b4/443/da39a3ee5e",
-					Type: v2.Cluster_EDS,
+					Name:        "beurocra-7fe4b4/tiny-cog-7fe4b4/443/da39a3ee5e",
+					AltStatName: "beurocratic-company-test-domain-1_tiny-cog-department-test-instance_443",
+					Type:        v2.Cluster_EDS,
 					EdsClusterConfig: &v2.Cluster_EdsClusterConfig{
 						EdsConfig:   envoy.ConfigSource("contour"),
 						ServiceName: "beurocratic-company-test-domain-1/tiny-cog-department-test-instance/svc-0",
@@ -226,8 +230,9 @@ func TestClusterVisit(t *testing.T) {
 			},
 			want: clustermap(
 				&v2.Cluster{
-					Name: "default/backend/80/da39a3ee5e",
-					Type: v2.Cluster_EDS,
+					Name:        "default/backend/80/da39a3ee5e",
+					AltStatName: "default_backend_80",
+					Type:        v2.Cluster_EDS,
 					EdsClusterConfig: &v2.Cluster_EdsClusterConfig{
 						EdsConfig:   envoy.ConfigSource("contour"),
 						ServiceName: "default/backend/http",
@@ -237,8 +242,9 @@ func TestClusterVisit(t *testing.T) {
 					CommonLbConfig: envoy.ClusterCommonLBConfig(),
 				},
 				&v2.Cluster{
-					Name: "default/backend/8080/da39a3ee5e",
-					Type: v2.Cluster_EDS,
+					Name:        "default/backend/8080/da39a3ee5e",
+					AltStatName: "default_backend_8080",
+					Type:        v2.Cluster_EDS,
 					EdsClusterConfig: &v2.Cluster_EdsClusterConfig{
 						EdsConfig:   envoy.ConfigSource("contour"),
 						ServiceName: "default/backend/alt",
@@ -281,8 +287,9 @@ func TestClusterVisit(t *testing.T) {
 			},
 			want: clustermap(
 				&v2.Cluster{
-					Name: "default/backend/80/c184349821",
-					Type: v2.Cluster_EDS,
+					Name:        "default/backend/80/c184349821",
+					AltStatName: "default_backend_80",
+					Type:        v2.Cluster_EDS,
 					EdsClusterConfig: &v2.Cluster_EdsClusterConfig{
 						EdsConfig:   envoy.ConfigSource("contour"),
 						ServiceName: "default/backend/http",
@@ -342,8 +349,9 @@ func TestClusterVisit(t *testing.T) {
 			},
 			want: clustermap(
 				&v2.Cluster{
-					Name: "default/backend/80/7f8051653a",
-					Type: v2.Cluster_EDS,
+					Name:        "default/backend/80/7f8051653a",
+					AltStatName: "default_backend_80",
+					Type:        v2.Cluster_EDS,
 					EdsClusterConfig: &v2.Cluster_EdsClusterConfig{
 						EdsConfig:   envoy.ConfigSource("contour"),
 						ServiceName: "default/backend/http",
@@ -396,8 +404,9 @@ func TestClusterVisit(t *testing.T) {
 			},
 			want: clustermap(
 				&v2.Cluster{
-					Name: "default/backend/80/f3b72af6a9",
-					Type: v2.Cluster_EDS,
+					Name:        "default/backend/80/f3b72af6a9",
+					AltStatName: "default_backend_80",
+					Type:        v2.Cluster_EDS,
 					EdsClusterConfig: &v2.Cluster_EdsClusterConfig{
 						EdsConfig:   envoy.ConfigSource("contour"),
 						ServiceName: "default/backend/http",
@@ -438,8 +447,9 @@ func TestClusterVisit(t *testing.T) {
 			},
 			want: clustermap(
 				&v2.Cluster{
-					Name: "default/backend/80/8bf87fefba",
-					Type: v2.Cluster_EDS,
+					Name:        "default/backend/80/8bf87fefba",
+					AltStatName: "default_backend_80",
+					Type:        v2.Cluster_EDS,
 					EdsClusterConfig: &v2.Cluster_EdsClusterConfig{
 						EdsConfig:   envoy.ConfigSource("contour"),
 						ServiceName: "default/backend/http",
@@ -480,8 +490,9 @@ func TestClusterVisit(t *testing.T) {
 			},
 			want: clustermap(
 				&v2.Cluster{
-					Name: "default/backend/80/40633a6ca9",
-					Type: v2.Cluster_EDS,
+					Name:        "default/backend/80/40633a6ca9",
+					AltStatName: "default_backend_80",
+					Type:        v2.Cluster_EDS,
 					EdsClusterConfig: &v2.Cluster_EdsClusterConfig{
 						EdsConfig:   envoy.ConfigSource("contour"),
 						ServiceName: "default/backend/http",
@@ -522,8 +533,9 @@ func TestClusterVisit(t *testing.T) {
 			},
 			want: clustermap(
 				&v2.Cluster{
-					Name: "default/backend/80/843e4ded8f",
-					Type: v2.Cluster_EDS,
+					Name:        "default/backend/80/843e4ded8f",
+					AltStatName: "default_backend_80",
+					Type:        v2.Cluster_EDS,
 					EdsClusterConfig: &v2.Cluster_EdsClusterConfig{
 						EdsConfig:   envoy.ConfigSource("contour"),
 						ServiceName: "default/backend/http",
@@ -564,8 +576,9 @@ func TestClusterVisit(t *testing.T) {
 			},
 			want: clustermap(
 				&v2.Cluster{
-					Name: "default/backend/80/58d888c08a",
-					Type: v2.Cluster_EDS,
+					Name:        "default/backend/80/58d888c08a",
+					AltStatName: "default_backend_80",
+					Type:        v2.Cluster_EDS,
 					EdsClusterConfig: &v2.Cluster_EdsClusterConfig{
 						EdsConfig:   envoy.ConfigSource("contour"),
 						ServiceName: "default/backend/http",
@@ -613,8 +626,9 @@ func TestClusterVisit(t *testing.T) {
 			},
 			want: clustermap(
 				&v2.Cluster{
-					Name: "default/backend/80/58d888c08a",
-					Type: v2.Cluster_EDS,
+					Name:        "default/backend/80/58d888c08a",
+					AltStatName: "default_backend_80",
+					Type:        v2.Cluster_EDS,
 					EdsClusterConfig: &v2.Cluster_EdsClusterConfig{
 						EdsConfig:   envoy.ConfigSource("contour"),
 						ServiceName: "default/backend/http",
@@ -624,8 +638,9 @@ func TestClusterVisit(t *testing.T) {
 					CommonLbConfig: envoy.ClusterCommonLBConfig(),
 				},
 				&v2.Cluster{
-					Name: "default/backend/80/843e4ded8f",
-					Type: v2.Cluster_EDS,
+					Name:        "default/backend/80/843e4ded8f",
+					AltStatName: "default_backend_80",
+					Type:        v2.Cluster_EDS,
 					EdsClusterConfig: &v2.Cluster_EdsClusterConfig{
 						EdsConfig:   envoy.ConfigSource("contour"),
 						ServiceName: "default/backend/http",
@@ -667,8 +682,9 @@ func TestClusterVisit(t *testing.T) {
 			},
 			want: clustermap(
 				&v2.Cluster{
-					Name: "default/backend/80/86d7a9c129",
-					Type: v2.Cluster_EDS,
+					Name:        "default/backend/80/86d7a9c129",
+					AltStatName: "default_backend_80",
+					Type:        v2.Cluster_EDS,
 					EdsClusterConfig: &v2.Cluster_EdsClusterConfig{
 						EdsConfig:   envoy.ConfigSource("contour"),
 						ServiceName: "default/backend/http",
@@ -711,8 +727,9 @@ func TestClusterVisit(t *testing.T) {
 			},
 			want: clustermap(
 				&v2.Cluster{
-					Name: "default/kuard/80/da39a3ee5e",
-					Type: v2.Cluster_EDS,
+					Name:        "default/kuard/80/da39a3ee5e",
+					AltStatName: "default_kuard_80",
+					Type:        v2.Cluster_EDS,
 					EdsClusterConfig: &v2.Cluster_EdsClusterConfig{
 						EdsConfig:   envoy.ConfigSource("contour"),
 						ServiceName: "default/kuard/http",
@@ -760,8 +777,9 @@ func TestClusterVisit(t *testing.T) {
 			},
 			want: clustermap(
 				&v2.Cluster{
-					Name: "default/kuard/443/da39a3ee5e",
-					Type: v2.Cluster_EDS,
+					Name:        "default/kuard/443/da39a3ee5e",
+					AltStatName: "default_kuard_443",
+					Type:        v2.Cluster_EDS,
 					EdsClusterConfig: &v2.Cluster_EdsClusterConfig{
 						EdsConfig:   envoy.ConfigSource("contour"),
 						ServiceName: "default/kuard/https",

--- a/internal/contour/visitor_test.go
+++ b/internal/contour/visitor_test.go
@@ -54,8 +54,9 @@ func TestVisitClusters(t *testing.T) {
 			},
 			want: clustermap(
 				&v2.Cluster{
-					Name: "default/example/443/da39a3ee5e",
-					Type: v2.Cluster_EDS,
+					Name:        "default/example/443/da39a3ee5e",
+					AltStatName: "default_example_443",
+					Type:        v2.Cluster_EDS,
 					EdsClusterConfig: &v2.Cluster_EdsClusterConfig{
 						EdsConfig:   envoy.ConfigSource("contour"),
 						ServiceName: "default/example",

--- a/internal/e2e/cds_test.go
+++ b/internal/e2e/cds_test.go
@@ -64,7 +64,7 @@ func TestClusterLongServiceName(t *testing.T) {
 	assertEqual(t, &v2.DiscoveryResponse{
 		VersionInfo: "0",
 		Resources: []types.Any{
-			any(t, cluster("default/kbujbkuh-c83ceb/8080/da39a3ee5e", "default/kbujbkuhdod66gjdmwmijz8xzgsx1nkfbrloezdjiulquzk4x3p0nnvpzi8r")),
+			any(t, cluster("default/kbujbkuh-c83ceb/8080/da39a3ee5e", "default/kbujbkuhdod66gjdmwmijz8xzgsx1nkfbrloezdjiulquzk4x3p0nnvpzi8r", "default_kbujbkuhdod66gjdmwmijz8xzgsx1nkfbrloezdjiulquzk4x3p0nnvpzi8r_8080")),
 		},
 		TypeUrl: clusterType,
 		Nonce:   "0",
@@ -126,7 +126,7 @@ func TestClusterAddUpdateDelete(t *testing.T) {
 	assertEqual(t, &v2.DiscoveryResponse{
 		VersionInfo: "0",
 		Resources: []types.Any{
-			any(t, cluster("default/kuard/80/da39a3ee5e", "default/kuard")),
+			any(t, cluster("default/kuard/80/da39a3ee5e", "default/kuard", "default_kuard_80")),
 		},
 		TypeUrl: clusterType,
 		Nonce:   "0",
@@ -147,7 +147,7 @@ func TestClusterAddUpdateDelete(t *testing.T) {
 	assertEqual(t, &v2.DiscoveryResponse{
 		VersionInfo: "0",
 		Resources: []types.Any{
-			any(t, cluster("default/kuard/80/da39a3ee5e", "default/kuard/http")),
+			any(t, cluster("default/kuard/80/da39a3ee5e", "default/kuard/http", "default_kuard_80")),
 		},
 		TypeUrl: clusterType,
 		Nonce:   "0",
@@ -178,8 +178,8 @@ func TestClusterAddUpdateDelete(t *testing.T) {
 	assertEqual(t, &v2.DiscoveryResponse{
 		VersionInfo: "0",
 		Resources: []types.Any{
-			any(t, cluster("default/kuard/443/da39a3ee5e", "default/kuard/https")),
-			any(t, cluster("default/kuard/80/da39a3ee5e", "default/kuard/http")),
+			any(t, cluster("default/kuard/443/da39a3ee5e", "default/kuard/https", "default_kuard_443")),
+			any(t, cluster("default/kuard/80/da39a3ee5e", "default/kuard/http", "default_kuard_80")),
 		},
 		TypeUrl: clusterType,
 		Nonce:   "0",
@@ -203,7 +203,7 @@ func TestClusterAddUpdateDelete(t *testing.T) {
 	assertEqual(t, &v2.DiscoveryResponse{
 		VersionInfo: "0",
 		Resources: []types.Any{
-			any(t, cluster("default/kuard/443/da39a3ee5e", "default/kuard/https")),
+			any(t, cluster("default/kuard/443/da39a3ee5e", "default/kuard/https", "default_kuard_443")),
 		},
 		TypeUrl: clusterType,
 		Nonce:   "0",
@@ -263,8 +263,8 @@ func TestClusterRenameUpdateDelete(t *testing.T) {
 	assertEqual(t, &v2.DiscoveryResponse{
 		VersionInfo: "0",
 		Resources: []types.Any{
-			any(t, cluster("default/kuard/443/da39a3ee5e", "default/kuard/https")),
-			any(t, cluster("default/kuard/80/da39a3ee5e", "default/kuard/http")),
+			any(t, cluster("default/kuard/443/da39a3ee5e", "default/kuard/https", "default_kuard_443")),
+			any(t, cluster("default/kuard/80/da39a3ee5e", "default/kuard/http", "default_kuard_80")),
 		},
 		TypeUrl: clusterType,
 		Nonce:   "0",
@@ -283,7 +283,7 @@ func TestClusterRenameUpdateDelete(t *testing.T) {
 	assertEqual(t, &v2.DiscoveryResponse{
 		VersionInfo: "0",
 		Resources: []types.Any{
-			any(t, cluster("default/kuard/443/da39a3ee5e", "default/kuard")),
+			any(t, cluster("default/kuard/443/da39a3ee5e", "default/kuard", "default_kuard_443")),
 		},
 		TypeUrl: clusterType,
 		Nonce:   "0",
@@ -294,8 +294,8 @@ func TestClusterRenameUpdateDelete(t *testing.T) {
 	assertEqual(t, &v2.DiscoveryResponse{
 		VersionInfo: "0",
 		Resources: []types.Any{
-			any(t, cluster("default/kuard/443/da39a3ee5e", "default/kuard/https")),
-			any(t, cluster("default/kuard/80/da39a3ee5e", "default/kuard/http")),
+			any(t, cluster("default/kuard/443/da39a3ee5e", "default/kuard/https", "default_kuard_443")),
+			any(t, cluster("default/kuard/80/da39a3ee5e", "default/kuard/http", "default_kuard_80")),
 		},
 		TypeUrl: clusterType,
 		Nonce:   "0",
@@ -342,7 +342,7 @@ func TestIssue243(t *testing.T) {
 		assertEqual(t, &v2.DiscoveryResponse{
 			VersionInfo: "0",
 			Resources: []types.Any{
-				any(t, cluster("default/kuard/80/da39a3ee5e", "default/kuard")),
+				any(t, cluster("default/kuard/80/da39a3ee5e", "default/kuard", "default_kuard_80")),
 			},
 			TypeUrl: clusterType,
 			Nonce:   "0",
@@ -385,7 +385,7 @@ func TestIssue247(t *testing.T) {
 	assertEqual(t, &v2.DiscoveryResponse{
 		VersionInfo: "0",
 		Resources: []types.Any{
-			any(t, cluster("default/kuard/80/da39a3ee5e", "default/kuard")),
+			any(t, cluster("default/kuard/80/da39a3ee5e", "default/kuard", "default_kuard_80")),
 		},
 		TypeUrl: clusterType,
 		Nonce:   "0",
@@ -445,8 +445,8 @@ func TestCDSResourceFiltering(t *testing.T) {
 		VersionInfo: "0",
 		Resources: []types.Any{
 			// note, resources are sorted by Cluster.Name
-			any(t, cluster("default/httpbin/8080/da39a3ee5e", "default/httpbin")),
-			any(t, cluster("default/kuard/80/da39a3ee5e", "default/kuard")),
+			any(t, cluster("default/httpbin/8080/da39a3ee5e", "default/httpbin", "default_httpbin_8080")),
+			any(t, cluster("default/kuard/80/da39a3ee5e", "default/kuard", "default_kuard_80")),
 		},
 		TypeUrl: clusterType,
 		Nonce:   "0",
@@ -456,7 +456,7 @@ func TestCDSResourceFiltering(t *testing.T) {
 	assertEqual(t, &v2.DiscoveryResponse{
 		VersionInfo: "0",
 		Resources: []types.Any{
-			any(t, cluster("default/kuard/80/da39a3ee5e", "default/kuard")),
+			any(t, cluster("default/kuard/80/da39a3ee5e", "default/kuard", "default_kuard_80")),
 		},
 		TypeUrl: clusterType,
 		Nonce:   "0",
@@ -511,8 +511,9 @@ func TestClusterCircuitbreakerAnnotations(t *testing.T) {
 		VersionInfo: "0",
 		Resources: []types.Any{
 			any(t, &v2.Cluster{
-				Name: "default/kuard/8080/da39a3ee5e",
-				Type: v2.Cluster_EDS,
+				Name:        "default/kuard/8080/da39a3ee5e",
+				AltStatName: "default_kuard_8080",
+				Type:        v2.Cluster_EDS,
 				EdsClusterConfig: &v2.Cluster_EdsClusterConfig{
 					EdsConfig:   envoy.ConfigSource("contour"),
 					ServiceName: "default/kuard",
@@ -556,8 +557,9 @@ func TestClusterCircuitbreakerAnnotations(t *testing.T) {
 		VersionInfo: "0",
 		Resources: []types.Any{
 			any(t, &v2.Cluster{
-				Name: "default/kuard/8080/da39a3ee5e",
-				Type: v2.Cluster_EDS,
+				Name:        "default/kuard/8080/da39a3ee5e",
+				AltStatName: "default_kuard_8080",
+				Type:        v2.Cluster_EDS,
 				EdsClusterConfig: &v2.Cluster_EdsClusterConfig{
 					EdsConfig:   envoy.ConfigSource("contour"),
 					ServiceName: "default/kuard",
@@ -625,7 +627,7 @@ func TestClusterPerServiceParameters(t *testing.T) {
 	assertEqual(t, &v2.DiscoveryResponse{
 		VersionInfo: "0",
 		Resources: []types.Any{
-			any(t, cluster("default/kuard/80/da39a3ee5e", "default/kuard")),
+			any(t, cluster("default/kuard/80/da39a3ee5e", "default/kuard", "default_kuard_80")),
 		},
 		TypeUrl: clusterType,
 		Nonce:   "0",
@@ -681,8 +683,9 @@ func TestClusterLoadBalancerStrategyPerRoute(t *testing.T) {
 		VersionInfo: "0",
 		Resources: []types.Any{
 			any(t, &v2.Cluster{
-				Name: "default/kuard/80/58d888c08a",
-				Type: v2.Cluster_EDS,
+				Name:        "default/kuard/80/58d888c08a",
+				AltStatName: "default_kuard_80",
+				Type:        v2.Cluster_EDS,
 				EdsClusterConfig: &v2.Cluster_EdsClusterConfig{
 					EdsConfig:   envoy.ConfigSource("contour"),
 					ServiceName: "default/kuard",
@@ -692,8 +695,9 @@ func TestClusterLoadBalancerStrategyPerRoute(t *testing.T) {
 				CommonLbConfig: envoy.ClusterCommonLBConfig(),
 			}),
 			any(t, &v2.Cluster{
-				Name: "default/kuard/80/843e4ded8f",
-				Type: v2.Cluster_EDS,
+				Name:        "default/kuard/80/843e4ded8f",
+				AltStatName: "default_kuard_80",
+				Type:        v2.Cluster_EDS,
 				EdsClusterConfig: &v2.Cluster_EdsClusterConfig{
 					EdsConfig:   envoy.ConfigSource("contour"),
 					ServiceName: "default/kuard",
@@ -732,10 +736,11 @@ func streamCDS(t *testing.T, cc *grpc.ClientConn, rn ...string) *v2.DiscoveryRes
 	})
 }
 
-func cluster(name, servicename string) *v2.Cluster {
+func cluster(name, servicename, statName string) *v2.Cluster {
 	return &v2.Cluster{
-		Name: name,
-		Type: v2.Cluster_EDS,
+		Name:        name,
+		Type:        v2.Cluster_EDS,
+		AltStatName: statName,
 		EdsClusterConfig: &v2.Cluster_EdsClusterConfig{
 			EdsConfig:   envoy.ConfigSource("contour"),
 			ServiceName: servicename,

--- a/internal/envoy/cluster.go
+++ b/internal/envoy/cluster.go
@@ -56,6 +56,7 @@ func httpCluster(service *dag.HTTPService) *v2.Cluster {
 func cluster(service *dag.TCPService) *v2.Cluster {
 	c := &v2.Cluster{
 		Name:             Clustername(service),
+		AltStatName:      altStatName(service),
 		Type:             v2.Cluster_EDS,
 		EdsClusterConfig: edsconfig("contour", service),
 		ConnectTimeout:   250 * time.Millisecond,
@@ -138,6 +139,12 @@ func Clustername(service *dag.TCPService) string {
 	ns := service.Namespace
 	name := service.Name
 	return hashname(60, ns, name, strconv.Itoa(int(service.Port)), fmt.Sprintf("%x", hash[:5]))
+}
+
+// altStatName generates an alternative stat name for the service
+// using format ns_name_port
+func altStatName(service *dag.TCPService) string {
+	return strings.Join([]string{service.Namespace, service.Name, strconv.Itoa(int(service.Port))}, "_")
 }
 
 // hashname takes a lenth l and a varargs of strings s and returns a string whose length

--- a/internal/envoy/cluster_test.go
+++ b/internal/envoy/cluster_test.go
@@ -55,8 +55,9 @@ func TestCluster(t *testing.T) {
 				TCPService: service(s1),
 			},
 			want: &v2.Cluster{
-				Name: "default/kuard/443/da39a3ee5e",
-				Type: v2.Cluster_EDS,
+				Name:        "default/kuard/443/da39a3ee5e",
+				AltStatName: "default_kuard_443",
+				Type:        v2.Cluster_EDS,
 				EdsClusterConfig: &v2.Cluster_EdsClusterConfig{
 					EdsConfig:   ConfigSource("contour"),
 					ServiceName: "default/kuard/http",
@@ -72,8 +73,9 @@ func TestCluster(t *testing.T) {
 				Protocol:   "h2c",
 			},
 			want: &v2.Cluster{
-				Name: "default/kuard/443/da39a3ee5e",
-				Type: v2.Cluster_EDS,
+				Name:        "default/kuard/443/da39a3ee5e",
+				AltStatName: "default_kuard_443",
+				Type:        v2.Cluster_EDS,
 				EdsClusterConfig: &v2.Cluster_EdsClusterConfig{
 					EdsConfig:   ConfigSource("contour"),
 					ServiceName: "default/kuard/http",
@@ -90,8 +92,9 @@ func TestCluster(t *testing.T) {
 				Protocol:   "h2",
 			},
 			want: &v2.Cluster{
-				Name: "default/kuard/443/da39a3ee5e",
-				Type: v2.Cluster_EDS,
+				Name:        "default/kuard/443/da39a3ee5e",
+				AltStatName: "default_kuard_443",
+				Type:        v2.Cluster_EDS,
 				EdsClusterConfig: &v2.Cluster_EdsClusterConfig{
 					EdsConfig:   ConfigSource("contour"),
 					ServiceName: "default/kuard/http",
@@ -112,8 +115,9 @@ func TestCluster(t *testing.T) {
 				},
 			},
 			want: &v2.Cluster{
-				Name: "default/kuard/443/da39a3ee5e",
-				Type: v2.Cluster_EDS,
+				Name:        "default/kuard/443/da39a3ee5e",
+				AltStatName: "default_kuard_443",
+				Type:        v2.Cluster_EDS,
 				EdsClusterConfig: &v2.Cluster_EdsClusterConfig{
 					EdsConfig:   ConfigSource("contour"),
 					ServiceName: "default/kuard/http",
@@ -137,8 +141,9 @@ func TestCluster(t *testing.T) {
 				},
 			},
 			want: &v2.Cluster{
-				Name: "default/kuard/443/da39a3ee5e",
-				Type: v2.Cluster_EDS,
+				Name:        "default/kuard/443/da39a3ee5e",
+				AltStatName: "default_kuard_443",
+				Type:        v2.Cluster_EDS,
 				EdsClusterConfig: &v2.Cluster_EdsClusterConfig{
 					EdsConfig:   ConfigSource("contour"),
 					ServiceName: "default/kuard/http",
@@ -162,8 +167,9 @@ func TestCluster(t *testing.T) {
 				},
 			},
 			want: &v2.Cluster{
-				Name: "default/kuard/443/da39a3ee5e",
-				Type: v2.Cluster_EDS,
+				Name:        "default/kuard/443/da39a3ee5e",
+				AltStatName: "default_kuard_443",
+				Type:        v2.Cluster_EDS,
 				EdsClusterConfig: &v2.Cluster_EdsClusterConfig{
 					EdsConfig:   ConfigSource("contour"),
 					ServiceName: "default/kuard/http",
@@ -187,8 +193,9 @@ func TestCluster(t *testing.T) {
 				},
 			},
 			want: &v2.Cluster{
-				Name: "default/kuard/443/da39a3ee5e",
-				Type: v2.Cluster_EDS,
+				Name:        "default/kuard/443/da39a3ee5e",
+				AltStatName: "default_kuard_443",
+				Type:        v2.Cluster_EDS,
 				EdsClusterConfig: &v2.Cluster_EdsClusterConfig{
 					EdsConfig:   ConfigSource("contour"),
 					ServiceName: "default/kuard/http",
@@ -209,8 +216,9 @@ func TestCluster(t *testing.T) {
 				ServicePort: &s1.Spec.Ports[0],
 			},
 			want: &v2.Cluster{
-				Name: "default/kuard/443/da39a3ee5e",
-				Type: v2.Cluster_EDS,
+				Name:        "default/kuard/443/da39a3ee5e",
+				AltStatName: "default_kuard_443",
+				Type:        v2.Cluster_EDS,
 				EdsClusterConfig: &v2.Cluster_EdsClusterConfig{
 					EdsConfig:   ConfigSource("contour"),
 					ServiceName: "default/kuard/http",


### PR DESCRIPTION
Attempt at providing a solution for https://github.com/heptio/contour/issues/689

Goal: Add support for Cluster.AltStatName to expose a more readable stat name.

Note: `AltStatName` does not seem to have the `maximum length of a cluster name is limited to 60` limitation, so it is possible that the cluster name and the stat name differ slightly.

Feedback welcome!