### PR TITLE
Allow VirtualHost port to be defined so that Envoy will serve traffic on

### DIFF
--- a/cmd/contour/contour.go
+++ b/cmd/contour/contour.go
@@ -22,6 +22,8 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/heptio/contour/internal/dag"
+
 	clientset "github.com/heptio/contour/apis/generated/clientset/versioned"
 	"github.com/heptio/contour/internal/contour"
 	"github.com/heptio/contour/internal/debug"
@@ -129,6 +131,8 @@ func main() {
 	serve.Flag("envoy-https-address", "Envoy HTTPS listener address").StringVar(&ch.HTTPSAddress)
 	serve.Flag("envoy-http-port", "Envoy HTTP listener port").IntVar(&ch.HTTPPort)
 	serve.Flag("envoy-https-port", "Envoy HTTPS listener port").IntVar(&ch.HTTPSPort)
+	serve.Flag("envoy-http-virtualhost-port", "Envoy HTTP virtual host listener port").IntVar(&ch.HTTPVHostPort)
+	serve.Flag("envoy-https-virtualhost-port", "Envoy HTTPS virtual host listener port").IntVar(&ch.HTTPSVHostPort)
 	serve.Flag("use-proxy-protocol", "Use PROXY protocol for all listeners").BoolVar(&ch.UseProxyProto)
 	serve.Flag("ingress-class-name", "Contour IngressClass name").StringVar(&reh.IngressClass)
 	serve.Flag("ingressroute-root-namespaces", "Restrict contour to searching these namespaces for root ingress routes").StringVar(&ingressrouteRootNamespaceFlag)
@@ -161,6 +165,10 @@ func main() {
 		flag.Parse()
 
 		reh.IngressRouteRootNamespaces = parseRootNamespaces(ingressrouteRootNamespaceFlag)
+		reh.VHostConfig = &dag.VHostConfig{
+			HTTPVHostPort:  ch.HTTPVHostPort,
+			HTTPSVHostPort: ch.HTTPSVHostPort,
+		}
 
 		client, contourClient := newClient(*kubeconfig, *inCluster)
 

--- a/internal/contour/cachehandler.go
+++ b/internal/contour/cachehandler.go
@@ -27,6 +27,7 @@ import (
 // CacheHandler manages the state of xDS caches.
 type CacheHandler struct {
 	ListenerVisitorConfig
+	RouteVisitorConfig
 	ListenerCache
 	RouteCache
 	ClusterCache
@@ -66,7 +67,7 @@ func (ch *CacheHandler) updateListeners(root dag.Visitable) {
 }
 
 func (ch *CacheHandler) updateRoutes(root dag.Visitable) {
-	routes := visitRoutes(root)
+	routes := visitRoutes(root, &ch.RouteVisitorConfig)
 	ch.RouteCache.Update(routes)
 }
 

--- a/internal/contour/cachehandler_test.go
+++ b/internal/contour/cachehandler_test.go
@@ -524,6 +524,7 @@ func TestIngressRouteMetrics(t *testing.T) {
 			b := dag.Builder{
 				KubernetesCache: dag.KubernetesCache{
 					IngressRouteRootNamespaces: tc.rootNamespaces,
+					VHostConfig:                &dag.VHostConfig{HTTPVHostPort: 80, HTTPSVHostPort: 443},
 				},
 			}
 			for _, o := range tc.objs {

--- a/internal/contour/cluster_test.go
+++ b/internal/contour/cluster_test.go
@@ -17,15 +17,16 @@ import (
 	"testing"
 	"time"
 
-	"github.com/envoyproxy/go-control-plane/envoy/api/v2"
+	v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2/cluster"
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 	"github.com/google/go-cmp/cmp"
 	ingressroutev1 "github.com/heptio/contour/apis/contour/v1beta1"
+	"github.com/heptio/contour/internal/dag"
 	"github.com/heptio/contour/internal/envoy"
 	"github.com/heptio/contour/internal/metrics"
 	"github.com/prometheus/client_golang/prometheus"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/api/extensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -797,6 +798,10 @@ func TestClusterVisit(t *testing.T) {
 				FieldLogger: testLogger(t),
 				Notifier:    new(nullNotifier),
 				Metrics:     metrics.NewMetrics(prometheus.NewRegistry()),
+			}
+			reh.VHostConfig = &dag.VHostConfig{
+				HTTPVHostPort:  80,
+				HTTPSVHostPort: 443,
 			}
 			for _, o := range tc.objs {
 				reh.OnAdd(o)

--- a/internal/contour/listener.go
+++ b/internal/contour/listener.go
@@ -16,12 +16,12 @@ package contour
 import (
 	"sync"
 
-	"github.com/envoyproxy/go-control-plane/envoy/api/v2"
+	v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2/listener"
 	"github.com/gogo/protobuf/proto"
 	"github.com/heptio/contour/internal/dag"
 	"github.com/heptio/contour/internal/envoy"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 )
 
 const (

--- a/internal/contour/listener_test.go
+++ b/internal/contour/listener_test.go
@@ -17,14 +17,15 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/envoyproxy/go-control-plane/envoy/api/v2"
+	v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2/auth"
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2/listener"
 	ingressroutev1 "github.com/heptio/contour/apis/contour/v1beta1"
+	"github.com/heptio/contour/internal/dag"
 	"github.com/heptio/contour/internal/envoy"
 	"github.com/heptio/contour/internal/metrics"
 	"github.com/prometheus/client_golang/prometheus"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/api/extensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -407,6 +408,10 @@ func TestListenerVisit(t *testing.T) {
 				FieldLogger: testLogger(t),
 				Notifier:    new(nullNotifier),
 				Metrics:     metrics.NewMetrics(prometheus.NewRegistry()),
+			}
+			reh.VHostConfig = &dag.VHostConfig{
+				HTTPVHostPort:  80,
+				HTTPSVHostPort: 443,
 			}
 			for _, o := range tc.objs {
 				reh.OnAdd(o)

--- a/internal/contour/route_test.go
+++ b/internal/contour/route_test.go
@@ -17,15 +17,16 @@ import (
 	"testing"
 	"time"
 
-	"github.com/envoyproxy/go-control-plane/envoy/api/v2"
+	v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
 	"github.com/google/go-cmp/cmp"
 	ingressroutev1 "github.com/heptio/contour/apis/contour/v1beta1"
+	"github.com/heptio/contour/internal/dag"
 	"github.com/heptio/contour/internal/envoy"
 	"github.com/heptio/contour/internal/metrics"
 	"github.com/prometheus/client_golang/prometheus"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/api/extensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -1702,11 +1703,15 @@ func TestRouteVisit(t *testing.T) {
 				Notifier:    new(nullNotifier),
 				Metrics:     metrics.NewMetrics(prometheus.NewRegistry()),
 			}
+			reh.VHostConfig = &dag.VHostConfig{
+				HTTPVHostPort:  80,
+				HTTPSVHostPort: 443,
+			}
 			for _, o := range tc.objs {
 				reh.OnAdd(o)
 			}
 			root := reh.Build()
-			got := visitRoutes(root)
+			got := visitRoutes(root, &RouteVisitorConfig{})
 			if diff := cmp.Diff(tc.want, got); diff != "" {
 				t.Fatal(diff)
 			}

--- a/internal/dag/builder_test.go
+++ b/internal/dag/builder_test.go
@@ -2448,6 +2448,14 @@ func TestDAGInsert(t *testing.T) {
 			for _, o := range tc.objs {
 				b.Insert(o)
 			}
+			b.KubernetesCache.VHostConfig = &VHostConfig{
+				HTTPVHostPort:  80,
+				HTTPSVHostPort: 443,
+			}
+			b.KubernetesCache.VHostConfig = &VHostConfig{
+				HTTPVHostPort:  80,
+				HTTPSVHostPort: 443,
+			}
 			dag := b.Build()
 
 			got := make(map[hostport]Vertex)
@@ -2614,6 +2622,11 @@ func TestDAGIngressRouteCycle(t *testing.T) {
 	var b Builder
 	b.Insert(ir2)
 	b.Insert(ir1)
+
+	b.KubernetesCache.VHostConfig = &VHostConfig{
+		HTTPVHostPort:  80,
+		HTTPSVHostPort: 443,
+	}
 	dag := b.Build()
 
 	got := make(map[hostport]*VirtualHost)
@@ -2660,6 +2673,10 @@ func TestDAGIngressRouteCycleSelfEdge(t *testing.T) {
 
 	var b Builder
 	b.Insert(ir1)
+	b.KubernetesCache.VHostConfig = &VHostConfig{
+		HTTPVHostPort:  80,
+		HTTPSVHostPort: 443,
+	}
 	dag := b.Build()
 
 	got := make(map[hostport]*VirtualHost)
@@ -2701,6 +2718,10 @@ func TestDAGIngressRouteDelegatesToNonExistent(t *testing.T) {
 
 	var b Builder
 	b.Insert(ir1)
+	b.KubernetesCache.VHostConfig = &VHostConfig{
+		HTTPVHostPort:  80,
+		HTTPSVHostPort: 443,
+	}
 	dag := b.Build()
 
 	got := make(map[hostport]*VirtualHost)
@@ -2757,6 +2778,10 @@ func TestDAGIngressRouteDelegatePrefixDoesntMatch(t *testing.T) {
 	var b Builder
 	b.Insert(ir2)
 	b.Insert(ir1)
+	b.KubernetesCache.VHostConfig = &VHostConfig{
+		HTTPVHostPort:  80,
+		HTTPSVHostPort: 443,
+	}
 	dag := b.Build()
 
 	got := make(map[hostport]*VirtualHost)
@@ -2869,6 +2894,10 @@ func TestDAGRootNamespaces(t *testing.T) {
 			for _, o := range tc.objs {
 				b.Insert(o)
 			}
+			b.KubernetesCache.VHostConfig = &VHostConfig{
+				HTTPVHostPort:  80,
+				HTTPSVHostPort: 443,
+			}
 			dag := b.Build()
 
 			var count int
@@ -2927,6 +2956,10 @@ func TestDAGIngressRouteDelegatePrefixMatchesStringPrefixButNotPathPrefix(t *tes
 	var b Builder
 	b.Insert(ir2)
 	b.Insert(ir1)
+	b.KubernetesCache.VHostConfig = &VHostConfig{
+		HTTPVHostPort:  80,
+		HTTPSVHostPort: 443,
+	}
 	dag := b.Build()
 
 	got := make(map[hostport]*VirtualHost)
@@ -3388,6 +3421,10 @@ func TestDAGIngressRouteStatus(t *testing.T) {
 					IngressRouteRootNamespaces: []string{"roots"},
 				},
 			}
+			b.KubernetesCache.VHostConfig = &VHostConfig{
+				HTTPVHostPort:  80,
+				HTTPSVHostPort: 443,
+			}
 			for _, o := range tc.objs {
 				b.Insert(o)
 			}
@@ -3506,6 +3543,10 @@ func TestDAGIngressRouteUniqueFQDNs(t *testing.T) {
 			var b Builder
 			for _, o := range tc.objs {
 				b.Insert(o)
+			}
+			b.KubernetesCache.VHostConfig = &VHostConfig{
+				HTTPVHostPort:  80,
+				HTTPSVHostPort: 443,
 			}
 			dag := b.Build()
 

--- a/internal/e2e/e2e.go
+++ b/internal/e2e/e2e.go
@@ -18,19 +18,20 @@ import (
 	"net"
 	"testing"
 
-	"github.com/envoyproxy/go-control-plane/envoy/api/v2"
+	v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	accesslog "github.com/envoyproxy/go-control-plane/envoy/config/accesslog/v2"
 	"github.com/gogo/protobuf/proto"
 	"github.com/gogo/protobuf/types"
 	"github.com/heptio/contour/apis/generated/clientset/versioned/fake"
 	"github.com/heptio/contour/internal/contour"
+	"github.com/heptio/contour/internal/dag"
 	cgrpc "github.com/heptio/contour/internal/grpc"
 	"github.com/heptio/contour/internal/k8s"
 	"github.com/heptio/contour/internal/metrics"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
 	"google.golang.org/grpc"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/tools/cache"
 )
 
@@ -79,6 +80,10 @@ func setup(t *testing.T, opts ...func(*contour.ResourceEventHandler)) (cache.Res
 		Notifier:    ch,
 		Metrics:     ch.Metrics,
 		FieldLogger: log,
+	}
+	reh.VHostConfig = &dag.VHostConfig{
+		HTTPVHostPort:  80,
+		HTTPSVHostPort: 443,
 	}
 
 	for _, opt := range opts {

--- a/internal/grpc/server_test.go
+++ b/internal/grpc/server_test.go
@@ -20,15 +20,16 @@ import (
 	"testing"
 	"time"
 
-	"github.com/envoyproxy/go-control-plane/envoy/api/v2"
+	v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	"github.com/heptio/contour/internal/contour"
+	"github.com/heptio/contour/internal/dag"
 	"github.com/heptio/contour/internal/metrics"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/api/extensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -216,6 +217,11 @@ func TestGRPC(t *testing.T) {
 				Metrics:     ch.Metrics,
 				FieldLogger: log,
 			}
+			reh.VHostConfig = &dag.VHostConfig{
+				HTTPVHostPort:  80,
+				HTTPSVHostPort: 443,
+			}
+
 			srv := NewAPI(log, map[string]Cache{
 				clusterType:  &ch.ClusterCache,
 				routeType:    &ch.RouteCache,


### PR DESCRIPTION
Fixes #661 by allowing the ports which Vhosts are configured to be dynamic. Previously, they were hardcoded to 80/443. 

@davecheney the VHost struct I added to the dag package seems out of place, not sure if you have any thoughts on how to pass that into the builder.go cleaner. What I have works, just smells funny to me. Open for additional thoughts about it. 

Signed-off-by: Steve Sloka <slokas@vmware.com>