### PR TITLE
cmd/contour: reattach --envoy-service-http{s}-address flags

### DIFF
--- a/cmd/contour/contour.go
+++ b/cmd/contour/contour.go
@@ -126,6 +126,8 @@ func main() {
 	serve.Flag("envoy-https-access-log", "Envoy HTTPS access log").Default(contour.DEFAULT_HTTPS_ACCESS_LOG).StringVar(&ch.HTTPSAccessLog)
 	serve.Flag("envoy-external-http-port", "External port for HTTP requests").Default("80").IntVar(&reh.ExternalInsecurePort)
 	serve.Flag("envoy-external-https-port", "External port for HTTPS requests").Default("443").IntVar(&reh.ExternalSecurePort)
+	serve.Flag("envoy-service-http-address", "Kubernetes Service address for HTTP requests").Default("0.0.0.0").StringVar(&ch.HTTPAddress)
+	serve.Flag("envoy-service-https-address", "Kubernetes Service address for HTTPS requests").Default("0.0.0.0").StringVar(&ch.HTTPSAddress)
 	serve.Flag("envoy-service-http-port", "Kubernetes Service port for HTTP requests").Default("8080").IntVar(&ch.HTTPPort)
 	serve.Flag("envoy-service-https-port", "Kubernetes Service port for HTTPS requests").Default("8443").IntVar(&ch.HTTPSPort)
 	serve.Flag("use-proxy-protocol", "Use PROXY protocol for all listeners").BoolVar(&ch.UseProxyProto)


### PR DESCRIPTION
Fixes #895

that Envoy will listen on. Reintroduce this feature with two new flags

 --envoy-service-http-address
 --envoy-service-https-address

Which permit the address that Envoy will bind to as part of the service,
that is, in the container, or on the host via host networking.

Signed-off-by: Dave Cheney <dave@cheney.net>