### PR TITLE
internal/contour: filter out status update OnUpdate

### DIFF
--- a/cmd/contour/contour.go
+++ b/cmd/contour/contour.go
@@ -99,6 +99,7 @@ func main() {
 	metrics := metrics.NewMetrics(registry)
 
 	reh := contour.ResourceEventHandler{
+		FieldLogger: log.WithField("context", "resourceEventHandler"),
 		Notifier: &contour.HoldoffNotifier{
 			Notifier:    &ch,
 			FieldLogger: log.WithField("context", "HoldoffNotifier"),

--- a/internal/contour/cluster_test.go
+++ b/internal/contour/cluster_test.go
@@ -794,8 +794,9 @@ func TestClusterVisit(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			reh := ResourceEventHandler{
-				Notifier: new(nullNotifier),
-				Metrics:  metrics.NewMetrics(prometheus.NewRegistry()),
+				FieldLogger: testLogger(t),
+				Notifier:    new(nullNotifier),
+				Metrics:     metrics.NewMetrics(prometheus.NewRegistry()),
 			}
 			for _, o := range tc.objs {
 				reh.OnAdd(o)

--- a/internal/contour/listener_test.go
+++ b/internal/contour/listener_test.go
@@ -404,8 +404,9 @@ func TestListenerVisit(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			reh := ResourceEventHandler{
-				Notifier: new(nullNotifier),
-				Metrics:  metrics.NewMetrics(prometheus.NewRegistry()),
+				FieldLogger: testLogger(t),
+				Notifier:    new(nullNotifier),
+				Metrics:     metrics.NewMetrics(prometheus.NewRegistry()),
 			}
 			for _, o := range tc.objs {
 				reh.OnAdd(o)

--- a/internal/contour/route_test.go
+++ b/internal/contour/route_test.go
@@ -1694,8 +1694,9 @@ func TestRouteVisit(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			reh := ResourceEventHandler{
-				Notifier: new(nullNotifier),
-				Metrics:  metrics.NewMetrics(prometheus.NewRegistry()),
+				FieldLogger: testLogger(t),
+				Notifier:    new(nullNotifier),
+				Metrics:     metrics.NewMetrics(prometheus.NewRegistry()),
 			}
 			for _, o := range tc.objs {
 				reh.OnAdd(o)

--- a/internal/e2e/e2e.go
+++ b/internal/e2e/e2e.go
@@ -76,8 +76,9 @@ func setup(t *testing.T, opts ...func(*contour.ResourceEventHandler)) (cache.Res
 	}
 
 	reh := contour.ResourceEventHandler{
-		Notifier: ch,
-		Metrics:  ch.Metrics,
+		Notifier:    ch,
+		Metrics:     ch.Metrics,
+		FieldLogger: log,
 	}
 
 	for _, opt := range opts {

--- a/internal/grpc/server_test.go
+++ b/internal/grpc/server_test.go
@@ -212,8 +212,9 @@ func TestGRPC(t *testing.T) {
 				Metrics: metrics.NewMetrics(prometheus.NewRegistry()),
 			}
 			reh = &contour.ResourceEventHandler{
-				Notifier: &ch,
-				Metrics:  ch.Metrics,
+				Notifier:    &ch,
+				Metrics:     ch.Metrics,
+				FieldLogger: log,
 			}
 			srv := NewAPI(log, map[string]Cache{
 				clusterType:  &ch.ClusterCache,


### PR DESCRIPTION
Updates #854

Depending on the order in which parts of an ingressroute document are
processed the invalid status message generated may differ over runs.
Specifically two or more invalid components of an ingressroute will
patch status in a random order, defeating patch's "is this the same"
check and causing Contour to see the update to the ingressroute's
document, thus triggering a new OnUpdate event and the cycle starts
again.

For the interim filter out fields which are known to change -- status,
and metadata.resourceversion, during the OnUpdate comparision.

Signed-off-by: Dave Cheney <dave@cheney.net>