### PR TITLE
Gopkg.toml: update to latest go-control-plane

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -45,7 +45,7 @@
   version = "v1.1.1"
 
 [[projects]]
-  digest = "1:8af062a766b7eeba568da0eae56173c77e75fae7325be2d1862665f6a7d8593c"
+  digest = "1:2042b0f0950a2b628ebb914c43fb56d151bf53a72594e7d4f09d9dd5272aec3e"
   name = "github.com/envoyproxy/go-control-plane"
   packages = [
     "envoy/api/v2",
@@ -63,8 +63,8 @@
     "pkg/util",
   ]
   pruneopts = ""
-  revision = "aab037a7e4ed4ccb603cdae3dc08db5fdfaff119"
-  version = "v0.6.4"
+  revision = "eb553e72ac8724721a99ed85fcb116467c7a2bac"
+  version = "v0.6.7"
 
 [[projects]]
   digest = "1:4216202f4088a73e2982df875e2f0d1401137bbc248e57391e70547af167a18a"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -24,4 +24,4 @@ required = [
 
 [[constraint]]
   name = "github.com/envoyproxy/go-control-plane"
-  version = "=0.6.4"
+  version = "=0.6.7"

--- a/internal/contour/route_test.go
+++ b/internal/contour/route_test.go
@@ -1744,7 +1744,7 @@ func routetimeout(cluster string, timeout *time.Duration) *route.Route_Route {
 
 func routeretry(cluster string, retryOn string, numRetries int, perTryTimeout time.Duration) *route.Route_Route {
 	r := routecluster(cluster)
-	r.Route.RetryPolicy = &route.RouteAction_RetryPolicy{
+	r.Route.RetryPolicy = &route.RetryPolicy{
 		RetryOn: retryOn,
 	}
 	if numRetries > 0 {

--- a/internal/e2e/rds_test.go
+++ b/internal/e2e/rds_test.go
@@ -2369,7 +2369,7 @@ func service(ns, name string, ports ...v1.ServicePort) *v1.Service {
 
 func routeretry(cluster string, retryOn string, numRetries int, perTryTimeout time.Duration) *route.Route_Route {
 	r := routecluster(cluster)
-	r.Route.RetryPolicy = &route.RouteAction_RetryPolicy{
+	r.Route.RetryPolicy = &route.RetryPolicy{
 		RetryOn: retryOn,
 	}
 	if numRetries > 0 {

--- a/internal/envoy/endpoint.go
+++ b/internal/envoy/endpoint.go
@@ -21,14 +21,16 @@ import (
 // LBEndpoint creates a new SocketAddress LbEndpoint..
 func LBEndpoint(addr string, port int) endpoint.LbEndpoint {
 	return endpoint.LbEndpoint{
-		Endpoint: &endpoint.Endpoint{
-			Address: &core.Address{
-				Address: &core.Address_SocketAddress{
-					SocketAddress: &core.SocketAddress{
-						Protocol: core.TCP,
-						Address:  addr,
-						PortSpecifier: &core.SocketAddress_PortValue{
-							PortValue: uint32(port),
+		HostIdentifier: &endpoint.LbEndpoint_Endpoint{
+			Endpoint: &endpoint.Endpoint{
+				Address: &core.Address{
+					Address: &core.Address_SocketAddress{
+						SocketAddress: &core.SocketAddress{
+							Protocol: core.TCP,
+							Address:  addr,
+							PortSpecifier: &core.SocketAddress_PortValue{
+								PortValue: uint32(port),
+							},
 						},
 					},
 				},

--- a/internal/envoy/endpoint_test.go
+++ b/internal/envoy/endpoint_test.go
@@ -29,14 +29,16 @@ func TestLBEndpoint(t *testing.T) {
 
 	got := LBEndpoint(addr, port)
 	want := endpoint.LbEndpoint{
-		Endpoint: &endpoint.Endpoint{
-			Address: &core.Address{
-				Address: &core.Address_SocketAddress{
-					SocketAddress: &core.SocketAddress{
-						Protocol: core.TCP,
-						Address:  addr,
-						PortSpecifier: &core.SocketAddress_PortValue{
-							PortValue: port,
+		HostIdentifier: &endpoint.LbEndpoint_Endpoint{
+			Endpoint: &endpoint.Endpoint{
+				Address: &core.Address{
+					Address: &core.Address_SocketAddress{
+						SocketAddress: &core.SocketAddress{
+							Protocol: core.TCP,
+							Address:  addr,
+							PortSpecifier: &core.SocketAddress_PortValue{
+								PortValue: port,
+							},
 						},
 					},
 				},

--- a/internal/envoy/route.go
+++ b/internal/envoy/route.go
@@ -73,11 +73,11 @@ func timeout(r *dag.Route) *time.Duration {
 	}
 }
 
-func retryPolicy(r *dag.Route) *route.RouteAction_RetryPolicy {
+func retryPolicy(r *dag.Route) *route.RetryPolicy {
 	if r.RetryOn == "" {
 		return nil
 	}
-	rp := &route.RouteAction_RetryPolicy{
+	rp := &route.RetryPolicy{
 		RetryOn: r.RetryOn,
 	}
 	if r.NumRetries > 0 {

--- a/internal/envoy/route_test.go
+++ b/internal/envoy/route_test.go
@@ -192,7 +192,7 @@ func TestRouteRoute(t *testing.T) {
 					RequestHeadersToAdd: headers(
 						appendHeader("x-request-start", "t=%START_TIME(%s.%3f)%"),
 					),
-					RetryPolicy: &route.RouteAction_RetryPolicy{
+					RetryPolicy: &route.RetryPolicy{
 						RetryOn:       "503",
 						NumRetries:    u32(6),
 						PerTryTimeout: duration(100 * time.Millisecond),


### PR DESCRIPTION
Update to go-control-plane 0.6.7. Pin to that version to avoid it
floating ahead while upgrading other dependencies.

Signed-off-by: Dave Cheney <dave@cheney.net>