### PR TITLE
Makefile: Remove unused make targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ test-race: | test
 vet: | test
 	go vet ./...
 
-check: test test-race vet gofmt staticcheck unused misspell unconvert gosimple ineffassign
+check: test test-race vet gofmt staticcheck misspell unconvert ineffassign
 	@echo Checking rendered files are up to date
 	@(cd deployment && bash render.sh && git diff --exit-code . || (echo "rendered files are out of date" && exit 1))
 
@@ -39,11 +39,9 @@ push: container
 
 staticcheck:
 	@go get honnef.co/go/tools/cmd/staticcheck
-	staticcheck $(PKGS)
-
-unused:
-	@go get honnef.co/go/tools/cmd/unused
-	unused -exported $(PKGS)
+	staticcheck \
+		-checks all,-ST1003 \
+		$(PKGS)
 
 misspell:
 	@go get github.com/client9/misspell/cmd/misspell
@@ -56,10 +54,6 @@ misspell:
 unconvert:
 	@go get github.com/mdempsky/unconvert
 	unconvert -v $(PKGS)
-
-gosimple:
-	@go get honnef.co/go/tools/cmd/gosimple
-	gosimple $(PKGS)
 
 ineffassign:
 	@go get github.com/gordonklaus/ineffassign

--- a/internal/e2e/e2e.go
+++ b/internal/e2e/e2e.go
@@ -11,9 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package e2e provides end-to-end tests.
 package e2e
-
-// grpc helpers
 
 import (
 	"net"

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -11,6 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package metrics provides Prometheus metrics for Contour.
 package metrics
 
 import (
@@ -152,33 +153,23 @@ func (m *Metrics) SetIngressRouteMetric(metrics IngressRouteMetric) {
 	// Process metrics
 	for meta, value := range metrics.Total {
 		m.ingressRouteTotalGauge.WithLabelValues(meta.Namespace).Set(float64(value))
-		if _, ok := m.metricCache.Total[meta]; ok {
-			delete(m.metricCache.Total, meta)
-		}
+		delete(m.metricCache.Total, meta)
 	}
 	for meta, value := range metrics.Invalid {
 		m.ingressRouteInvalidGauge.WithLabelValues(meta.Namespace, meta.VHost).Set(float64(value))
-		if _, ok := m.metricCache.Invalid[meta]; ok {
-			delete(m.metricCache.Invalid, meta)
-		}
+		delete(m.metricCache.Invalid, meta)
 	}
 	for meta, value := range metrics.Orphaned {
 		m.ingressRouteOrphanedGauge.WithLabelValues(meta.Namespace).Set(float64(value))
-		if _, ok := m.metricCache.Orphaned[meta]; ok {
-			delete(m.metricCache.Orphaned, meta)
-		}
+		delete(m.metricCache.Orphaned, meta)
 	}
 	for meta, value := range metrics.Valid {
 		m.ingressRouteValidGauge.WithLabelValues(meta.Namespace, meta.VHost).Set(float64(value))
-		if _, ok := m.metricCache.Valid[meta]; ok {
-			delete(m.metricCache.Valid, meta)
-		}
+		delete(m.metricCache.Valid, meta)
 	}
 	for meta, value := range metrics.Root {
 		m.ingressRouteRootTotalGauge.WithLabelValues(meta.Namespace).Set(float64(value))
-		if _, ok := m.metricCache.Root[meta]; ok {
-			delete(m.metricCache.Root, meta)
-		}
+		delete(m.metricCache.Root, meta)
 	}
 
 	// All metrics processed, now remove what's left as they are not needed


### PR DESCRIPTION
staticcheck has incorporated changes from go-simple and unused. Clean up
the Makefile to support that. Also address several issues found by the
recent version of static check.

Signed-off-by: Dave Cheney <dave@cheney.net>