### PR TITLE
deployment/render.sh: Run from any CWD

### DIFF
--- a/deployment/render.sh
+++ b/deployment/render.sh
@@ -1,5 +1,8 @@
 #! /bin/sh
 
+# Run correctly from any CWD
+cd $(dirname $0)
+
 ls ds-grpc-v2/*.yaml | xargs cat common/gen-warning.yaml > render/daemonset-rbac.yaml
 
 ls deployment-grpc-v2/*.yaml | xargs cat common/gen-warning.yaml > render/deployment-rbac.yaml


### PR DESCRIPTION
This just makes it possible to run the script from any current working
directory. Currently it should be run from /development only.

Signed-off-by: Rodrigo Campos <rodrigo@kinvolk.io>