### PR TITLE
internal/contour: use header match for /healthz probe

### DIFF
--- a/internal/envoy/config.go
+++ b/internal/envoy/config.go
@@ -142,8 +142,10 @@ static_resources:
                 http_filters:
                   - name: envoy.health_check
                     config:
-                      endpoint: "/healthz"
                       pass_through_mode: false
+                      headers:
+                      - name: ":path"
+                        exact_match: "/healthz"
                   - name: envoy.router
                     config:
 {{ if .StatsdEnabled }}stats_sinks:

--- a/internal/envoy/config_test.go
+++ b/internal/envoy/config_test.go
@@ -95,8 +95,10 @@ static_resources:
                 http_filters:
                   - name: envoy.health_check
                     config:
-                      endpoint: "/healthz"
                       pass_through_mode: false
+                      headers:
+                      - name: ":path"
+                        exact_match: "/healthz"
                   - name: envoy.router
                     config:
 admin:
@@ -183,8 +185,10 @@ static_resources:
                 http_filters:
                   - name: envoy.health_check
                     config:
-                      endpoint: "/healthz"
                       pass_through_mode: false
+                      headers:
+                      - name: ":path"
+                        exact_match: "/healthz"
                   - name: envoy.router
                     config:
 stats_sinks:


### PR DESCRIPTION
Update #737

The `endpoint: /healthz` syntax was deprecated in Envoy 1.7. Switch to
the replacement syntax.

This change is backwards compatible with Envoy 1.7.0.

Signed-off-by: Dave Cheney <dave@cheney.net>