### PR TITLE
deployment: add validation to enforce delegations is a list of objects

### DIFF
--- a/deployment/common/common.yaml
+++ b/deployment/common/common.yaml
@@ -161,4 +161,21 @@ spec:
   names:
     plural: tlscertificatedelegations
     kind: TLSCertificateDelegation
+  validation:
+    openAPIV3Schema:
+      properties:
+        spec:
+          properties:
+            delegations:
+              type: array
+              items:
+                type: object
+                required:
+                  - secretName
+                  - targetNamespaces
+                properties:
+                  match:
+                    type: string
+                  targetNamespaces:
+                    type: array
 ---

--- a/deployment/render/daemonset-rbac.yaml
+++ b/deployment/render/daemonset-rbac.yaml
@@ -164,6 +164,23 @@ spec:
   names:
     plural: tlscertificatedelegations
     kind: TLSCertificateDelegation
+  validation:
+    openAPIV3Schema:
+      properties:
+        spec:
+          properties:
+            delegations:
+              type: array
+              items:
+                type: object
+                required:
+                  - secretName
+                  - targetNamespaces
+                properties:
+                  match:
+                    type: string
+                  targetNamespaces:
+                    type: array
 ---
 apiVersion: extensions/v1beta1
 kind: DaemonSet

--- a/deployment/render/deployment-rbac.yaml
+++ b/deployment/render/deployment-rbac.yaml
@@ -164,6 +164,23 @@ spec:
   names:
     plural: tlscertificatedelegations
     kind: TLSCertificateDelegation
+  validation:
+    openAPIV3Schema:
+      properties:
+        spec:
+          properties:
+            delegations:
+              type: array
+              items:
+                type: object
+                required:
+                  - secretName
+                  - targetNamespaces
+                properties:
+                  match:
+                    type: string
+                  targetNamespaces:
+                    type: array
 ---
 apiVersion: extensions/v1beta1
 kind: Deployment

--- a/docs/ingressroute.md
+++ b/docs/ingressroute.md
@@ -286,9 +286,9 @@ metadata:
   namespace: www-admin
 spec:
   delegations:
-    secretName: example-com-wildcard
-    targetNamespaces:
-    - example-com
+    - secretName: example-com-wildcard
+      targetNamespaces:
+      - example-com
 ---
 apiVersion: contour.heptio.com/v1beta1
 kind: IngressRoute


### PR DESCRIPTION
Fixes #977

Also correct documentation that incorrectly stated that spec.delegations
was a singular key.

Signed-off-by: Dave Cheney <dave@cheney.net>