### PR TITLE
add a PR template outlining the contribution workflow

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -1,0 +1,10 @@
+<!--  Thanks for contributing to Contour!
+
+Before submitting a pull request, make sure you read about our Contribution Workflow here: https://github.com/heptio/contour/blob/master/CONTRIBUTING.md#contribution-workflow
+
+Some notable call outs from our Contribution Workflow:
+
+1. Contour operates according to the talk, then code rule. If you plan to submit a pull request for anything more than a typo or obvious bug fix, first you should raise an issue to discuss your proposal, before submitting any code.
+2. All commits to Contour must have a Developer Certificate of Origin (DCO) sign off. More about that here https://github.com/heptio/contour/blob/master/CONTRIBUTING.md#dco-sign-off
+
+-->


### PR DESCRIPTION
Addresses https://github.com/heptio/contour/issues/931

Adds a PR template which references the Contribution workflow. It specifically highlights two key points that I think can be common "gotchas" for new contributors:

1. Contour operates according to the talk, then code rule. If you plan to submit a pull request for anything more than a typo or obvious bug fix, first you should raise an issue to discuss your proposal, before submitting any code.
2. All commits to Contour must have a Developer Certificate of Origin (DCO) sign off. More about that here https://github.com/heptio/contour/blob/master/CONTRIBUTING.md#dco-sign-off