### PR TITLE
internal/dag: implement TLS Certificate Delegation

### DIFF
--- a/design/tls-certificate-delegation.md
+++ b/design/tls-certificate-delegation.md
@@ -33,7 +33,7 @@ The implementation of this design is in three parts; the addition of a TLSCertif
 
 ### TLSCertificateDelegation CRD
 
-The TLSCertificateDelegation object records the permission to reference a Secret object from the namespace of the  TLSCertificateDelegation object to Ingress or IngressRoute objects in the target namespaces.
+The TLSCertificateDelegation object records the permission to reference a Secret object from the namespace of the TLSCertificateDelegation object to Ingress or IngressRoute objects in the target namespaces.
 This permission is managed by the Ingress controller which has the RBAC permissions to read all the relevant Secrets but currently only allows an Ingress or IngressRoute object to reference secrets from its own namespace.
 
 ```

--- a/internal/dag/builder_test.go
+++ b/internal/dag/builder_test.go
@@ -3930,6 +3930,58 @@ func TestEnforceRoute(t *testing.T) {
 	}
 }
 
+func TestSplitSecret(t *testing.T) {
+	tests := map[string]struct {
+		secret, defns string
+		want          meta
+	}{
+		"no namespace": {
+			secret: "secret",
+			defns:  "default",
+			want: meta{
+				name:      "secret",
+				namespace: "default",
+			},
+		},
+		"with namespace": {
+			secret: "ns1/secret",
+			defns:  "default",
+			want: meta{
+				name:      "secret",
+				namespace: "ns1",
+			},
+		},
+		"missing namespace": {
+			secret: "/secret",
+			defns:  "default",
+			want: meta{
+				name:      "secret",
+				namespace: "default",
+			},
+		},
+		"missing secret name": {
+			secret: "secret/",
+			defns:  "default",
+			want: meta{
+				name:      "",
+				namespace: "secret",
+			},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := splitSecret(tc.secret, tc.defns)
+			opts := []cmp.Option{
+				cmp.AllowUnexported(meta{}),
+			}
+			if diff := cmp.Diff(tc.want, got, opts...); diff != "" {
+				t.Fatal(diff)
+			}
+		})
+	}
+}
+
 func routemap(routes ...*Route) map[string]*Route {
 	m := make(map[string]*Route)
 	for _, r := range routes {


### PR DESCRIPTION
Fixes #905
Updates #410

This PR implements TLS Certificate Delegation for ingress (untested) and
ingressroute objects. See #889 for design.

Signed-off-by: Dave Cheney <dave@cheney.net>