### PR TITLE
Fix split hostnet example not creating

### DIFF
--- a/deployment/ds-hostnet-split/03-contour.yaml
+++ b/deployment/ds-hostnet-split/03-contour.yaml
@@ -31,14 +31,10 @@ spec:
       - args:
         - serve
         - --incluster
-        - --xds-address
-        - 0.0.0.0
-        - --xds-port
-        - $(CONTOUR_SERVICE_PORT)
-        - --envoy-service-http-port
-        - 80
-        - --envoy-service-https-port
-        - 443
+        - --xds-address=0.0.0.0
+        - --xds-port=$(CONTOUR_SERVICE_PORT)
+        - --envoy-service-http-port=80
+        - --envoy-service-https-port=443
         command: ["contour"]
         image: gcr.io/heptio-images/contour:master
         imagePullPolicy: Always


### PR DESCRIPTION
The example hostnet-split example didn't have escaped strings for the host-ports causing an error when applying the manifest. 

Fixes #940 

Signed-off-by: Steve Sloka <slokas@vmware.com>