### PR TITLE
internal/grpc: do no use reflect.DeepEqual on errors

### DIFF
--- a/internal/grpc/xds_test.go
+++ b/internal/grpc/xds_test.go
@@ -59,7 +59,7 @@ func TestXDSHandlerFetch(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			_, got := tc.xh.fetch(tc.req)
-			if !reflect.DeepEqual(tc.want, got) {
+			if !equalError(tc.want, got) {
 				t.Fatalf("expected: %v, got: %v", tc.want, got)
 			}
 		})
@@ -182,7 +182,7 @@ func TestXDSHandlerStream(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			got := tc.xh.stream(tc.stream)
-			if !reflect.DeepEqual(tc.want, got) {
+			if !equalError(tc.want, got) {
 				t.Fatalf("expected: %v, got: %v", tc.want, got)
 			}
 		})
@@ -281,4 +281,14 @@ func TestCounterNext(t *testing.T) {
 			t.Fatalf("expected %d, got %d", tc.want, got)
 		}
 	}
+}
+
+func equalError(a, b error) bool {
+	if a == nil {
+		return b == nil
+	}
+	if b == nil {
+		return a == nil
+	}
+	return a.Error() == b.Error()
 }


### PR DESCRIPTION
Go 1.13 changed the internal representation of errors, they are no
longer comparable with DeepEqual.

Signed-off-by: Dave Cheney <dave@cheney.net>