### PR TITLE
Gopkg.toml: upgrade go-control-plane to v0.6.4

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -45,7 +45,7 @@
   version = "v1.1.1"
 
 [[projects]]
-  digest = "1:1eefd93232eb6f9b73c3d652ceb540bdc7a6c5326837687377fc0b2b3b18de0d"
+  digest = "1:8af062a766b7eeba568da0eae56173c77e75fae7325be2d1862665f6a7d8593c"
   name = "github.com/envoyproxy/go-control-plane"
   packages = [
     "envoy/api/v2",
@@ -63,8 +63,8 @@
     "pkg/util",
   ]
   pruneopts = ""
-  revision = "51b27c23cab9d18a020bf06acb0ddd00d23a2d77"
-  version = "v0.6.1"
+  revision = "aab037a7e4ed4ccb603cdae3dc08db5fdfaff119"
+  version = "v0.6.4"
 
 [[projects]]
   digest = "1:4216202f4088a73e2982df875e2f0d1401137bbc248e57391e70547af167a18a"
@@ -144,6 +144,7 @@
   name = "github.com/google/go-cmp"
   packages = [
     "cmp",
+    "cmp/cmpopts",
     "cmp/internal/diff",
     "cmp/internal/function",
     "cmp/internal/value",
@@ -754,6 +755,7 @@
     "github.com/gogo/protobuf/proto",
     "github.com/gogo/protobuf/types",
     "github.com/google/go-cmp/cmp",
+    "github.com/google/go-cmp/cmp/cmpopts",
     "github.com/heptio/workgroup",
     "github.com/prometheus/client_golang/prometheus",
     "github.com/prometheus/client_golang/prometheus/promhttp",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -24,5 +24,4 @@ required = [
 
 [[constraint]]
   name = "github.com/envoyproxy/go-control-plane"
-  # 0.6.1 matches Envoy v1.8.0, higher versions are for 1.9-dev
-  version = "=0.6.1"
+  version = "=0.6.4"

--- a/internal/contour/route_test.go
+++ b/internal/contour/route_test.go
@@ -331,7 +331,9 @@ func TestRouteVisit(t *testing.T) {
 							Match: envoy.PrefixMatch("/"),
 							Action: &route.Route_Redirect{
 								Redirect: &route.RedirectAction{
-									HttpsRedirect: true,
+									SchemeRewriteSpecifier: &route.RedirectAction_HttpsRedirect{
+										HttpsRedirect: true,
+									},
 								},
 							},
 						}},
@@ -481,7 +483,9 @@ func TestRouteVisit(t *testing.T) {
 							Match: envoy.PrefixMatch("/"),
 							Action: &route.Route_Redirect{
 								Redirect: &route.RedirectAction{
-									HttpsRedirect: true,
+									SchemeRewriteSpecifier: &route.RedirectAction_HttpsRedirect{
+										HttpsRedirect: true,
+									},
 								},
 							},
 						}},
