### PR TITLE
internal/contour: use proxy_protocol PROXY listener

### DIFF
--- a/internal/contour/listener_test.go
+++ b/internal/contour/listener_test.go
@@ -56,11 +56,9 @@ func TestListenerVisit(t *testing.T) {
 				},
 			},
 			want: listenermap(&v2.Listener{
-				Name:    ENVOY_HTTP_LISTENER,
-				Address: envoy.SocketAddress("0.0.0.0", 8080),
-				FilterChains: []listener.FilterChain{
-					filterchain(false, envoy.HTTPConnectionManager(ENVOY_HTTP_LISTENER, DEFAULT_HTTP_ACCESS_LOG)),
-				},
+				Name:         ENVOY_HTTP_LISTENER,
+				Address:      envoy.SocketAddress("0.0.0.0", 8080),
+				FilterChains: filterchain(envoy.HTTPConnectionManager(ENVOY_HTTP_LISTENER, DEFAULT_HTTP_ACCESS_LOG)),
 			}),
 		},
 		"one http only ingressroute": {
@@ -88,11 +86,9 @@ func TestListenerVisit(t *testing.T) {
 				},
 			},
 			want: listenermap(&v2.Listener{
-				Name:    ENVOY_HTTP_LISTENER,
-				Address: envoy.SocketAddress("0.0.0.0", 8080),
-				FilterChains: []listener.FilterChain{
-					filterchain(false, envoy.HTTPConnectionManager(ENVOY_HTTP_LISTENER, DEFAULT_HTTP_ACCESS_LOG)),
-				},
+				Name:         ENVOY_HTTP_LISTENER,
+				Address:      envoy.SocketAddress("0.0.0.0", 8080),
+				FilterChains: filterchain(envoy.HTTPConnectionManager(ENVOY_HTTP_LISTENER, DEFAULT_HTTP_ACCESS_LOG)),
 			}),
 		},
 		"simple ingress with secret": {
@@ -122,14 +118,15 @@ func TestListenerVisit(t *testing.T) {
 				},
 			},
 			want: listenermap(&v2.Listener{
-				Name:    ENVOY_HTTP_LISTENER,
-				Address: envoy.SocketAddress("0.0.0.0", 8080),
-				FilterChains: []listener.FilterChain{
-					filterchain(false, envoy.HTTPConnectionManager(ENVOY_HTTP_LISTENER, DEFAULT_HTTP_ACCESS_LOG)),
-				},
+				Name:         ENVOY_HTTP_LISTENER,
+				Address:      envoy.SocketAddress("0.0.0.0", 8080),
+				FilterChains: filterchain(envoy.HTTPConnectionManager(ENVOY_HTTP_LISTENER, DEFAULT_HTTP_ACCESS_LOG)),
 			}, &v2.Listener{
 				Name:    ENVOY_HTTPS_LISTENER,
 				Address: envoy.SocketAddress("0.0.0.0", 8443),
+				ListenerFilters: []listener.ListenerFilter{
+					envoy.TLSInspector(),
+				},
 				FilterChains: []listener.FilterChain{{
 					FilterChainMatch: &listener.FilterChainMatch{
 						ServerNames: []string{"whatever.example.com"},
@@ -137,9 +134,6 @@ func TestListenerVisit(t *testing.T) {
 					TlsContext: tlscontext(auth.TlsParameters_TLSv1_1, "h2", "http/1.1"),
 					Filters:    filters(envoy.HTTPConnectionManager(ENVOY_HTTPS_LISTENER, DEFAULT_HTTPS_ACCESS_LOG)),
 				}},
-				ListenerFilters: []listener.ListenerFilter{
-					envoy.TLSInspector(),
-				},
 			}),
 		},
 		"simple ingress with missing secret": {
@@ -169,11 +163,9 @@ func TestListenerVisit(t *testing.T) {
 				},
 			},
 			want: listenermap(&v2.Listener{
-				Name:    ENVOY_HTTP_LISTENER,
-				Address: envoy.SocketAddress("0.0.0.0", 8080),
-				FilterChains: []listener.FilterChain{
-					filterchain(false, envoy.HTTPConnectionManager(ENVOY_HTTP_LISTENER, DEFAULT_HTTP_ACCESS_LOG)),
-				},
+				Name:         ENVOY_HTTP_LISTENER,
+				Address:      envoy.SocketAddress("0.0.0.0", 8080),
+				FilterChains: filterchain(envoy.HTTPConnectionManager(ENVOY_HTTP_LISTENER, DEFAULT_HTTP_ACCESS_LOG)),
 			}),
 		},
 		"simple ingressroute with secret": {
@@ -211,11 +203,9 @@ func TestListenerVisit(t *testing.T) {
 				},
 			},
 			want: listenermap(&v2.Listener{
-				Name:    ENVOY_HTTP_LISTENER,
-				Address: envoy.SocketAddress("0.0.0.0", 8080),
-				FilterChains: []listener.FilterChain{
-					filterchain(false, envoy.HTTPConnectionManager(ENVOY_HTTP_LISTENER, DEFAULT_HTTP_ACCESS_LOG)),
-				},
+				Name:         ENVOY_HTTP_LISTENER,
+				Address:      envoy.SocketAddress("0.0.0.0", 8080),
+				FilterChains: filterchain(envoy.HTTPConnectionManager(ENVOY_HTTP_LISTENER, DEFAULT_HTTP_ACCESS_LOG)),
 			}, &v2.Listener{
 				Name:    ENVOY_HTTPS_LISTENER,
 				Address: envoy.SocketAddress("0.0.0.0", 8443),
@@ -328,14 +318,15 @@ func TestListenerVisit(t *testing.T) {
 				},
 			},
 			want: listenermap(&v2.Listener{
-				Name:    ENVOY_HTTP_LISTENER,
-				Address: envoy.SocketAddress("127.0.0.100", 9100),
-				FilterChains: []listener.FilterChain{
-					filterchain(false, envoy.HTTPConnectionManager(ENVOY_HTTP_LISTENER, DEFAULT_HTTP_ACCESS_LOG)),
-				},
+				Name:         ENVOY_HTTP_LISTENER,
+				Address:      envoy.SocketAddress("127.0.0.100", 9100),
+				FilterChains: filterchain(envoy.HTTPConnectionManager(ENVOY_HTTP_LISTENER, DEFAULT_HTTP_ACCESS_LOG)),
 			}, &v2.Listener{
 				Name:    ENVOY_HTTPS_LISTENER,
 				Address: envoy.SocketAddress("127.0.0.200", 9200),
+				ListenerFilters: []listener.ListenerFilter{
+					envoy.TLSInspector(),
+				},
 				FilterChains: []listener.FilterChain{{
 					FilterChainMatch: &listener.FilterChainMatch{
 						ServerNames: []string{"whatever.example.com"},
@@ -343,9 +334,6 @@ func TestListenerVisit(t *testing.T) {
 					TlsContext: tlscontext(auth.TlsParameters_TLSv1_1, "h2", "http/1.1"),
 					Filters:    filters(envoy.HTTPConnectionManager(ENVOY_HTTPS_LISTENER, DEFAULT_HTTPS_ACCESS_LOG)),
 				}},
-				ListenerFilters: []listener.ListenerFilter{
-					envoy.TLSInspector(),
-				},
 			}),
 		},
 		"use proxy proto": {
@@ -380,23 +368,24 @@ func TestListenerVisit(t *testing.T) {
 			want: listenermap(&v2.Listener{
 				Name:    ENVOY_HTTP_LISTENER,
 				Address: envoy.SocketAddress("0.0.0.0", 8080),
-				FilterChains: []listener.FilterChain{
-					filterchain(true, envoy.HTTPConnectionManager(ENVOY_HTTP_LISTENER, DEFAULT_HTTP_ACCESS_LOG)),
+				ListenerFilters: []listener.ListenerFilter{
+					envoy.ProxyProtocol(),
 				},
+				FilterChains: filterchain(envoy.HTTPConnectionManager(ENVOY_HTTP_LISTENER, DEFAULT_HTTP_ACCESS_LOG)),
 			}, &v2.Listener{
 				Name:    ENVOY_HTTPS_LISTENER,
 				Address: envoy.SocketAddress("0.0.0.0", 8443),
+				ListenerFilters: []listener.ListenerFilter{
+					envoy.ProxyProtocol(),
+					envoy.TLSInspector(),
+				},
 				FilterChains: []listener.FilterChain{{
 					FilterChainMatch: &listener.FilterChainMatch{
 						ServerNames: []string{"whatever.example.com"},
 					},
-					TlsContext:    tlscontext(auth.TlsParameters_TLSv1_1, "h2", "http/1.1"),
-					Filters:       filters(envoy.HTTPConnectionManager(ENVOY_HTTPS_LISTENER, DEFAULT_HTTPS_ACCESS_LOG)),
-					UseProxyProto: bv(true),
+					TlsContext: tlscontext(auth.TlsParameters_TLSv1_1, "h2", "http/1.1"),
+					Filters:    filters(envoy.HTTPConnectionManager(ENVOY_HTTPS_LISTENER, DEFAULT_HTTPS_ACCESS_LOG)),
 				}},
-				ListenerFilters: []listener.ListenerFilter{
-					envoy.TLSInspector(),
-				},
 			}),
 		},
 	}
@@ -424,12 +413,11 @@ func filters(first listener.Filter, rest ...listener.Filter) []listener.Filter {
 	return append([]listener.Filter{first}, rest...)
 }
 
-func filterchain(useproxy bool, filters ...listener.Filter) listener.FilterChain {
+func filterchain(filters ...listener.Filter) []listener.FilterChain {
 	fc := listener.FilterChain{
-		Filters:       filters,
-		UseProxyProto: bv(useproxy),
+		Filters: filters,
 	}
-	return fc
+	return []listener.FilterChain{fc}
 }
 
 func tlscontext(tlsMinProtoVersion auth.TlsParameters_TlsProtocol, alpnprotos ...string) *auth.DownstreamTlsContext {

--- a/internal/e2e/lds_test.go
+++ b/internal/e2e/lds_test.go
@@ -73,7 +73,7 @@ func TestNonTLSListener(t *testing.T) {
 				Name:    "ingress_http",
 				Address: envoy.SocketAddress("0.0.0.0", 8080),
 				FilterChains: []listener.FilterChain{
-					filterchain(false, envoy.HTTPConnectionManager("ingress_http", "/dev/stdout")),
+					filterchain(envoy.HTTPConnectionManager("ingress_http", "/dev/stdout")),
 				},
 			}),
 		},
@@ -128,7 +128,7 @@ func TestNonTLSListener(t *testing.T) {
 				Name:    "ingress_http",
 				Address: envoy.SocketAddress("0.0.0.0", 8080),
 				FilterChains: []listener.FilterChain{
-					filterchain(false, envoy.HTTPConnectionManager("ingress_http", "/dev/stdout")),
+					filterchain(envoy.HTTPConnectionManager("ingress_http", "/dev/stdout")),
 				},
 			}),
 		},
@@ -188,7 +188,7 @@ func TestTLSListener(t *testing.T) {
 				Name:    "ingress_http",
 				Address: envoy.SocketAddress("0.0.0.0", 8080),
 				FilterChains: []listener.FilterChain{
-					filterchain(false, envoy.HTTPConnectionManager("ingress_http", "/dev/stdout")),
+					filterchain(envoy.HTTPConnectionManager("ingress_http", "/dev/stdout")),
 				},
 			}),
 			any(t, &v2.Listener{
@@ -345,7 +345,7 @@ func TestIngressRouteTLSListener(t *testing.T) {
 				Name:    "ingress_http",
 				Address: envoy.SocketAddress("0.0.0.0", 8080),
 				FilterChains: []listener.FilterChain{
-					filterchain(false, envoy.HTTPConnectionManager("ingress_http", "/dev/stdout")),
+					filterchain(envoy.HTTPConnectionManager("ingress_http", "/dev/stdout")),
 				},
 			}),
 			any(t, l1),
@@ -363,7 +363,7 @@ func TestIngressRouteTLSListener(t *testing.T) {
 				Name:    "ingress_http",
 				Address: envoy.SocketAddress("0.0.0.0", 8080),
 				FilterChains: []listener.FilterChain{
-					filterchain(false, envoy.HTTPConnectionManager("ingress_http", "/dev/stdout")),
+					filterchain(envoy.HTTPConnectionManager("ingress_http", "/dev/stdout")),
 				},
 			}),
 		},
