### PR TITLE
Dockerfile: switch to scratch for the final image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,5 @@ COPY internal internal
 COPY apis apis
 RUN CGO_ENABLED=0 GOOS=linux GOFLAGS=-ldflags=-w go build -o /go/bin/contour -ldflags=-s -v github.com/heptio/contour/cmd/contour
 
-FROM alpine:3.8 AS final
-RUN apk --no-cache add ca-certificates
+FROM scratch AS final
 COPY --from=build /go/bin/contour /bin/contour


### PR DESCRIPTION
We don't need anything from Alpine, not even the certificates. If I need
the certs in the future I can copy them from the build container.

Signed-off-by: Dave Cheney <dave@cheney.net>