### PR TITLE
internal/envoy: stop using deprecated cluster.host stanza

### DIFF
--- a/internal/contour/listener.go
+++ b/internal/contour/listener.go
@@ -202,7 +202,7 @@ func visitListeners(root dag.Vertex, lvc *ListenerVisitorConfig) map[string]*v2.
 		listeners: map[string]*v2.Listener{
 			ENVOY_HTTP_LISTENER: {
 				Name:            ENVOY_HTTP_LISTENER,
-				Address:         envoy.SocketAddress(lvc.httpAddress(), lvc.httpPort()),
+				Address:         *envoy.SocketAddress(lvc.httpAddress(), lvc.httpPort()),
 				ListenerFilters: httpListenerFilters,
 				FilterChains: []listener.FilterChain{{
 					Filters: []listener.Filter{
@@ -212,7 +212,7 @@ func visitListeners(root dag.Vertex, lvc *ListenerVisitorConfig) map[string]*v2.
 			},
 			ENVOY_HTTPS_LISTENER: {
 				Name:            ENVOY_HTTPS_LISTENER,
-				Address:         envoy.SocketAddress(lvc.httpsAddress(), lvc.httpsPort()),
+				Address:         *envoy.SocketAddress(lvc.httpsAddress(), lvc.httpsPort()),
 				ListenerFilters: httpsListenerFilters,
 			},
 		},

--- a/internal/contour/listener_test.go
+++ b/internal/contour/listener_test.go
@@ -57,7 +57,7 @@ func TestListenerVisit(t *testing.T) {
 			},
 			want: listenermap(&v2.Listener{
 				Name:         ENVOY_HTTP_LISTENER,
-				Address:      envoy.SocketAddress("0.0.0.0", 8080),
+				Address:      *envoy.SocketAddress("0.0.0.0", 8080),
 				FilterChains: filterchain(envoy.HTTPConnectionManager(ENVOY_HTTP_LISTENER, DEFAULT_HTTP_ACCESS_LOG)),
 			}),
 		},
@@ -87,7 +87,7 @@ func TestListenerVisit(t *testing.T) {
 			},
 			want: listenermap(&v2.Listener{
 				Name:         ENVOY_HTTP_LISTENER,
-				Address:      envoy.SocketAddress("0.0.0.0", 8080),
+				Address:      *envoy.SocketAddress("0.0.0.0", 8080),
 				FilterChains: filterchain(envoy.HTTPConnectionManager(ENVOY_HTTP_LISTENER, DEFAULT_HTTP_ACCESS_LOG)),
 			}),
 		},
@@ -119,11 +119,11 @@ func TestListenerVisit(t *testing.T) {
 			},
 			want: listenermap(&v2.Listener{
 				Name:         ENVOY_HTTP_LISTENER,
-				Address:      envoy.SocketAddress("0.0.0.0", 8080),
+				Address:      *envoy.SocketAddress("0.0.0.0", 8080),
 				FilterChains: filterchain(envoy.HTTPConnectionManager(ENVOY_HTTP_LISTENER, DEFAULT_HTTP_ACCESS_LOG)),
 			}, &v2.Listener{
 				Name:    ENVOY_HTTPS_LISTENER,
-				Address: envoy.SocketAddress("0.0.0.0", 8443),
+				Address: *envoy.SocketAddress("0.0.0.0", 8443),
 				ListenerFilters: []listener.ListenerFilter{
 					envoy.TLSInspector(),
 				},
@@ -164,7 +164,7 @@ func TestListenerVisit(t *testing.T) {
 			},
 			want: listenermap(&v2.Listener{
 				Name:         ENVOY_HTTP_LISTENER,
-				Address:      envoy.SocketAddress("0.0.0.0", 8080),
+				Address:      *envoy.SocketAddress("0.0.0.0", 8080),
 				FilterChains: filterchain(envoy.HTTPConnectionManager(ENVOY_HTTP_LISTENER, DEFAULT_HTTP_ACCESS_LOG)),
 			}),
 		},
@@ -204,11 +204,11 @@ func TestListenerVisit(t *testing.T) {
 			},
 			want: listenermap(&v2.Listener{
 				Name:         ENVOY_HTTP_LISTENER,
-				Address:      envoy.SocketAddress("0.0.0.0", 8080),
+				Address:      *envoy.SocketAddress("0.0.0.0", 8080),
 				FilterChains: filterchain(envoy.HTTPConnectionManager(ENVOY_HTTP_LISTENER, DEFAULT_HTTP_ACCESS_LOG)),
 			}, &v2.Listener{
 				Name:    ENVOY_HTTPS_LISTENER,
-				Address: envoy.SocketAddress("0.0.0.0", 8443),
+				Address: *envoy.SocketAddress("0.0.0.0", 8443),
 				FilterChains: []listener.FilterChain{{
 					FilterChainMatch: &listener.FilterChainMatch{
 						ServerNames: []string{"www.example.com"},
@@ -272,7 +272,7 @@ func TestListenerVisit(t *testing.T) {
 			},
 			want: listenermap(&v2.Listener{
 				Name:    ENVOY_HTTPS_LISTENER,
-				Address: envoy.SocketAddress("0.0.0.0", 8443),
+				Address: *envoy.SocketAddress("0.0.0.0", 8443),
 				FilterChains: []listener.FilterChain{{
 					FilterChainMatch: &listener.FilterChainMatch{
 						ServerNames: []string{"www.example.com"},
@@ -319,11 +319,11 @@ func TestListenerVisit(t *testing.T) {
 			},
 			want: listenermap(&v2.Listener{
 				Name:         ENVOY_HTTP_LISTENER,
-				Address:      envoy.SocketAddress("127.0.0.100", 9100),
+				Address:      *envoy.SocketAddress("127.0.0.100", 9100),
 				FilterChains: filterchain(envoy.HTTPConnectionManager(ENVOY_HTTP_LISTENER, DEFAULT_HTTP_ACCESS_LOG)),
 			}, &v2.Listener{
 				Name:    ENVOY_HTTPS_LISTENER,
-				Address: envoy.SocketAddress("127.0.0.200", 9200),
+				Address: *envoy.SocketAddress("127.0.0.200", 9200),
 				ListenerFilters: []listener.ListenerFilter{
 					envoy.TLSInspector(),
 				},
@@ -367,14 +367,14 @@ func TestListenerVisit(t *testing.T) {
 			},
 			want: listenermap(&v2.Listener{
 				Name:    ENVOY_HTTP_LISTENER,
-				Address: envoy.SocketAddress("0.0.0.0", 8080),
+				Address: *envoy.SocketAddress("0.0.0.0", 8080),
 				ListenerFilters: []listener.ListenerFilter{
 					envoy.ProxyProtocol(),
 				},
 				FilterChains: filterchain(envoy.HTTPConnectionManager(ENVOY_HTTP_LISTENER, DEFAULT_HTTP_ACCESS_LOG)),
 			}, &v2.Listener{
 				Name:    ENVOY_HTTPS_LISTENER,
-				Address: envoy.SocketAddress("0.0.0.0", 8443),
+				Address: *envoy.SocketAddress("0.0.0.0", 8443),
 				ListenerFilters: []listener.ListenerFilter{
 					envoy.ProxyProtocol(),
 					envoy.TLSInspector(),

--- a/internal/contour/visitor_test.go
+++ b/internal/contour/visitor_test.go
@@ -117,7 +117,7 @@ func TestVisitListeners(t *testing.T) {
 			want: listenermap(
 				&v2.Listener{
 					Name:    ENVOY_HTTPS_LISTENER,
-					Address: envoy.SocketAddress("0.0.0.0", 8443),
+					Address: *envoy.SocketAddress("0.0.0.0", 8443),
 					FilterChains: []listener.FilterChain{{
 						FilterChainMatch: &listener.FilterChainMatch{
 							ServerNames: []string{"tcpproxy.example.com"},

--- a/internal/e2e/lds_test.go
+++ b/internal/e2e/lds_test.go
@@ -71,7 +71,7 @@ func TestNonTLSListener(t *testing.T) {
 		Resources: []types.Any{
 			any(t, &v2.Listener{
 				Name:         "ingress_http",
-				Address:      envoy.SocketAddress("0.0.0.0", 8080),
+				Address:      *envoy.SocketAddress("0.0.0.0", 8080),
 				FilterChains: filterchain(envoy.HTTPConnectionManager("ingress_http", "/dev/stdout")),
 			}),
 		},
@@ -124,7 +124,7 @@ func TestNonTLSListener(t *testing.T) {
 		Resources: []types.Any{
 			any(t, &v2.Listener{
 				Name:         "ingress_http",
-				Address:      envoy.SocketAddress("0.0.0.0", 8080),
+				Address:      *envoy.SocketAddress("0.0.0.0", 8080),
 				FilterChains: filterchain(envoy.HTTPConnectionManager("ingress_http", "/dev/stdout")),
 			}),
 		},
@@ -182,12 +182,12 @@ func TestTLSListener(t *testing.T) {
 		Resources: []types.Any{
 			any(t, &v2.Listener{
 				Name:         "ingress_http",
-				Address:      envoy.SocketAddress("0.0.0.0", 8080),
+				Address:      *envoy.SocketAddress("0.0.0.0", 8080),
 				FilterChains: filterchain(envoy.HTTPConnectionManager("ingress_http", "/dev/stdout")),
 			}),
 			any(t, &v2.Listener{
 				Name:    "ingress_https",
-				Address: envoy.SocketAddress("0.0.0.0", 8443),
+				Address: *envoy.SocketAddress("0.0.0.0", 8443),
 				ListenerFilters: []listener.ListenerFilter{
 					envoy.TLSInspector(),
 				},
@@ -223,7 +223,7 @@ func TestTLSListener(t *testing.T) {
 		Resources: []types.Any{
 			any(t, &v2.Listener{
 				Name:    "ingress_https",
-				Address: envoy.SocketAddress("0.0.0.0", 8443),
+				Address: *envoy.SocketAddress("0.0.0.0", 8443),
 				ListenerFilters: []listener.ListenerFilter{
 					envoy.TLSInspector(),
 				},
@@ -321,7 +321,7 @@ func TestIngressRouteTLSListener(t *testing.T) {
 
 	l1 := &v2.Listener{
 		Name:    "ingress_https",
-		Address: envoy.SocketAddress("0.0.0.0", 8443),
+		Address: *envoy.SocketAddress("0.0.0.0", 8443),
 		ListenerFilters: []listener.ListenerFilter{
 			envoy.TLSInspector(),
 		},
@@ -337,7 +337,7 @@ func TestIngressRouteTLSListener(t *testing.T) {
 		Resources: []types.Any{
 			any(t, &v2.Listener{
 				Name:         "ingress_http",
-				Address:      envoy.SocketAddress("0.0.0.0", 8080),
+				Address:      *envoy.SocketAddress("0.0.0.0", 8080),
 				FilterChains: filterchain(envoy.HTTPConnectionManager("ingress_http", "/dev/stdout")),
 			}),
 			any(t, l1),
@@ -353,7 +353,7 @@ func TestIngressRouteTLSListener(t *testing.T) {
 		Resources: []types.Any{
 			any(t, &v2.Listener{
 				Name:         "ingress_http",
-				Address:      envoy.SocketAddress("0.0.0.0", 8080),
+				Address:      *envoy.SocketAddress("0.0.0.0", 8080),
 				FilterChains: filterchain(envoy.HTTPConnectionManager("ingress_http", "/dev/stdout")),
 			}),
 		},
@@ -366,7 +366,7 @@ func TestIngressRouteTLSListener(t *testing.T) {
 	rh.OnAdd(s1)
 	l2 := &v2.Listener{
 		Name:    "ingress_https",
-		Address: envoy.SocketAddress("0.0.0.0", 8443),
+		Address: *envoy.SocketAddress("0.0.0.0", 8443),
 		ListenerFilters: []listener.ListenerFilter{
 			envoy.TLSInspector(),
 		},
@@ -382,7 +382,7 @@ func TestIngressRouteTLSListener(t *testing.T) {
 		Resources: []types.Any{
 			any(t, &v2.Listener{
 				Name:         "ingress_http",
-				Address:      envoy.SocketAddress("0.0.0.0", 8080),
+				Address:      *envoy.SocketAddress("0.0.0.0", 8080),
 				FilterChains: filterchain(envoy.HTTPConnectionManager("ingress_http", "/dev/stdout")),
 			}),
 			any(t, l2),
@@ -433,7 +433,7 @@ func TestLDSFilter(t *testing.T) {
 		Resources: []types.Any{
 			any(t, &v2.Listener{
 				Name:    "ingress_https",
-				Address: envoy.SocketAddress("0.0.0.0", 8443),
+				Address: *envoy.SocketAddress("0.0.0.0", 8443),
 				ListenerFilters: []listener.ListenerFilter{
 					envoy.TLSInspector(),
 				},
@@ -451,7 +451,7 @@ func TestLDSFilter(t *testing.T) {
 
 			any(t, &v2.Listener{
 				Name:         "ingress_http",
-				Address:      envoy.SocketAddress("0.0.0.0", 8080),
+				Address:      *envoy.SocketAddress("0.0.0.0", 8080),
 				FilterChains: filterchain(envoy.HTTPConnectionManager("ingress_http", "/dev/stdout")),
 			}),
 		},
@@ -518,7 +518,7 @@ func TestLDSTLSMinimumProtocolVersion(t *testing.T) {
 		Resources: []types.Any{
 			any(t, &v2.Listener{
 				Name:    "ingress_https",
-				Address: envoy.SocketAddress("0.0.0.0", 8443),
+				Address: *envoy.SocketAddress("0.0.0.0", 8443),
 				ListenerFilters: []listener.ListenerFilter{
 					envoy.TLSInspector(),
 				},
@@ -551,7 +551,7 @@ func TestLDSTLSMinimumProtocolVersion(t *testing.T) {
 
 	l1 := &v2.Listener{
 		Name:    "ingress_https",
-		Address: envoy.SocketAddress("0.0.0.0", 8443),
+		Address: *envoy.SocketAddress("0.0.0.0", 8443),
 		ListenerFilters: []listener.ListenerFilter{
 			envoy.TLSInspector(),
 		},
@@ -604,7 +604,7 @@ func TestLDSIngressHTTPUseProxyProtocol(t *testing.T) {
 		Resources: []types.Any{
 			any(t, &v2.Listener{
 				Name:    "ingress_http",
-				Address: envoy.SocketAddress("0.0.0.0", 8080),
+				Address: *envoy.SocketAddress("0.0.0.0", 8080),
 				ListenerFilters: []listener.ListenerFilter{
 					envoy.ProxyProtocol(),
 				},
@@ -666,7 +666,7 @@ func TestLDSIngressHTTPSUseProxyProtocol(t *testing.T) {
 
 	ingress_https := &v2.Listener{
 		Name:    "ingress_https",
-		Address: envoy.SocketAddress("0.0.0.0", 8443),
+		Address: *envoy.SocketAddress("0.0.0.0", 8443),
 		ListenerFilters: []listener.ListenerFilter{
 			envoy.ProxyProtocol(),
 			envoy.TLSInspector(),
@@ -678,7 +678,7 @@ func TestLDSIngressHTTPSUseProxyProtocol(t *testing.T) {
 		Resources: []types.Any{
 			any(t, &v2.Listener{
 				Name:    "ingress_http",
-				Address: envoy.SocketAddress("0.0.0.0", 8080),
+				Address: *envoy.SocketAddress("0.0.0.0", 8080),
 				ListenerFilters: []listener.ListenerFilter{
 					envoy.ProxyProtocol(),
 				},
@@ -744,12 +744,12 @@ func TestLDSCustomAddressAndPort(t *testing.T) {
 
 	ingress_http := &v2.Listener{
 		Name:         "ingress_http",
-		Address:      envoy.SocketAddress("127.0.0.100", 9100),
+		Address:      *envoy.SocketAddress("127.0.0.100", 9100),
 		FilterChains: filterchain(envoy.HTTPConnectionManager("ingress_http", "/dev/stdout")),
 	}
 	ingress_https := &v2.Listener{
 		Name:    "ingress_https",
-		Address: envoy.SocketAddress("127.0.0.200", 9200),
+		Address: *envoy.SocketAddress("127.0.0.200", 9200),
 		ListenerFilters: []listener.ListenerFilter{
 			envoy.TLSInspector(),
 		},
@@ -810,7 +810,7 @@ func TestLDSIngressRouteInsideRootNamespaces(t *testing.T) {
 		Resources: []types.Any{
 			any(t, &v2.Listener{
 				Name:         "ingress_http",
-				Address:      envoy.SocketAddress("0.0.0.0", 8080),
+				Address:      *envoy.SocketAddress("0.0.0.0", 8080),
 				FilterChains: filterchain(envoy.HTTPConnectionManager("ingress_http", "/dev/stdout")),
 			}),
 		},
@@ -926,13 +926,13 @@ func TestIngressRouteHTTPS(t *testing.T) {
 
 	ingressHTTP := &v2.Listener{
 		Name:         "ingress_http",
-		Address:      envoy.SocketAddress("0.0.0.0", 8080),
+		Address:      *envoy.SocketAddress("0.0.0.0", 8080),
 		FilterChains: filterchain(envoy.HTTPConnectionManager("ingress_http", "/dev/stdout")),
 	}
 
 	ingressHTTPS := &v2.Listener{
 		Name:    "ingress_https",
-		Address: envoy.SocketAddress("0.0.0.0", 8443),
+		Address: *envoy.SocketAddress("0.0.0.0", 8443),
 		ListenerFilters: []listener.ListenerFilter{
 			envoy.TLSInspector(),
 		},
@@ -993,7 +993,7 @@ func TestLDSIngressRouteTCPProxyTLSPassthrough(t *testing.T) {
 
 	ingressHTTPS := &v2.Listener{
 		Name:    "ingress_https",
-		Address: envoy.SocketAddress("0.0.0.0", 8443),
+		Address: *envoy.SocketAddress("0.0.0.0", 8443),
 		FilterChains: []listener.FilterChain{{
 			Filters: []listener.Filter{
 				tcpproxy("ingress_https", "default/correct-backend/80/da39a3ee5e"),
@@ -1071,7 +1071,7 @@ func TestLDSIngressRouteTCPForward(t *testing.T) {
 
 	ingressHTTPS := &v2.Listener{
 		Name:         "ingress_https",
-		Address:      envoy.SocketAddress("0.0.0.0", 8443),
+		Address:      *envoy.SocketAddress("0.0.0.0", 8443),
 		FilterChains: filterchaintls("kuard-tcp.example.com", tcpproxy("ingress_https", "default/correct-backend/80/da39a3ee5e")),
 		ListenerFilters: []listener.ListenerFilter{
 			envoy.TLSInspector(),

--- a/internal/envoy/bootstrap_test.go
+++ b/internal/envoy/bootstrap_test.go
@@ -94,14 +94,25 @@ func TestBootstrap(t *testing.T) {
         "name": "contour",
         "type": "STRICT_DNS",
         "connect_timeout": "5s",
-        "hosts": [
-          {
-            "socket_address": {
-              "address": "127.0.0.1",
-              "port_value": 8001
+        "load_assignment": {
+          "cluster_name": "contour",
+          "endpoints": [
+            {
+              "lb_endpoints": [
+                {
+                  "endpoint": {
+                    "address": {
+                      "socket_address": {
+                        "address": "127.0.0.1",
+                        "port_value": 8001
+                      }
+                    }
+                  }
+                }
+              ]
             }
-          }
-        ],
+          ]
+        },
         "circuit_breakers": {
           "thresholds": [
             {
@@ -125,14 +136,25 @@ func TestBootstrap(t *testing.T) {
         "name": "service_stats",
         "type": "LOGICAL_DNS",
         "connect_timeout": "0.250s",
-        "hosts": [
-          {
-            "socket_address": {
-              "address": "127.0.0.1",
-              "port_value": 9001
+        "load_assignment": {
+          "cluster_name": "service_stats",
+          "endpoints": [   
+            {                          
+              "lb_endpoints": [
+                {
+                  "endpoint": {
+                    "address": {
+                      "socket_address": {
+                        "address": "127.0.0.1",
+                        "port_value": 9001
+                      }    
+                    }     
+                  }
+                }          
+              ]                        
             }
-          }
-        ]
+          ]
+        }
       }
     ]
   },
@@ -242,14 +264,25 @@ func TestBootstrap(t *testing.T) {
         "name": "contour",
         "type": "STRICT_DNS",
         "connect_timeout": "5s",
-        "hosts": [
-          {
-            "socket_address": {
-              "address": "127.0.0.1",
-              "port_value": 8001
+        "load_assignment": {
+          "cluster_name": "contour",
+          "endpoints": [
+            {
+              "lb_endpoints": [
+                {
+                  "endpoint": {
+                    "address": {
+                      "socket_address": {
+                        "address": "127.0.0.1",
+                        "port_value": 8001
+                      }
+                    }
+                  }
+                }
+              ]
             }
-          }
-        ],
+          ]
+        },
         "circuit_breakers": {
           "thresholds": [
             {
@@ -273,14 +306,25 @@ func TestBootstrap(t *testing.T) {
         "name": "service_stats",
         "type": "LOGICAL_DNS",
         "connect_timeout": "0.250s",
-        "hosts": [
-          {
-            "socket_address": {
-              "address": "127.0.0.1",
-              "port_value": 9001
+        "load_assignment": {
+          "cluster_name": "service_stats",
+          "endpoints": [   
+            {                          
+              "lb_endpoints": [
+                {
+                  "endpoint": {
+                    "address": {
+                      "socket_address": {
+                        "address": "127.0.0.1",
+                        "port_value": 9001
+                      }    
+                    }     
+                  }
+                }          
+              ]                        
             }
-          }
-        ]
+          ]
+        }
       }
     ]
   },
@@ -406,14 +450,25 @@ func TestBootstrap(t *testing.T) {
         "name": "contour",
         "type": "STRICT_DNS",
         "connect_timeout": "5s",
-        "hosts": [
-          {
-            "socket_address": {
-              "address": "127.0.0.1",
-              "port_value": 8001
+        "load_assignment": {
+          "cluster_name": "contour",
+          "endpoints": [
+            {
+              "lb_endpoints": [
+                {
+                  "endpoint": {
+                    "address": {
+                      "socket_address": {
+                        "address": "127.0.0.1",
+                        "port_value": 8001
+                      }
+                    }
+                  }
+                }
+              ]
             }
-          }
-        ],
+          ]
+        },
         "circuit_breakers": {
           "thresholds": [
             {
@@ -437,14 +492,25 @@ func TestBootstrap(t *testing.T) {
         "name": "service_stats",
         "type": "LOGICAL_DNS",
         "connect_timeout": "0.250s",
-        "hosts": [
-          {
-            "socket_address": {
-              "address": "127.0.0.1",
-              "port_value": 9001
+        "load_assignment": {
+          "cluster_name": "service_stats",
+          "endpoints": [   
+            {                          
+              "lb_endpoints": [
+                {
+                  "endpoint": {
+                    "address": {
+                      "socket_address": {
+                        "address": "127.0.0.1",
+                        "port_value": 9001
+                      }    
+                    }     
+                  }
+                }          
+              ]                        
             }
-          }
-        ]
+          ]
+        }
       }
     ]
   },
@@ -569,14 +635,25 @@ func TestBootstrap(t *testing.T) {
         "name": "contour",
         "type": "STRICT_DNS",
         "connect_timeout": "5s",
-        "hosts": [
-          {
-            "socket_address": {
-              "address": "127.0.0.1",
-              "port_value": 8001
+        "load_assignment": {
+          "cluster_name": "contour",
+          "endpoints": [
+            {
+              "lb_endpoints": [
+                {
+                  "endpoint": {
+                    "address": {
+                      "socket_address": {
+                        "address": "127.0.0.1",
+                        "port_value": 8001
+                      }
+                    }
+                  }
+                }
+              ]
             }
-          }
-        ],
+          ]
+        },
         "circuit_breakers": {
           "thresholds": [
             {
@@ -600,14 +677,25 @@ func TestBootstrap(t *testing.T) {
         "name": "service_stats",
         "type": "LOGICAL_DNS",
         "connect_timeout": "0.250s",
-        "hosts": [
-          {
-            "socket_address": {
-              "address": "8.8.8.8",
-              "port_value": 9200
+        "load_assignment": {
+          "cluster_name": "service_stats",
+          "endpoints": [   
+            {                          
+              "lb_endpoints": [
+                {
+                  "endpoint": {
+                    "address": {
+                      "socket_address": {
+                        "address": "8.8.8.8",
+                        "port_value": 9200
+                      }    
+                    }     
+                  }
+                }          
+              ]                        
             }
-          }
-        ]
+          ]
+        }
       }
     ]
   },
@@ -717,14 +805,25 @@ func TestBootstrap(t *testing.T) {
         "name": "contour",
         "type": "STRICT_DNS",
         "connect_timeout": "5s",
-        "hosts": [
-          {
-            "socket_address": {
-              "address": "127.0.0.1",
-              "port_value": 8001
+        "load_assignment": {
+          "cluster_name": "contour",
+          "endpoints": [
+            {
+              "lb_endpoints": [
+                {
+                  "endpoint": {
+                    "address": {
+                      "socket_address": {
+                        "address": "127.0.0.1",
+                        "port_value": 8001
+                      }
+                    }
+                  }
+                }
+              ]
             }
-          }
-        ],
+          ]
+        },
         "circuit_breakers": {
           "thresholds": [
             {
@@ -748,14 +847,25 @@ func TestBootstrap(t *testing.T) {
         "name": "service_stats",
         "type": "LOGICAL_DNS",
         "connect_timeout": "0.250s",
-        "hosts": [
-          {
-            "socket_address": {
-              "address": "127.0.0.1",
-              "port_value": 9001
+        "load_assignment": {
+          "cluster_name": "service_stats",
+          "endpoints": [   
+            {                          
+              "lb_endpoints": [
+                {
+                  "endpoint": {
+                    "address": {
+                      "socket_address": {
+                        "address": "127.0.0.1",
+                        "port_value": 9001
+                      }    
+                    }     
+                  }
+                }          
+              ]                        
             }
-          }
-        ]
+          ]
+        }
       }
     ]
   },
@@ -866,14 +976,25 @@ func TestBootstrap(t *testing.T) {
         "name": "contour",
         "type": "STRICT_DNS",
         "connect_timeout": "5s",
-        "hosts": [
-          {
-            "socket_address": {
-              "address": "8.8.8.8",
-              "port_value": 9200
+        "load_assignment": {
+          "cluster_name": "contour",
+          "endpoints": [
+            {
+              "lb_endpoints": [
+                {
+                  "endpoint": {
+                    "address": {
+                      "socket_address": {
+                        "address": "8.8.8.8",
+                        "port_value": 9200
+                      }
+                    }
+                  }
+                }
+              ]
             }
-          }
-        ],
+          ]
+        },
         "circuit_breakers": {
           "thresholds": [
             {
@@ -897,14 +1018,25 @@ func TestBootstrap(t *testing.T) {
         "name": "service_stats",
         "type": "LOGICAL_DNS",
         "connect_timeout": "0.250s",
-        "hosts": [
-          {
-            "socket_address": {
-              "address": "127.0.0.1",
-              "port_value": 9001
+        "load_assignment": {
+          "cluster_name": "service_stats",
+          "endpoints": [   
+            {                          
+              "lb_endpoints": [
+                {
+                  "endpoint": {
+                    "address": {
+                      "socket_address": {
+                        "address": "127.0.0.1",
+                        "port_value": 9001
+                      }    
+                    }     
+                  }
+                }          
+              ]                        
             }
-          }
-        ]
+          ]
+        }
       }
     ]
   },
@@ -1015,14 +1147,25 @@ func TestBootstrap(t *testing.T) {
         "name": "contour",
         "type": "STRICT_DNS",
         "connect_timeout": "5s",
-        "hosts": [
-          {
-            "socket_address": {
-              "address": "127.0.0.1",
-              "port_value": 8001
+        "load_assignment": {
+          "cluster_name": "contour",
+          "endpoints": [
+            {
+              "lb_endpoints": [
+                {
+                  "endpoint": {
+                    "address": {
+                      "socket_address": {
+                        "address": "127.0.0.1",
+                        "port_value": 8001
+                      }
+                    }
+                  }
+                }
+              ]
             }
-          }
-        ],
+          ]
+        },
         "circuit_breakers": {
           "thresholds": [
             {
@@ -1046,14 +1189,25 @@ func TestBootstrap(t *testing.T) {
         "name": "service_stats",
         "type": "LOGICAL_DNS",
         "connect_timeout": "0.250s",
-        "hosts": [
-          {
-            "socket_address": {
-              "address": "127.0.0.1",
-              "port_value": 9001
+        "load_assignment": {
+          "cluster_name": "service_stats",
+          "endpoints": [   
+            {                          
+              "lb_endpoints": [
+                {
+                  "endpoint": {
+                    "address": {
+                      "socket_address": {
+                        "address": "127.0.0.1",
+                        "port_value": 9001
+                      }    
+                    }     
+                  }
+                }          
+              ]                        
             }
-          }
-        ]
+          ]
+        }
       }
     ]
   },

--- a/internal/envoy/endpoint.go
+++ b/internal/envoy/endpoint.go
@@ -14,26 +14,15 @@
 package envoy
 
 import (
-	"github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2/endpoint"
 )
 
-// LBEndpoint creates a new SocketAddress LbEndpoint..
+// LBEndpoint creates a new SocketAddress LbEndpoint.
 func LBEndpoint(addr string, port int) endpoint.LbEndpoint {
 	return endpoint.LbEndpoint{
 		HostIdentifier: &endpoint.LbEndpoint_Endpoint{
 			Endpoint: &endpoint.Endpoint{
-				Address: &core.Address{
-					Address: &core.Address_SocketAddress{
-						SocketAddress: &core.SocketAddress{
-							Protocol: core.TCP,
-							Address:  addr,
-							PortSpecifier: &core.SocketAddress_PortValue{
-								PortValue: uint32(port),
-							},
-						},
-					},
-				},
+				Address: SocketAddress(addr, port),
 			},
 		},
 	}

--- a/internal/envoy/listener.go
+++ b/internal/envoy/listener.go
@@ -152,8 +152,8 @@ func (t tcpServiceByName) Less(i, j int) bool {
 }
 
 // SocketAddress creates a new TCP core.Address.
-func SocketAddress(address string, port int) core.Address {
-	return core.Address{
+func SocketAddress(address string, port int) *core.Address {
+	return &core.Address{
 		Address: &core.Address_SocketAddress{
 			SocketAddress: &core.SocketAddress{
 				Protocol: core.TCP,

--- a/internal/envoy/listener_test.go
+++ b/internal/envoy/listener_test.go
@@ -40,7 +40,7 @@ func TestSocketAddress(t *testing.T) {
 	)
 
 	got := SocketAddress(addr, port)
-	want := core.Address{
+	want := &core.Address{
 		Address: &core.Address_SocketAddress{
 			SocketAddress: &core.SocketAddress{
 				Protocol: core.TCP,


### PR DESCRIPTION
Updates #738

Address outstanding TODO in bootstrap configuration. Switch from
Cluster.Host to Cluster.LoadAssignment.

Signed-off-by: Dave Cheney <dave@cheney.net>