@@ -394,7 +394,7 @@ func TestIngressRouteTLSListener(t *testing.T) {
 				Name:    "ingress_http",
 				Address: envoy.SocketAddress("0.0.0.0", 8080),
 				FilterChains: []listener.FilterChain{
-					filterchain(false, envoy.HTTPConnectionManager("ingress_http", "/dev/stdout")),
+					filterchain(envoy.HTTPConnectionManager("ingress_http", "/dev/stdout")),
 				},
 			}),
 			any(t, l2),
@@ -465,7 +465,7 @@ func TestLDSFilter(t *testing.T) {
 				Name:    "ingress_http",
 				Address: envoy.SocketAddress("0.0.0.0", 8080),
 				FilterChains: []listener.FilterChain{
-					filterchain(false, envoy.HTTPConnectionManager("ingress_http", "/dev/stdout")),
+					filterchain(envoy.HTTPConnectionManager("ingress_http", "/dev/stdout")),
 				},
 			}),
 		},
@@ -619,8 +619,11 @@ func TestLDSIngressHTTPUseProxyProtocol(t *testing.T) {
 			any(t, &v2.Listener{
 				Name:    "ingress_http",
 				Address: envoy.SocketAddress("0.0.0.0", 8080),
+				ListenerFilters: []listener.ListenerFilter{
+					envoy.ProxyProtocol(),
+				},
 				FilterChains: []listener.FilterChain{
-					filterchain(true, envoy.HTTPConnectionManager("ingress_http", "/dev/stdout")),
+					filterchain(envoy.HTTPConnectionManager("ingress_http", "/dev/stdout")),
 				},
 			}),
 		},
