### PR TITLE
Remove envoy deprecated flag "--v2-config-only"

### DIFF
--- a/deployment/deployment-grpc-v2/02-contour.yaml
+++ b/deployment/deployment-grpc-v2/02-contour.yaml
@@ -39,7 +39,6 @@ spec:
         - --service-cluster cluster0
         - --service-node node0
         - --log-level info
-        - --v2-config-only
         readinessProbe:
           httpGet:
             path: /healthz

--- a/deployment/ds-grpc-v2/02-contour.yaml
+++ b/deployment/ds-grpc-v2/02-contour.yaml
@@ -40,7 +40,6 @@ spec:
         - --service-cluster cluster0
         - --service-node node0
         - --log-level info
-        - --v2-config-only
         readinessProbe:
           httpGet:
             path: /healthz

--- a/deployment/ds-hostnet/02-contour.yaml
+++ b/deployment/ds-hostnet/02-contour.yaml
@@ -44,7 +44,6 @@ spec:
         - --service-cluster cluster0
         - --service-node node0
         - --log-level info
-        - --v2-config-only
         readinessProbe:
           httpGet:
             path: /healthz

--- a/deployment/render/daemonset-rbac.yaml
+++ b/deployment/render/daemonset-rbac.yaml
@@ -207,7 +207,6 @@ spec:
         - --service-cluster cluster0
         - --service-node node0
         - --log-level info
-        - --v2-config-only
         readinessProbe:
           httpGet:
             path: /healthz

--- a/deployment/render/deployment-rbac.yaml
+++ b/deployment/render/deployment-rbac.yaml
@@ -206,7 +206,6 @@ spec:
         - --service-cluster cluster0
         - --service-node node0
         - --log-level info
-        - --v2-config-only
         readinessProbe:
           httpGet:
             path: /healthz


### PR DESCRIPTION
Remove "--v2-config-only" option as it was already deprecated in
envoy 1.9.0 [1] and is already removed in envoy master. This is safe
just to be removed, there is nothing else needed to change as the link
says.

To create this patch I changed:
	ds-hostnet/02-contour.yaml
	ds-grpc-v2/02-contour.yaml
	deployment-grpc-v2/02-contour.yaml

And then run depoyment/render.sh script

[1]: https://www.envoyproxy.io/docs/envoy/v1.9.0/operations/cli#cmdoption-v2-config-only