### PR TITLE
internal/dag: adds validation for TLS secret for IngressRoute

### DIFF
--- a/internal/dag/builder_test.go
+++ b/internal/dag/builder_test.go
@@ -3598,6 +3598,30 @@ func TestDAGIngressRouteStatus(t *testing.T) {
 		},
 	}
 
+	// ir15 is a tls ingressroute without a TLS secret
+	ir15 := &ingressroutev1.IngressRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "simple",
+			Namespace: "roots",
+		},
+		Spec: ingressroutev1.IngressRouteSpec{
+			VirtualHost: &ingressroutev1.VirtualHost{
+				Fqdn: "simple.example.com",
+				TLS: &ingressroutev1.TLS{
+					SecretName:             "secret",
+					MinimumProtocolVersion: "1.1",
+				},
+			},
+			Routes: []ingressroutev1.Route{{
+				Match: "/",
+				Services: []ingressroutev1.Service{{
+					Name: "backend",
+					Port: 80,
+				}},
+			}},
+		},
+	}
+
 	tests := map[string]struct {
 		objs []*ingressroutev1.IngressRoute
 		want []Status
@@ -3670,6 +3694,10 @@ func TestDAGIngressRouteStatus(t *testing.T) {
 				{Object: ir11, Status: "valid", Description: "valid IngressRoute", Vhost: "example.com"},
 				{Object: ir10, Status: "valid", Description: "valid IngressRoute", Vhost: "example.com"},
 			},
+		},
+		"ingressroute does not have secret": {
+			objs: []*ingressroutev1.IngressRoute{ir15},
+			want: []Status{{Object: ir15, Status: "invalid", Description: "TLS secret not found"}},
 		},
 	}
 

--- a/internal/e2e/lds_test.go
+++ b/internal/e2e/lds_test.go
@@ -350,16 +350,11 @@ func TestIngressRouteTLSListener(t *testing.T) {
 	rh.OnDelete(s1)
 	assertEqual(t, &v2.DiscoveryResponse{
 		VersionInfo: "0",
-		Resources: []types.Any{
-			any(t, &v2.Listener{
-				Name:         "ingress_http",
-				Address:      *envoy.SocketAddress("0.0.0.0", 8080),
-				FilterChains: filterchain(envoy.HTTPConnectionManager("ingress_http", "/dev/stdout")),
-			}),
-		},
-		TypeUrl: listenerType,
-		Nonce:   "0",
+		Resources:   []types.Any{},
+		TypeUrl:     listenerType,
+		Nonce:       "0",
 	}, streamLDS(t, cc))
+	streamLDS(t, cc)
 
 	rh.OnDelete(i1)
 	// add secret


### PR DESCRIPTION
Sets the status on the IngressRoute as invalid if TLS secret is invalid

Signed-off-by: Amarnath <vaamarnath@gmail.com>

Updates #517