### PR TITLE
Upgrade Envoy to v1.9.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ local: $(LOCAL_BOOTSTRAP_CONFIG)
 		--mount type=bind,source=$(CURDIR),target=/config \
 		-p 9001:9001 \
 		-p 8002:8002 \
-		docker.io/envoyproxy/envoy-alpine:v1.9.0 \
+		docker.io/envoyproxy/envoy-alpine:v1.9.1 \
 		envoy \
 		--config-path /config/$< \
 		--service-node node0 \

--- a/deployment/deployment-grpc-v2/02-contour.yaml
+++ b/deployment/deployment-grpc-v2/02-contour.yaml
@@ -26,7 +26,7 @@ spec:
         name: contour
         command: ["contour"]
         args: ["serve", "--incluster"]
-      - image: docker.io/envoyproxy/envoy:v1.9.0
+      - image: docker.io/envoyproxy/envoy:v1.9.1
         name: envoy
         ports:
         - containerPort: 8080

--- a/deployment/ds-grpc-v2/02-contour.yaml
+++ b/deployment/ds-grpc-v2/02-contour.yaml
@@ -27,7 +27,7 @@ spec:
         name: contour
         command: ["contour"]
         args: ["serve", "--incluster"]
-      - image: docker.io/envoyproxy/envoy:v1.9.0
+      - image: docker.io/envoyproxy/envoy:v1.9.1
         name: envoy
         ports:
         - containerPort: 8080

--- a/deployment/ds-hostnet-split/03-envoy.yaml
+++ b/deployment/ds-hostnet-split/03-envoy.yaml
@@ -33,7 +33,7 @@ spec:
         - node0
         command:
         - envoy
-        image: docker.io/envoyproxy/envoy-alpine:v1.9.0
+        image: docker.io/envoyproxy/envoy:v1.9.1
         imagePullPolicy: IfNotPresent
         name: envoy
         ports:

--- a/deployment/ds-hostnet/02-contour.yaml
+++ b/deployment/ds-hostnet/02-contour.yaml
@@ -31,7 +31,7 @@ spec:
         name: contour
         command: ["contour"]
         args: ["serve", "--incluster"]
-      - image: docker.io/envoyproxy/envoy:v1.9.0
+      - image: docker.io/envoyproxy/envoy:v1.9.1
         name: envoy
         ports:
         - containerPort: 8080

--- a/deployment/render/daemonset-rbac.yaml
+++ b/deployment/render/daemonset-rbac.yaml
@@ -194,7 +194,7 @@ spec:
         name: contour
         command: ["contour"]
         args: ["serve", "--incluster"]
-      - image: docker.io/envoyproxy/envoy:v1.9.0
+      - image: docker.io/envoyproxy/envoy:v1.9.1
         name: envoy
         ports:
         - containerPort: 8080

--- a/deployment/render/deployment-rbac.yaml
+++ b/deployment/render/deployment-rbac.yaml
@@ -193,7 +193,7 @@ spec:
         name: contour
         command: ["contour"]
         args: ["serve", "--incluster"]
-      - image: docker.io/envoyproxy/envoy:v1.9.0
+      - image: docker.io/envoyproxy/envoy:v1.9.1
         name: envoy
         ports:
         - containerPort: 8080


### PR DESCRIPTION
Updates #983 by updating the example deployment files to use Envoy v1.9.1

Signed-off-by: Steve Sloka <slokas@vmware.com>