### PR TITLE
Dockerfile: update for go modules

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,12 @@
 FROM golang:1.12.1 AS build
-WORKDIR /go/src/github.com/heptio/contour
+WORKDIR /contour
 
-ENV GO111MODULE on
-ENV GOFLAGS -mod=vendor
-COPY go.mod go.sum ./
+COPY go.mod ./
+RUN go mod download
 
 COPY cmd cmd
 COPY internal internal
 COPY apis apis
-RUN go mod vendor
 RUN CGO_ENABLED=0 GOOS=linux GOFLAGS=-ldflags=-w go build -o /go/bin/contour -ldflags=-s -v github.com/heptio/contour/cmd/contour
 
 FROM scratch AS final


### PR DESCRIPTION
- Build outside the implicit $GOPATH provided by golang:1.12.1. This
enables module mode without an ENV line
- Switch to go mod download to populate the build cache

Signed-off-by: Dave Cheney <dave@cheney.net>