@@ -682,18 +685,21 @@ func TestLDSIngressHTTPSUseProxyProtocol(t *testing.T) {
 		Address:      envoy.SocketAddress("0.0.0.0", 8443),
 		FilterChains: filterchaintls("kuard.example.com", envoy.HTTPConnectionManager("ingress_https", "/dev/stdout"), "h2", "http/1.1"),
 		ListenerFilters: []listener.ListenerFilter{
+			envoy.ProxyProtocol(),
 			envoy.TLSInspector(),
 		},
 	}
-	ingress_https.FilterChains[0].UseProxyProto = bv(true)
 	assertEqual(t, &v2.DiscoveryResponse{
 		VersionInfo: "0",
 		Resources: []types.Any{
 			any(t, &v2.Listener{
 				Name:    "ingress_http",
 				Address: envoy.SocketAddress("0.0.0.0", 8080),
+				ListenerFilters: []listener.ListenerFilter{
+					envoy.ProxyProtocol(),
+				},
 				FilterChains: []listener.FilterChain{
-					filterchain(true, envoy.HTTPConnectionManager("ingress_http", "/dev/stdout")),
+					filterchain(envoy.HTTPConnectionManager("ingress_http", "/dev/stdout")),
 				},
 			}),
 			any(t, ingress_https),
@@ -758,7 +764,7 @@ func TestLDSCustomAddressAndPort(t *testing.T) {
 		Name:    "ingress_http",
 		Address: envoy.SocketAddress("127.0.0.100", 9100),
 		FilterChains: []listener.FilterChain{
-			filterchain(false, envoy.HTTPConnectionManager("ingress_http", "/dev/stdout")),
+			filterchain(envoy.HTTPConnectionManager("ingress_http", "/dev/stdout")),
 		},
 	}
 	ingress_https := &v2.Listener{
@@ -826,7 +832,7 @@ func TestLDSIngressRouteInsideRootNamespaces(t *testing.T) {
 				Name:    "ingress_http",
 				Address: envoy.SocketAddress("0.0.0.0", 8080),
 				FilterChains: []listener.FilterChain{
-					filterchain(false, envoy.HTTPConnectionManager("ingress_http", "/dev/stdout")),
+					filterchain(envoy.HTTPConnectionManager("ingress_http", "/dev/stdout")),
 				},
 			}),
 		},
@@ -944,7 +950,7 @@ func TestIngressRouteHTTPS(t *testing.T) {
 		Name:    "ingress_http",
 		Address: envoy.SocketAddress("0.0.0.0", 8080),
 		FilterChains: []listener.FilterChain{
-			filterchain(false, envoy.HTTPConnectionManager("ingress_http", "/dev/stdout")),
+			filterchain(envoy.HTTPConnectionManager("ingress_http", "/dev/stdout")),
 		},
 	}
 
@@ -1124,18 +1130,15 @@ func backend(name string, port intstr.IntOrString) *v1beta1.IngressBackend {
 	}
 }
 
-func filterchain(useproxy bool, filters ...listener.Filter) listener.FilterChain {
+func filterchain(filters ...listener.Filter) listener.FilterChain {
 	fc := listener.FilterChain{
 		Filters: filters,
-	}
-	if useproxy {
-		fc.UseProxyProto = bv(true)
 	}
 	return fc
 }
 
 func filterchaintls(domain string, filter listener.Filter, alpn ...string) []listener.FilterChain {
-	fc := filterchain(false, filter)
+	fc := filterchain(filter)
 	fc.FilterChainMatch = &listener.FilterChainMatch{
 		ServerNames: []string{domain},
 	}

--- a/internal/e2e/lds_test.go
+++ b/internal/e2e/lds_test.go
@@ -70,11 +70,9 @@ func TestNonTLSListener(t *testing.T) {
 		VersionInfo: "0",
 		Resources: []types.Any{
 			any(t, &v2.Listener{
-				Name:    "ingress_http",
-				Address: envoy.SocketAddress("0.0.0.0", 8080),
-				FilterChains: []listener.FilterChain{
-					filterchain(envoy.HTTPConnectionManager("ingress_http", "/dev/stdout")),
-				},
+				Name:         "ingress_http",
+				Address:      envoy.SocketAddress("0.0.0.0", 8080),
+				FilterChains: filterchain(envoy.HTTPConnectionManager("ingress_http", "/dev/stdout")),
 			}),
 		},
 		TypeUrl: listenerType,
@@ -125,11 +123,9 @@ func TestNonTLSListener(t *testing.T) {
 		VersionInfo: "0",
 		Resources: []types.Any{
 			any(t, &v2.Listener{
-				Name:    "ingress_http",
-				Address: envoy.SocketAddress("0.0.0.0", 8080),
-				FilterChains: []listener.FilterChain{
-					filterchain(envoy.HTTPConnectionManager("ingress_http", "/dev/stdout")),
-				},
+				Name:         "ingress_http",
+				Address:      envoy.SocketAddress("0.0.0.0", 8080),
+				FilterChains: filterchain(envoy.HTTPConnectionManager("ingress_http", "/dev/stdout")),
 			}),
 		},
 		TypeUrl: listenerType,
@@ -185,19 +181,17 @@ func TestTLSListener(t *testing.T) {
 		VersionInfo: "0",
 		Resources: []types.Any{
 			any(t, &v2.Listener{
-				Name:    "ingress_http",
-				Address: envoy.SocketAddress("0.0.0.0", 8080),
-				FilterChains: []listener.FilterChain{
-					filterchain(envoy.HTTPConnectionManager("ingress_http", "/dev/stdout")),
-				},
+				Name:         "ingress_http",
+				Address:      envoy.SocketAddress("0.0.0.0", 8080),
+				FilterChains: filterchain(envoy.HTTPConnectionManager("ingress_http", "/dev/stdout")),
 			}),
 			any(t, &v2.Listener{
-				Name:         "ingress_https",
-				Address:      envoy.SocketAddress("0.0.0.0", 8443),
-				FilterChains: filterchaintls("kuard.example.com", envoy.HTTPConnectionManager("ingress_https", "/dev/stdout"), "h2", "http/1.1"),
+				Name:    "ingress_https",
+				Address: envoy.SocketAddress("0.0.0.0", 8443),
 				ListenerFilters: []listener.ListenerFilter{
 					envoy.TLSInspector(),
 				},
+				FilterChains: filterchaintls("kuard.example.com", envoy.HTTPConnectionManager("ingress_https", "/dev/stdout"), "h2", "http/1.1"),
 			}),
 		},
 		TypeUrl: listenerType,
@@ -228,12 +222,12 @@ func TestTLSListener(t *testing.T) {
 		VersionInfo: "0",
 		Resources: []types.Any{
 			any(t, &v2.Listener{
-				Name:         "ingress_https",
-				Address:      envoy.SocketAddress("0.0.0.0", 8443),
-				FilterChains: filterchaintls("kuard.example.com", envoy.HTTPConnectionManager("ingress_https", "/dev/stdout"), "h2", "http/1.1"),
+				Name:    "ingress_https",
+				Address: envoy.SocketAddress("0.0.0.0", 8443),
 				ListenerFilters: []listener.ListenerFilter{
 					envoy.TLSInspector(),
 				},
+				FilterChains: filterchaintls("kuard.example.com", envoy.HTTPConnectionManager("ingress_https", "/dev/stdout"), "h2", "http/1.1"),
 			}),
 		},
 		TypeUrl: listenerType,
@@ -326,12 +320,12 @@ func TestIngressRouteTLSListener(t *testing.T) {
 	}, streamLDS(t, cc))
 
 	l1 := &v2.Listener{
-		Name:         "ingress_https",
-		Address:      envoy.SocketAddress("0.0.0.0", 8443),
-		FilterChains: filterchaintls("kuard.example.com", envoy.HTTPConnectionManager("ingress_https", "/dev/stdout"), "h2", "http/1.1"),
+		Name:    "ingress_https",
+		Address: envoy.SocketAddress("0.0.0.0", 8443),
 		ListenerFilters: []listener.ListenerFilter{
 			envoy.TLSInspector(),
 		},
+		FilterChains: filterchaintls("kuard.example.com", envoy.HTTPConnectionManager("ingress_https", "/dev/stdout"), "h2", "http/1.1"),
 	}
 
 	l1.FilterChains[0].TlsContext.CommonTlsContext.TlsParams.TlsMinimumProtocolVersion = auth.TlsParameters_TLSv1_1
@@ -342,11 +336,9 @@ func TestIngressRouteTLSListener(t *testing.T) {
 		VersionInfo: "0",
 		Resources: []types.Any{
 			any(t, &v2.Listener{
-				Name:    "ingress_http",
-				Address: envoy.SocketAddress("0.0.0.0", 8080),
-				FilterChains: []listener.FilterChain{
-					filterchain(envoy.HTTPConnectionManager("ingress_http", "/dev/stdout")),
-				},
+				Name:         "ingress_http",
+				Address:      envoy.SocketAddress("0.0.0.0", 8080),
+				FilterChains: filterchain(envoy.HTTPConnectionManager("ingress_http", "/dev/stdout")),
 			}),
 			any(t, l1),
 		},
@@ -360,11 +352,9 @@ func TestIngressRouteTLSListener(t *testing.T) {
 		VersionInfo: "0",
 		Resources: []types.Any{
 			any(t, &v2.Listener{
-				Name:    "ingress_http",
-				Address: envoy.SocketAddress("0.0.0.0", 8080),
-				FilterChains: []listener.FilterChain{
-					filterchain(envoy.HTTPConnectionManager("ingress_http", "/dev/stdout")),
-				},
+				Name:         "ingress_http",
+				Address:      envoy.SocketAddress("0.0.0.0", 8080),
+				FilterChains: filterchain(envoy.HTTPConnectionManager("ingress_http", "/dev/stdout")),
 			}),
 		},
 		TypeUrl: listenerType,
@@ -375,12 +365,12 @@ func TestIngressRouteTLSListener(t *testing.T) {
 	// add secret
 	rh.OnAdd(s1)
 	l2 := &v2.Listener{
-		Name:         "ingress_https",
-		Address:      envoy.SocketAddress("0.0.0.0", 8443),
-		FilterChains: filterchaintls("kuard.example.com", envoy.HTTPConnectionManager("ingress_https", "/dev/stdout"), "h2", "http/1.1"),
+		Name:    "ingress_https",
+		Address: envoy.SocketAddress("0.0.0.0", 8443),
 		ListenerFilters: []listener.ListenerFilter{
 			envoy.TLSInspector(),
 		},
+		FilterChains: filterchaintls("kuard.example.com", envoy.HTTPConnectionManager("ingress_https", "/dev/stdout"), "h2", "http/1.1"),
 	}
 
 	l2.FilterChains[0].TlsContext.CommonTlsContext.TlsParams.TlsMinimumProtocolVersion = auth.TlsParameters_TLSv1_3
@@ -391,11 +381,9 @@ func TestIngressRouteTLSListener(t *testing.T) {
 		VersionInfo: "0",
 		Resources: []types.Any{
 			any(t, &v2.Listener{
-				Name:    "ingress_http",
-				Address: envoy.SocketAddress("0.0.0.0", 8080),
-				FilterChains: []listener.FilterChain{
-					filterchain(envoy.HTTPConnectionManager("ingress_http", "/dev/stdout")),
-				},
+				Name:         "ingress_http",
+				Address:      envoy.SocketAddress("0.0.0.0", 8080),
+				FilterChains: filterchain(envoy.HTTPConnectionManager("ingress_http", "/dev/stdout")),
 			}),
 			any(t, l2),
 		},
@@ -444,12 +432,12 @@ func TestLDSFilter(t *testing.T) {
 		VersionInfo: "0",
 		Resources: []types.Any{
 			any(t, &v2.Listener{
-				Name:         "ingress_https",
-				Address:      envoy.SocketAddress("0.0.0.0", 8443),
-				FilterChains: filterchaintls("kuard.example.com", envoy.HTTPConnectionManager("ingress_https", "/dev/stdout"), "h2", "http/1.1"),
+				Name:    "ingress_https",
+				Address: envoy.SocketAddress("0.0.0.0", 8443),
 				ListenerFilters: []listener.ListenerFilter{
 					envoy.TLSInspector(),
 				},
+				FilterChains: filterchaintls("kuard.example.com", envoy.HTTPConnectionManager("ingress_https", "/dev/stdout"), "h2", "http/1.1"),
 			}),
 		},
 		TypeUrl: listenerType,
@@ -462,11 +450,9 @@ func TestLDSFilter(t *testing.T) {
 		Resources: []types.Any{
 
 			any(t, &v2.Listener{
-				Name:    "ingress_http",
-				Address: envoy.SocketAddress("0.0.0.0", 8080),
-				FilterChains: []listener.FilterChain{
-					filterchain(envoy.HTTPConnectionManager("ingress_http", "/dev/stdout")),
-				},
+				Name:         "ingress_http",
+				Address:      envoy.SocketAddress("0.0.0.0", 8080),
+				FilterChains: filterchain(envoy.HTTPConnectionManager("ingress_http", "/dev/stdout")),
 			}),
 		},
 		TypeUrl: listenerType,
@@ -531,12 +517,12 @@ func TestLDSTLSMinimumProtocolVersion(t *testing.T) {
 		VersionInfo: "0",
 		Resources: []types.Any{
 			any(t, &v2.Listener{
-				Name:         "ingress_https",
-				Address:      envoy.SocketAddress("0.0.0.0", 8443),
-				FilterChains: filterchaintls("kuard.example.com", envoy.HTTPConnectionManager("ingress_https", "/dev/stdout"), "h2", "http/1.1"),
+				Name:    "ingress_https",
+				Address: envoy.SocketAddress("0.0.0.0", 8443),
 				ListenerFilters: []listener.ListenerFilter{
 					envoy.TLSInspector(),
 				},
+				FilterChains: filterchaintls("kuard.example.com", envoy.HTTPConnectionManager("ingress_https", "/dev/stdout"), "h2", "http/1.1"),
 			}),
 		},
 		TypeUrl: listenerType,
@@ -564,12 +550,12 @@ func TestLDSTLSMinimumProtocolVersion(t *testing.T) {
 	rh.OnUpdate(i1, i2)
 
 	l1 := &v2.Listener{
-		Name:         "ingress_https",
-		Address:      envoy.SocketAddress("0.0.0.0", 8443),
-		FilterChains: filterchaintls("kuard.example.com", envoy.HTTPConnectionManager("ingress_https", "/dev/stdout"), "h2", "http/1.1"),
+		Name:    "ingress_https",
+		Address: envoy.SocketAddress("0.0.0.0", 8443),
 		ListenerFilters: []listener.ListenerFilter{
 			envoy.TLSInspector(),
 		},
+		FilterChains: filterchaintls("kuard.example.com", envoy.HTTPConnectionManager("ingress_https", "/dev/stdout"), "h2", "http/1.1"),
 	}
 	// easier to patch this up than add more params to filterchaintls
 	l1.FilterChains[0].TlsContext.CommonTlsContext.TlsParams.TlsMinimumProtocolVersion = auth.TlsParameters_TLSv1_3
@@ -622,9 +608,7 @@ func TestLDSIngressHTTPUseProxyProtocol(t *testing.T) {
 				ListenerFilters: []listener.ListenerFilter{
 					envoy.ProxyProtocol(),
 				},
-				FilterChains: []listener.FilterChain{
-					filterchain(envoy.HTTPConnectionManager("ingress_http", "/dev/stdout")),
-				},
+				FilterChains: filterchain(envoy.HTTPConnectionManager("ingress_http", "/dev/stdout")),
 			}),
 		},
 		TypeUrl: listenerType,
@@ -681,13 +665,13 @@ func TestLDSIngressHTTPSUseProxyProtocol(t *testing.T) {
 	rh.OnAdd(i1)
 
 	ingress_https := &v2.Listener{
-		Name:         "ingress_https",
-		Address:      envoy.SocketAddress("0.0.0.0", 8443),
-		FilterChains: filterchaintls("kuard.example.com", envoy.HTTPConnectionManager("ingress_https", "/dev/stdout"), "h2", "http/1.1"),
+		Name:    "ingress_https",
+		Address: envoy.SocketAddress("0.0.0.0", 8443),
 		ListenerFilters: []listener.ListenerFilter{
 			envoy.ProxyProtocol(),
 			envoy.TLSInspector(),
 		},
+		FilterChains: filterchaintls("kuard.example.com", envoy.HTTPConnectionManager("ingress_https", "/dev/stdout"), "h2", "http/1.1"),
 	}
 	assertEqual(t, &v2.DiscoveryResponse{
 		VersionInfo: "0",
@@ -698,9 +682,7 @@ func TestLDSIngressHTTPSUseProxyProtocol(t *testing.T) {
 				ListenerFilters: []listener.ListenerFilter{
 					envoy.ProxyProtocol(),
 				},
-				FilterChains: []listener.FilterChain{
-					filterchain(envoy.HTTPConnectionManager("ingress_http", "/dev/stdout")),
-				},
+				FilterChains: filterchain(envoy.HTTPConnectionManager("ingress_http", "/dev/stdout")),
 			}),
 			any(t, ingress_https),
 		},
@@ -761,19 +743,17 @@ func TestLDSCustomAddressAndPort(t *testing.T) {
 	rh.OnAdd(i1)
 
 	ingress_http := &v2.Listener{
-		Name:    "ingress_http",
-		Address: envoy.SocketAddress("127.0.0.100", 9100),
-		FilterChains: []listener.FilterChain{
-			filterchain(envoy.HTTPConnectionManager("ingress_http", "/dev/stdout")),
-		},
+		Name:         "ingress_http",
+		Address:      envoy.SocketAddress("127.0.0.100", 9100),
+		FilterChains: filterchain(envoy.HTTPConnectionManager("ingress_http", "/dev/stdout")),
 	}
 	ingress_https := &v2.Listener{
-		Name:         "ingress_https",
-		Address:      envoy.SocketAddress("127.0.0.200", 9200),
-		FilterChains: filterchaintls("kuard.example.com", envoy.HTTPConnectionManager("ingress_https", "/dev/stdout"), "h2", "http/1.1"),
+		Name:    "ingress_https",
+		Address: envoy.SocketAddress("127.0.0.200", 9200),
 		ListenerFilters: []listener.ListenerFilter{
 			envoy.TLSInspector(),
 		},
+		FilterChains: filterchaintls("kuard.example.com", envoy.HTTPConnectionManager("ingress_https", "/dev/stdout"), "h2", "http/1.1"),
 	}
 	assertEqual(t, &v2.DiscoveryResponse{
 		VersionInfo: "0",
@@ -829,11 +809,9 @@ func TestLDSIngressRouteInsideRootNamespaces(t *testing.T) {
 		VersionInfo: "0",
 		Resources: []types.Any{
 			any(t, &v2.Listener{
-				Name:    "ingress_http",
-				Address: envoy.SocketAddress("0.0.0.0", 8080),
-				FilterChains: []listener.FilterChain{
-					filterchain(envoy.HTTPConnectionManager("ingress_http", "/dev/stdout")),
-				},
+				Name:         "ingress_http",
+				Address:      envoy.SocketAddress("0.0.0.0", 8080),
+				FilterChains: filterchain(envoy.HTTPConnectionManager("ingress_http", "/dev/stdout")),
 			}),
 		},
 		TypeUrl: listenerType,
@@ -947,20 +925,18 @@ func TestIngressRouteHTTPS(t *testing.T) {
 	rh.OnAdd(ir1)
 
 	ingressHTTP := &v2.Listener{
-		Name:    "ingress_http",
-		Address: envoy.SocketAddress("0.0.0.0", 8080),
-		FilterChains: []listener.FilterChain{
-			filterchain(envoy.HTTPConnectionManager("ingress_http", "/dev/stdout")),
-		},
+		Name:         "ingress_http",
+		Address:      envoy.SocketAddress("0.0.0.0", 8080),
+		FilterChains: filterchain(envoy.HTTPConnectionManager("ingress_http", "/dev/stdout")),
 	}
 
 	ingressHTTPS := &v2.Listener{
-		Name:         "ingress_https",
-		Address:      envoy.SocketAddress("0.0.0.0", 8443),
-		FilterChains: filterchaintls("example.com", envoy.HTTPConnectionManager("ingress_https", "/dev/stdout"), "h2", "http/1.1"),
+		Name:    "ingress_https",
+		Address: envoy.SocketAddress("0.0.0.0", 8443),
 		ListenerFilters: []listener.ListenerFilter{
 			envoy.TLSInspector(),
 		},
+		FilterChains: filterchaintls("example.com", envoy.HTTPConnectionManager("ingress_https", "/dev/stdout"), "h2", "http/1.1"),
 	}
 	assertEqual(t, &v2.DiscoveryResponse{
 		VersionInfo: "0",
@@ -1130,15 +1106,19 @@ func backend(name string, port intstr.IntOrString) *v1beta1.IngressBackend {
 	}
 }
 
-func filterchain(filters ...listener.Filter) listener.FilterChain {
+func filterchain(filters ...listener.Filter) []listener.FilterChain {
 	fc := listener.FilterChain{
 		Filters: filters,
 	}
-	return fc
+	return []listener.FilterChain{fc}
 }
 
 func filterchaintls(domain string, filter listener.Filter, alpn ...string) []listener.FilterChain {
-	fc := filterchain(filter)
+	fc := listener.FilterChain{
+		Filters: []listener.Filter{
+			filter,
+		},
+	}
 	fc.FilterChainMatch = &listener.FilterChainMatch{
 		ServerNames: []string{domain},
 	}

--- a/internal/envoy/listener.go
+++ b/internal/envoy/listener.go
@@ -34,6 +34,16 @@ func TLSInspector() listener.ListenerFilter {
 	}
 }
 
+// ProxyProtocol returns a new Proxy Protocol listener filter.
+func ProxyProtocol() listener.ListenerFilter {
+	return listener.ListenerFilter{
+		Name: util.ProxyProtocol,
+		ConfigType: &listener.ListenerFilter_Config{
+			Config: new(types.Struct),
+		},
+	}
+}
+
 // HTTPConnectionManager creates a new HTTP Connection Manager filter
 // for the supplied route and access log.
 func HTTPConnectionManager(routename, accessLogPath string) listener.Filter {


### PR DESCRIPTION
Fixes #802

The proxy_protocol listener filter supports PROXY V1 (AWS/ELB) and PROXY
V2 (HAProxy).

Signed-off-by: Dave Cheney <dave@cheney.net>