### PR TITLE
Allow '/' in tls secretName for certificate delegations

### DIFF
--- a/deployment/common/common.yaml
+++ b/deployment/common/common.yaml
@@ -57,7 +57,7 @@ spec:
                   properties:
                     secretName:
                       type: string
-                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$ # DNS-1123 subdomain
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?([\.\/][a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                     minimumProtocolVersion:
                       type: string
                       enum:

--- a/deployment/render/daemonset-rbac.yaml
+++ b/deployment/render/daemonset-rbac.yaml
@@ -60,7 +60,7 @@ spec:
                   properties:
                     secretName:
                       type: string
-                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$ # DNS-1123 subdomain
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?([\.\/][a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                     minimumProtocolVersion:
                       type: string
                       enum:

--- a/deployment/render/deployment-rbac.yaml
+++ b/deployment/render/deployment-rbac.yaml
@@ -60,7 +60,7 @@ spec:
                   properties:
                     secretName:
                       type: string
-                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$ # DNS-1123 subdomain
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?([\.\/][a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                     minimumProtocolVersion:
                       type: string
                       enum:


### PR DESCRIPTION
Fixes heptio/contour#965

As described in the issue, the current regex does not allow namespaced tls delegation secrets as `secretName` which was introduced in contour v0.10.0.

This implementation is not perfect since it allows multiple '/' which should not be valid. But IMO it's better than removing the regex validation until something better is in place.