### PR TITLE
TLS verification of backend services

### DIFF
--- a/apis/contour/v1beta1/ingressroute.go
+++ b/apis/contour/v1beta1/ingressroute.go
@@ -118,7 +118,16 @@ type HealthCheck struct {
 
 // TLS verification for the upstream services
 type TLSVerification struct {
-	// required, the name of a configmap in the current namespace
+	// Required, the CA to use for TLS verification
+	CA CA `json:"ca"`
+	// If specified, at least one of the hostnames must be included in the
+	// certificate's Subject Alternative Names field
+	Hostnames []string `json:"hostnames"`
+}
+
+// TLS verification for the upstream services
+type CA struct {
+	// Required, the name of a configmap in the current namespace
 	ConfigMapName string `json:"configMapName"`
 }
 

--- a/apis/contour/v1beta1/ingressroute.go
+++ b/apis/contour/v1beta1/ingressroute.go
@@ -86,6 +86,8 @@ type Service struct {
 	HealthCheck *HealthCheck `json:"healthCheck,omitempty"`
 	// LB Algorithm to apply (see https://github.com/heptio/contour/blob/master/design/ingressroute-design.md#load-balancing)
 	Strategy string `json:"strategy,omitempty"`
+	// Optional TLS verification of the service using a CA certificate
+	TLSVerification *TLSVerification `json:"tlsVerification,omitempty"`
 }
 
 // Delegate allows for delegating VHosts to other IngressRoutes
@@ -112,6 +114,12 @@ type HealthCheck struct {
 	UnhealthyThresholdCount uint32 `json:"unhealthyThresholdCount"`
 	// The number of healthy health checks required before a host is marked healthy
 	HealthyThresholdCount uint32 `json:"healthyThresholdCount"`
+}
+
+// TLS verification for the upstream services
+type TLSVerification struct {
+	// required, the name of a configmap in the current namespace
+	ConfigMapName string `json:"configMapName"`
 }
 
 // Status reports the current state of the IngressRoute

--- a/apis/contour/v1beta1/ingressroute.go
+++ b/apis/contour/v1beta1/ingressroute.go
@@ -120,9 +120,9 @@ type HealthCheck struct {
 type TLSVerification struct {
 	// Required, the CA to use for TLS verification
 	CA CA `json:"ca"`
-	// If specified, at least one of the hostnames must be included in the
-	// certificate's Subject Alternative Names field
-	Hostnames []string `json:"hostnames"`
+	// If specified, the hostname must be included in the certificate's Subject
+	// Alternative Names field
+	Hostname string `json:"hostname"`
 }
 
 // TLS verification for the upstream services

--- a/cmd/contour/contour.go
+++ b/cmd/contour/contour.go
@@ -166,6 +166,7 @@ func main() {
 		wl := log.WithField("context", "watch")
 		k8s.WatchServices(&g, client, wl, &reh)
 		k8s.WatchIngress(&g, client, wl, &reh)
+		k8s.WatchConfigMaps(&g, client, wl, &reh)
 		k8s.WatchSecrets(&g, client, wl, &reh)
 		k8s.WatchIngressRoutes(&g, contourClient, wl, &reh)
 

--- a/deployment/common/common.yaml
+++ b/deployment/common/common.yaml
@@ -150,9 +150,18 @@ spec:
                         tlsVerification:
                           type: object
                           required:
-                            - configMapName
+                            - ca
                           properties:
-                            configMapName:
-                              type: string
-                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$ # DNS-1123 subdomain
+                            ca:
+                              type: object
+                              required:
+                                - configMapName
+                              properties:
+                                configMapName:
+                                  type: string
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$ # DNS-1123 subdomain
+                            hostnames:
+                              type: array
+                              items:
+                                type: string
 ---

--- a/deployment/common/common.yaml
+++ b/deployment/common/common.yaml
@@ -161,7 +161,5 @@ spec:
                                   type: string
                                   pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$ # DNS-1123 subdomain
                             hostnames:
-                              type: array
-                              items:
-                                type: string
+                              type: string
 ---

--- a/deployment/common/common.yaml
+++ b/deployment/common/common.yaml
@@ -147,4 +147,12 @@ spec:
                               type: integer
                             healthyThresholdCount:
                               type: integer
+                        tlsVerification:
+                          type: object
+                          required:
+                            - configMapName
+                          properties:
+                            configMapName:
+                              type: string
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$ # DNS-1123 subdomain
 ---

--- a/deployment/common/rbac.yaml
+++ b/deployment/common/rbac.yaml
@@ -19,7 +19,6 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - configmaps
   - endpoints
   - nodes
   - pods
@@ -36,6 +35,7 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - configmaps
   - services
   verbs:
   - get

--- a/deployment/render/daemonset-rbac.yaml
+++ b/deployment/render/daemonset-rbac.yaml
@@ -153,11 +153,20 @@ spec:
                         tlsVerification:
                           type: object
                           required:
-                            - configMapName
+                            - ca
                           properties:
-                            configMapName:
-                              type: string
-                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$ # DNS-1123 subdomain
+                            ca:
+                              type: object
+                              required:
+                                - configMapName
+                              properties:
+                                configMapName:
+                                  type: string
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$ # DNS-1123 subdomain
+                            hostnames:
+                              type: array
+                              items:
+                                type: string
 ---
 apiVersion: extensions/v1beta1
 kind: DaemonSet

--- a/deployment/render/daemonset-rbac.yaml
+++ b/deployment/render/daemonset-rbac.yaml
@@ -164,9 +164,7 @@ spec:
                                   type: string
                                   pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$ # DNS-1123 subdomain
                             hostnames:
-                              type: array
-                              items:
-                                type: string
+                              type: string
 ---
 apiVersion: extensions/v1beta1
 kind: DaemonSet

--- a/deployment/render/daemonset-rbac.yaml
+++ b/deployment/render/daemonset-rbac.yaml
@@ -150,6 +150,14 @@ spec:
                               type: integer
                             healthyThresholdCount:
                               type: integer
+                        tlsVerification:
+                          type: object
+                          required:
+                            - configMapName
+                          properties:
+                            configMapName:
+                              type: string
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$ # DNS-1123 subdomain
 ---
 apiVersion: extensions/v1beta1
 kind: DaemonSet
@@ -244,7 +252,6 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - configmaps
   - endpoints
   - nodes
   - pods
@@ -261,6 +268,7 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - configmaps
   - services
   verbs:
   - get

--- a/deployment/render/deployment-rbac.yaml
+++ b/deployment/render/deployment-rbac.yaml
@@ -153,11 +153,20 @@ spec:
                         tlsVerification:
                           type: object
                           required:
-                            - configMapName
+                            - ca
                           properties:
-                            configMapName:
-                              type: string
-                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$ # DNS-1123 subdomain
+                            ca:
+                              type: object
+                              required:
+                                - configMapName
+                              properties:
+                                configMapName:
+                                  type: string
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$ # DNS-1123 subdomain
+                            hostnames:
+                              type: array
+                              items:
+                                type: string
 ---
 apiVersion: extensions/v1beta1
 kind: Deployment

--- a/deployment/render/deployment-rbac.yaml
+++ b/deployment/render/deployment-rbac.yaml
@@ -164,9 +164,7 @@ spec:
                                   type: string
                                   pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$ # DNS-1123 subdomain
                             hostnames:
-                              type: array
-                              items:
-                                type: string
+                              type: string
 ---
 apiVersion: extensions/v1beta1
 kind: Deployment

--- a/deployment/render/deployment-rbac.yaml
+++ b/deployment/render/deployment-rbac.yaml
@@ -150,6 +150,14 @@ spec:
                               type: integer
                             healthyThresholdCount:
                               type: integer
+                        tlsVerification:
+                          type: object
+                          required:
+                            - configMapName
+                          properties:
+                            configMapName:
+                              type: string
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$ # DNS-1123 subdomain
 ---
 apiVersion: extensions/v1beta1
 kind: Deployment
@@ -261,7 +269,6 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - configmaps
   - endpoints
   - nodes
   - pods
@@ -278,6 +285,7 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - configmaps
   - services
   verbs:
   - get

--- a/internal/contour/cluster.go
+++ b/internal/contour/cluster.go
@@ -97,13 +97,7 @@ func visitClusters(root dag.Vertex) map[string]*v2.Cluster {
 
 func (v *clusterVisitor) visit(vertex dag.Vertex) {
 	switch service := vertex.(type) {
-	case *dag.HTTPService:
-		name := envoy.Clustername(&service.TCPService)
-		if _, ok := v.clusters[name]; !ok {
-			c := envoy.Cluster(service)
-			v.clusters[c.Name] = c
-		}
-	case *dag.TCPService:
+	case dag.Service:
 		name := envoy.Clustername(service)
 		if _, ok := v.clusters[name]; !ok {
 			c := envoy.Cluster(service)

--- a/internal/dag/annotations.go
+++ b/internal/dag/annotations.go
@@ -78,7 +78,7 @@ func parseAnnotation(annotations map[string]string, annotation string) int {
 	return int(v)
 }
 
-// parseAnnotationUint32 parsers the annotation map for the supplied annotation key.
+// parseAnnotationUint32 parses the annotation map for the supplied annotation key.
 // If the value is not present, or malformed, then nil is returned.
 func parseAnnotationUInt32(annotations map[string]string, annotation string) *types.UInt32Value {
 	v, err := strconv.ParseUint(annotations[annotation], 10, 32)

--- a/internal/dag/builder_test.go
+++ b/internal/dag/builder_test.go
@@ -2446,7 +2446,7 @@ func TestBuilderLookupHTTPService(t *testing.T) {
 					},
 				},
 			}
-			got := b.lookupHTTPService(tc.meta, tc.port, tc.weight, tc.strategy, tc.healthcheck)
+			got := b.lookupHTTPService(tc.meta, tc.port, tc.weight, tc.strategy, tc.healthcheck, nil, "")
 			if diff := cmp.Diff(tc.want, got); diff != "" {
 				t.Fatal(diff)
 			}

--- a/internal/dag/dag.go
+++ b/internal/dag/dag.go
@@ -236,6 +236,10 @@ type HTTPService struct {
 
 	// ConfigMap that holds the CA certificate used for TLS verification
 	CACertificate *ConfigMap
+
+	// If specified, at least one of the hostnames must be included in the
+	// certificate's Subject Alternative Names field
+	Hostnames []string
 }
 
 // ConfigMap represents a K8s ConfigMap as a DAG Vertex. A ConfigMap is

--- a/internal/dag/dag.go
+++ b/internal/dag/dag.go
@@ -233,6 +233,31 @@ type HTTPService struct {
 	// Protocol is the layer 7 protocol of this service
 	// One of "", "h2", or "h2c".
 	Protocol string
+
+	// ConfigMap that holds the CA certificate used for TLS verification
+	CACertificate *ConfigMap
+}
+
+// ConfigMap represents a K8s ConfigMap as a DAG Vertex. A ConfigMap is
+// a leaf in the DAG.
+type ConfigMap struct {
+	Object *v1.ConfigMap
+}
+
+func (c *ConfigMap) Name() string       { return c.Object.Name }
+func (c *ConfigMap) Namespace() string  { return c.Object.Namespace }
+func (c *ConfigMap) Visit(func(Vertex)) {}
+
+// Data returns the contents of the backing configmap.
+func (c *ConfigMap) Data() map[string]string {
+	return c.Object.Data
+}
+
+func (c *ConfigMap) toMeta() meta {
+	return meta{
+		name:      c.Name(),
+		namespace: c.Namespace(),
+	}
 }
 
 // Secret represents a K8s Secret for TLS usage as a DAG Vertex. A Secret is

--- a/internal/envoy/auth.go
+++ b/internal/envoy/auth.go
@@ -28,7 +28,7 @@ func UpstreamTLSContext() *auth.UpstreamTlsContext {
 }
 
 // UpstreamTLSContext creates an ALPN h2 enabled TLS Context with TLS verification enabled.
-func UpstreamTLSContextWithVerification(cert []byte) *auth.UpstreamTlsContext {
+func UpstreamTLSContextWithVerification(cert []byte, hostnames []string) *auth.UpstreamTlsContext {
 	return &auth.UpstreamTlsContext{
 		CommonTlsContext: &auth.CommonTlsContext{
 			ValidationContextType: &auth.CommonTlsContext_ValidationContext{
@@ -38,6 +38,7 @@ func UpstreamTLSContextWithVerification(cert []byte) *auth.UpstreamTlsContext {
 							InlineBytes: cert,
 						},
 					},
+					VerifySubjectAltName: hostnames,
 				},
 			},
 			AlpnProtocols: []string{"h2"},

--- a/internal/envoy/auth.go
+++ b/internal/envoy/auth.go
@@ -28,7 +28,14 @@ func UpstreamTLSContext() *auth.UpstreamTlsContext {
 }
 
 // UpstreamTLSContext creates an ALPN h2 enabled TLS Context with TLS verification enabled.
-func UpstreamTLSContextWithVerification(cert []byte, hostnames []string) *auth.UpstreamTlsContext {
+func UpstreamTLSContextWithVerification(cert []byte, hostname string) *auth.UpstreamTlsContext {
+	var hostnames []string
+	if hostname == "" {
+		hostnames = []string{}
+	} else {
+		hostnames = []string{hostname}
+	}
+
 	return &auth.UpstreamTlsContext{
 		CommonTlsContext: &auth.CommonTlsContext{
 			ValidationContextType: &auth.CommonTlsContext_ValidationContext{

--- a/internal/envoy/auth.go
+++ b/internal/envoy/auth.go
@@ -13,12 +13,33 @@
 
 package envoy
 
-import "github.com/envoyproxy/go-control-plane/envoy/api/v2/auth"
+import (
+	"github.com/envoyproxy/go-control-plane/envoy/api/v2/auth"
+	"github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
+)
 
 // UpstreamTLSContext creates an ALPN h2 enabled TLS Context.
 func UpstreamTLSContext() *auth.UpstreamTlsContext {
 	return &auth.UpstreamTlsContext{
 		CommonTlsContext: &auth.CommonTlsContext{
+			AlpnProtocols: []string{"h2"},
+		},
+	}
+}
+
+// UpstreamTLSContext creates an ALPN h2 enabled TLS Context with TLS verification enabled.
+func UpstreamTLSContextWithVerification(cert []byte) *auth.UpstreamTlsContext {
+	return &auth.UpstreamTlsContext{
+		CommonTlsContext: &auth.CommonTlsContext{
+			ValidationContextType: &auth.CommonTlsContext_ValidationContext{
+				ValidationContext: &auth.CertificateValidationContext{
+					TrustedCa: &core.DataSource{
+						Specifier: &core.DataSource_InlineBytes{
+							InlineBytes: cert,
+						},
+					},
+				},
+			},
 			AlpnProtocols: []string{"h2"},
 		},
 	}

--- a/internal/envoy/cluster.go
+++ b/internal/envoy/cluster.go
@@ -52,7 +52,7 @@ func httpCluster(service *dag.HTTPService) *v2.Cluster {
 			if cert := cm["ca.crt"]; cert == "" {
 				c.TlsContext = UpstreamTLSContext()
 			} else {
-				c.TlsContext = UpstreamTLSContextWithVerification([]byte(cert))
+				c.TlsContext = UpstreamTLSContextWithVerification([]byte(cert), service.Hostnames)
 			}
 		}
 		fallthrough

--- a/internal/envoy/cluster.go
+++ b/internal/envoy/cluster.go
@@ -45,7 +45,16 @@ func httpCluster(service *dag.HTTPService) *v2.Cluster {
 	c := cluster(&service.TCPService)
 	switch service.Protocol {
 	case "h2":
-		c.TlsContext = UpstreamTLSContext()
+		if service.CACertificate == nil {
+			c.TlsContext = UpstreamTLSContext()
+		} else {
+			cm := service.CACertificate.Data()
+			if cert := cm["ca.crt"]; cert == "" {
+				c.TlsContext = UpstreamTLSContext()
+			} else {
+				c.TlsContext = UpstreamTLSContextWithVerification([]byte(cert))
+			}
+		}
 		fallthrough
 	case "h2c":
 		c.Http2ProtocolOptions = &core.Http2ProtocolOptions{}

--- a/internal/envoy/cluster_test.go
+++ b/internal/envoy/cluster_test.go
@@ -242,7 +242,7 @@ func TestCluster(t *testing.T) {
 
 func TestClustername(t *testing.T) {
 	tests := map[string]struct {
-		service *dag.TCPService
+		service dag.Service
 		want    string
 	}{
 		"simple": {
@@ -291,6 +291,29 @@ func TestClustername(t *testing.T) {
 				},
 			},
 			want: "default/backend/80/32737eb011",
+		},
+		"various TLS verification params": {
+			service: &dag.HTTPService{
+				TCPService: dag.TCPService{
+					Name:      "backend",
+					Namespace: "default",
+					ServicePort: &v1.ServicePort{
+						Name:       "https",
+						Protocol:   "TCP",
+						Port:       443,
+						TargetPort: intstr.FromInt(8443),
+					},
+				},
+				CACertificate: &dag.ConfigMap{
+					Object: &v1.ConfigMap{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "ca",
+							Namespace: "default",
+						},
+					},
+				},
+			},
+			want: "default/backend/443/f717bfc27a",
 		},
 	}
 

--- a/internal/envoy/route.go
+++ b/internal/envoy/route.go
@@ -37,7 +37,7 @@ func RouteRoute(r *dag.Route, services []*dag.HTTPService) *route.Route_Route {
 	switch len(services) {
 	case 1:
 		ra.ClusterSpecifier = &route.RouteAction_Cluster{
-			Cluster: Clustername(&services[0].TCPService),
+			Cluster: Clustername(services[0]),
 		}
 		ra.RequestHeadersToAdd = headers(
 			appendHeader("x-request-start", "t=%START_TIME(%s.%3f)%"),
@@ -99,7 +99,7 @@ func weightedClusters(services []*dag.HTTPService) *route.WeightedCluster {
 	for _, service := range services {
 		total += service.Weight
 		wc.Clusters = append(wc.Clusters, &route.WeightedCluster_ClusterWeight{
-			Name:   Clustername(&service.TCPService),
+			Name:   Clustername(service),
 			Weight: u32(service.Weight),
 			RequestHeadersToAdd: headers(
 				appendHeader("x-request-start", "t=%START_TIME(%s.%3f)%"),

--- a/internal/k8s/watcher.go
+++ b/internal/k8s/watcher.go
@@ -45,6 +45,11 @@ func WatchIngress(g *workgroup.Group, client *kubernetes.Clientset, log logrus.F
 	watch(g, client.ExtensionsV1beta1().RESTClient(), log, "ingresses", new(v1beta1.Ingress), rs...)
 }
 
+// WatchConfigMaps creates a SharedInformer for v1.ConfigMaps and registers it with g.
+func WatchConfigMaps(g *workgroup.Group, client *kubernetes.Clientset, log logrus.FieldLogger, rs ...cache.ResourceEventHandler) {
+	watch(g, client.CoreV1().RESTClient(), log, "configmaps", new(v1.ConfigMap), rs...)
+}
+
 // WatchSecrets creates a SharedInformer for v1.Secrets and registers it with g.
 func WatchSecrets(g *workgroup.Group, client *kubernetes.Clientset, log logrus.FieldLogger, rs ...cache.ResourceEventHandler) {
 	watch(g, client.CoreV1().RESTClient(), log, "secrets", new(v1.Secret), rs...)


### PR DESCRIPTION
@davecheney It was good to meet you at the YOW! Conference. I briefly talked to you about implementing TLS verification for backend services; I finally got around to finishing off a sample implementation which verifies both the CA and hostname of the certificate.

This PR addresses issue #813. The implementation is similar to the design I suggested in that issue, however the ingress route schema has changed slightly to accommodate hostname verification. The question I had around the granularity of specifying the TLS verification settings (i.e. should it be one per ingress route, route or service?) is still my main concern and it would be good to get your thoughts. I'm happy to rework this PR based on any design concerns or code review comments.