@@ -1724,7 +1728,11 @@ func routecluster(cluster string) *route.Route_Route {
 
 func websocketroute(c string) *route.Route_Route {
 	r := routecluster(c)
-	r.Route.UseWebsocket = bv(true)
+	r.Route.UpgradeConfigs = append(r.Route.UpgradeConfigs,
+		&route.RouteAction_UpgradeConfig{
+			UpgradeType: "websocket",
+		},
+	)
 	return r
 }
 

--- a/internal/e2e/lds_test.go
+++ b/internal/e2e/lds_test.go
@@ -1146,16 +1146,20 @@ func filterchaintls(domain string, filter listener.Filter, alpn ...string) []lis
 func tcpproxy(statPrefix, cluster string) listener.Filter {
 	return listener.Filter{
 		Name: util.TCPProxy,
-		Config: messageToStruct(&envoy_config_v2_tcpproxy.TcpProxy{
-			StatPrefix: statPrefix,
-			ClusterSpecifier: &envoy_config_v2_tcpproxy.TcpProxy_Cluster{
-				Cluster: cluster,
-			},
-			AccessLog: []*accesslog.AccessLog{{
-				Name:   "envoy.file_access_log",
-				Config: messageToStruct(fileAccessLog("/dev/stdout")),
-			}},
-		}),
+		ConfigType: &listener.Filter_Config{
+			Config: messageToStruct(&envoy_config_v2_tcpproxy.TcpProxy{
+				StatPrefix: statPrefix,
+				ClusterSpecifier: &envoy_config_v2_tcpproxy.TcpProxy_Cluster{
+					Cluster: cluster,
+				},
+				AccessLog: []*accesslog.AccessLog{{
+					Name: "envoy.file_access_log",
+					ConfigType: &accesslog.AccessLog_Config{
+						Config: messageToStruct(fileAccessLog("/dev/stdout")),
+					},
+				}},
+			}),
+		},
 	}
 }
 

--- a/internal/e2e/rds_test.go
+++ b/internal/e2e/rds_test.go
@@ -2335,7 +2335,11 @@ func weightedclusters(clusters []weightedcluster) *route.WeightedCluster {
 
 func websocketroute(c string) *route.Route_Route {
 	cl := routecluster(c)
-	cl.Route.UseWebsocket = bv(true)
+	cl.Route.UpgradeConfigs = append(cl.Route.UpgradeConfigs,
+		&route.RouteAction_UpgradeConfig{
+			UpgradeType: "websocket",
+		},
+	)
 	return cl
 }
 

--- a/internal/envoy/listener.go
+++ b/internal/envoy/listener.go
@@ -27,8 +27,10 @@ import (
 // TLSInspector returns a new TLS inspector listener filter.
 func TLSInspector() listener.ListenerFilter {
 	return listener.ListenerFilter{
-		Name:   util.TlsInspector,
-		Config: new(types.Struct),
+		Name: util.TlsInspector,
+		ConfigType: &listener.ListenerFilter_Config{
+			Config: new(types.Struct),
+		},
 	}
 }
 
@@ -37,40 +39,42 @@ func TLSInspector() listener.ListenerFilter {
 func HTTPConnectionManager(routename, accessLogPath string) listener.Filter {
 	return listener.Filter{
 		Name: util.HTTPConnectionManager,
-		Config: &types.Struct{
-			Fields: map[string]*types.Value{
-				"stat_prefix": sv(routename),
-				"rds": st(map[string]*types.Value{
-					"route_config_name": sv(routename),
-					"config_source": st(map[string]*types.Value{
-						"api_config_source": st(map[string]*types.Value{
-							"api_type": sv("GRPC"),
-							"grpc_services": lv(
-								st(map[string]*types.Value{
-									"envoy_grpc": st(map[string]*types.Value{
-										"cluster_name": sv("contour"),
+		ConfigType: &listener.Filter_Config{
+			Config: &types.Struct{
+				Fields: map[string]*types.Value{
+					"stat_prefix": sv(routename),
+					"rds": st(map[string]*types.Value{
+						"route_config_name": sv(routename),
+						"config_source": st(map[string]*types.Value{
+							"api_config_source": st(map[string]*types.Value{
+								"api_type": sv("GRPC"),
+								"grpc_services": lv(
+									st(map[string]*types.Value{
+										"envoy_grpc": st(map[string]*types.Value{
+											"cluster_name": sv("contour"),
+										}),
 									}),
-								}),
-							),
+								),
+							}),
 						}),
 					}),
-				}),
-				"http_filters": lv(
-					st(map[string]*types.Value{
-						"name": sv(util.Gzip),
+					"http_filters": lv(
+						st(map[string]*types.Value{
+							"name": sv(util.Gzip),
+						}),
+						st(map[string]*types.Value{
+							"name": sv(util.GRPCWeb),
+						}),
+						st(map[string]*types.Value{
+							"name": sv(util.Router),
+						}),
+					),
+					"http_protocol_options": st(map[string]*types.Value{
+						"accept_http_10": {Kind: &types.Value_BoolValue{BoolValue: true}},
 					}),
-					st(map[string]*types.Value{
-						"name": sv(util.GRPCWeb),
-					}),
-					st(map[string]*types.Value{
-						"name": sv(util.Router),
-					}),
-				),
-				"http_protocol_options": st(map[string]*types.Value{
-					"accept_http_10": {Kind: &types.Value_BoolValue{BoolValue: true}},
-				}),
-				"access_log":         accesslog(accessLogPath),
-				"use_remote_address": {Kind: &types.Value_BoolValue{BoolValue: true}}, // TODO(jbeda) should this ever be false?
+					"access_log":         accesslog(accessLogPath),
+					"use_remote_address": {Kind: &types.Value_BoolValue{BoolValue: true}}, // TODO(jbeda) should this ever be false?
+				},
 			},
 		},
 	}
@@ -82,11 +86,13 @@ func TCPProxy(statPrefix string, proxy *dag.TCPProxy, accessLogPath string) list
 	case 1:
 		return listener.Filter{
 			Name: util.TCPProxy,
-			Config: &types.Struct{
-				Fields: map[string]*types.Value{
-					"stat_prefix": sv(statPrefix),
-					"cluster":     sv(Clustername(proxy.Services[0])),
-					"access_log":  accesslog(accessLogPath),
+			ConfigType: &listener.Filter_Config{
+				Config: &types.Struct{
+					Fields: map[string]*types.Value{
+						"stat_prefix": sv(statPrefix),
+						"cluster":     sv(Clustername(proxy.Services[0])),
+						"access_log":  accesslog(accessLogPath),
+					},
 				},
 			},
 		}
@@ -109,13 +115,15 @@ func TCPProxy(statPrefix string, proxy *dag.TCPProxy, accessLogPath string) list
 		}
 		return listener.Filter{
 			Name: util.TCPProxy,
-			Config: &types.Struct{
-				Fields: map[string]*types.Value{
-					"stat_prefix": sv(statPrefix),
-					"weighted_clusters": st(map[string]*types.Value{
-						"clusters": lv(l...),
-					}),
-					"access_log": accesslog(accessLogPath),
+			ConfigType: &listener.Filter_Config{
+				Config: &types.Struct{
+					Fields: map[string]*types.Value{
+						"stat_prefix": sv(statPrefix),
+						"weighted_clusters": st(map[string]*types.Value{
+							"clusters": lv(l...),
+						}),
+						"access_log": accesslog(accessLogPath),
+					},
 				},
 			},
 		}

--- a/internal/envoy/listener_test.go
+++ b/internal/envoy/listener_test.go
@@ -126,16 +126,20 @@ func TestTCPProxy(t *testing.T) {
 			},
 			want: listener.Filter{
 				Name: util.TCPProxy,
-				Config: messageToStruct(&envoy_config_v2_tcpproxy.TcpProxy{
-					StatPrefix: statPrefix,
-					ClusterSpecifier: &envoy_config_v2_tcpproxy.TcpProxy_Cluster{
-						Cluster: Clustername(s1),
-					},
-					AccessLog: []*envoy_accesslog.AccessLog{{
-						Name:   util.FileAccessLog,
-						Config: messageToStruct(fileAccessLog(accessLogPath)),
-					}},
-				}),
+				ConfigType: &listener.Filter_Config{
+					Config: messageToStruct(&envoy_config_v2_tcpproxy.TcpProxy{
+						StatPrefix: statPrefix,
+						ClusterSpecifier: &envoy_config_v2_tcpproxy.TcpProxy_Cluster{
+							Cluster: Clustername(s1),
+						},
+						AccessLog: []*envoy_accesslog.AccessLog{{
+							Name: util.FileAccessLog,
+							ConfigType: &envoy_accesslog.AccessLog_Config{
+								Config: messageToStruct(fileAccessLog(accessLogPath)),
+							},
+						}},
+					}),
+				},
 			},
 		},
 		"multiple cluster": {
@@ -146,24 +150,28 @@ func TestTCPProxy(t *testing.T) {
 			},
 			want: listener.Filter{
 				Name: util.TCPProxy,
-				Config: messageToStruct(&envoy_config_v2_tcpproxy.TcpProxy{
-					StatPrefix: statPrefix,
-					ClusterSpecifier: &envoy_config_v2_tcpproxy.TcpProxy_WeightedClusters{
-						WeightedClusters: &envoy_config_v2_tcpproxy.TcpProxy_WeightedCluster{
-							Clusters: []*envoy_config_v2_tcpproxy.TcpProxy_WeightedCluster_ClusterWeight{{
-								Name:   Clustername(s1),
-								Weight: 1,
-							}, {
-								Name:   Clustername(s2),
-								Weight: 20,
-							}},
+				ConfigType: &listener.Filter_Config{
+					Config: messageToStruct(&envoy_config_v2_tcpproxy.TcpProxy{
+						StatPrefix: statPrefix,
+						ClusterSpecifier: &envoy_config_v2_tcpproxy.TcpProxy_WeightedClusters{
+							WeightedClusters: &envoy_config_v2_tcpproxy.TcpProxy_WeightedCluster{
+								Clusters: []*envoy_config_v2_tcpproxy.TcpProxy_WeightedCluster_ClusterWeight{{
+									Name:   Clustername(s1),
+									Weight: 1,
+								}, {
+									Name:   Clustername(s2),
+									Weight: 20,
+								}},
+							},
 						},
-					},
-					AccessLog: []*envoy_accesslog.AccessLog{{
-						Name:   util.FileAccessLog,
-						Config: messageToStruct(fileAccessLog(accessLogPath)),
-					}},
-				}),
+						AccessLog: []*envoy_accesslog.AccessLog{{
+							Name: util.FileAccessLog,
+							ConfigType: &envoy_accesslog.AccessLog_Config{
+								Config: messageToStruct(fileAccessLog(accessLogPath)),
+							},
+						}},
+					}),
+				},
 			},
 		},
 	}

--- a/internal/envoy/route.go
+++ b/internal/envoy/route.go
@@ -28,10 +28,17 @@ import (
 // weighted cluster.
 func RouteRoute(r *dag.Route, services []*dag.HTTPService) *route.Route_Route {
 	ra := route.RouteAction{
-		UseWebsocket:  bv(r.Websocket),
 		RetryPolicy:   retryPolicy(r),
 		Timeout:       timeout(r),
 		PrefixRewrite: r.PrefixRewrite,
+	}
+
+	if r.Websocket {
+		ra.UpgradeConfigs = append(ra.UpgradeConfigs,
+			&route.RouteAction_UpgradeConfig{
+				UpgradeType: "websocket",
+			},
+		)
 	}
 
 	switch len(services) {
@@ -87,7 +94,9 @@ func retryPolicy(r *dag.Route) *route.RouteAction_RetryPolicy {
 func UpgradeHTTPS() *route.Route_Redirect {
 	return &route.Route_Redirect{
 		Redirect: &route.RedirectAction{
-			HttpsRedirect: true,
+			SchemeRewriteSpecifier: &route.RedirectAction_HttpsRedirect{
+				HttpsRedirect: true,
+			},
 		},
 	}
 }

--- a/internal/envoy/route_test.go
+++ b/internal/envoy/route_test.go
@@ -18,7 +18,6 @@ import (
 	"time"
 
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
-	"github.com/gogo/protobuf/types"
 	"github.com/google/go-cmp/cmp"
 	"github.com/heptio/contour/internal/dag"
 	"k8s.io/api/core/v1"
@@ -79,7 +78,9 @@ func TestRouteRoute(t *testing.T) {
 					RequestHeadersToAdd: headers(
 						appendHeader("x-request-start", "t=%START_TIME(%s.%3f)%"),
 					),
-					UseWebsocket: &types.BoolValue{Value: true},
+					UpgradeConfigs: []*route.RouteAction_UpgradeConfig{{
+						UpgradeType: "websocket",
+					}},
 				},
 			},
 		},
@@ -150,7 +151,9 @@ func TestRouteRoute(t *testing.T) {
 							TotalWeight: u32(90),
 						},
 					},
-					UseWebsocket: &types.BoolValue{Value: true},
+					UpgradeConfigs: []*route.RouteAction_UpgradeConfig{{
+						UpgradeType: "websocket",
+					}},
 				},
 			},
 		},
@@ -426,7 +429,9 @@ func TestUpgradeHTTPS(t *testing.T) {
 	got := UpgradeHTTPS()
 	want := &route.Route_Redirect{
 		Redirect: &route.RedirectAction{
-			HttpsRedirect: true,
+			SchemeRewriteSpecifier: &route.RedirectAction_HttpsRedirect{
+				HttpsRedirect: true,
+			},
 		},
 	}
 


### PR DESCRIPTION
Upgrade to go-control-plane 0.6.4. Note versions 0.6.2 and 0.6.3 lack
the route_action.upgrade_configs definition which makes it impossible to
retain support for websocket upgrades. 0.6.4 is the least recent version
that can support websocket upgrades per route.

Signed-off-by: Dave Cheney <dave@cheney.net>