### PR TITLE
tcpproxy: add tls passthrough

### DIFF
--- a/docs/ingressroute.md
+++ b/docs/ingressroute.md
@@ -776,6 +776,10 @@ spec:
 
 The `spec.tcpproxy` key indicates that this _root_ IngressRoute will forward all de-encrypted TCP traffic to the backend service.
 
+In case `spec.virtualhost.tls` is not present, TLS is not going to be terminated
+on Envoy and will be forwarded to the specified services, where the termination
+would happen. This is called SSL/TLS Passthrough.
+
 ### Limitations
 
 The current limitations are present in Contour 0.8. These will be addressed in later Contour versions.
@@ -783,7 +787,6 @@ The current limitations are present in Contour 0.8. These will be addressed in l
 - `spec.routes` must be present in the `IngressRoute` document to pass validation, however they are ignored when `spec.tcpproxy` is present.
 - TCP Proxy IngressRoutes must be roots and can not delegate to other IngressRoutes.
 - TCP Proxying is not available on Kubernetes Ingress objects.
-- `spec.virtualhost.tls` is required for TCP proxying. If not present, `spec.tcpproxy` will be ignored.
 
 ## Status Reporting
 

--- a/internal/dag/builder.go
+++ b/internal/dag/builder.go
@@ -23,7 +23,7 @@ import (
 	"sync"
 	"time"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/api/extensions/v1beta1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/tools/cache"
@@ -540,8 +540,8 @@ func (b *builder) DAG() *DAG {
 		}
 	}
 	for _, svh := range b.svhosts {
-		// suppress secure virtual hosts without secrets.
-		if svh.Secret != nil {
+		// suppress secure virtual hosts without secrets or tcpproxy.
+		if svh.Secret != nil || svh.TCPProxy != nil {
 			dag.roots = append(dag.roots, svh)
 		}
 	}
@@ -586,7 +586,7 @@ func (b *builder) processIngressRoute(ir *ingressroutev1.IngressRoute, prefixMat
 	visited = append(visited, ir)
 
 	proxy := ir.Spec.TCPProxy
-	if proxy != nil && enforceTLS {
+	if proxy != nil {
 		var ts []*TCPService
 		for _, service := range proxy.Services {
 			m := meta{name: service.Name, namespace: ir.Namespace}


### PR DESCRIPTION
Allow an IngressRoute for TCP forwarding but without a `tls` section
which implicitly configures it as a TLS Passthrough. TLS Passthrough
only reads the very first TLS packets and routes the traffic without
doing any kind of TLS termination. The chosen `virtualhost` is
discovered by reading the TLS SNI (Server Name Indication) extension.

Closes #15

Signed-off-by: Gorka Lerchundi Osa <glertxundi@gmail.com>