### PR TITLE
travis: switch to gocenter proxy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,9 @@ go:
 
 sudo: false
 
+env:
+  - GOPROXY=https://gocenter.io
+
 install:
   - make download
 


### PR DESCRIPTION
Try to make the build more stable by using gocenter as a proxy rather than
direct to github.

Signed-off-by: Dave Cheney <dave@cheney.net>