### PR TITLE
internal/envoy: enable normalize_paths

### DIFF
--- a/internal/envoy/bootstrap.go
+++ b/internal/envoy/bootstrap.go
@@ -82,6 +82,7 @@ func Bootstrap(c *BootstrapConfig) *bootstrap.Bootstrap {
 											"name": sv(util.Router),
 										}),
 									),
+									"normalize_path": {Kind: &types.Value_BoolValue{BoolValue: true}},
 								},
 							},
 						},

--- a/internal/envoy/bootstrap_test.go
+++ b/internal/envoy/bootstrap_test.go
@@ -81,7 +81,8 @@ func TestBootstrap(t *testing.T) {
                       ]
                     }
                   },
-                  "stat_prefix": "stats"
+                  "stat_prefix": "stats",
+                  "normalize_path": true
                 }
               }
             ]
@@ -251,7 +252,8 @@ func TestBootstrap(t *testing.T) {
                       ]
                     }
                   },
-                  "stat_prefix": "stats"
+                  "stat_prefix": "stats",
+                  "normalize_path": true
                 }
               }
             ]
@@ -437,7 +439,8 @@ func TestBootstrap(t *testing.T) {
                       ]
                     }
                   },
-                  "stat_prefix": "stats"
+                  "stat_prefix": "stats",
+                  "normalize_path": true
                 }
               }
             ]
@@ -622,7 +625,8 @@ func TestBootstrap(t *testing.T) {
                       ]
                     }
                   },
-                  "stat_prefix": "stats"
+                  "stat_prefix": "stats",
+                  "normalize_path": true
                 }
               }
             ]
@@ -792,7 +796,8 @@ func TestBootstrap(t *testing.T) {
                       ]
                     }
                   },
-                  "stat_prefix": "stats"
+                  "stat_prefix": "stats",
+                  "normalize_path": true
                 }
               }
             ]
@@ -963,7 +968,8 @@ func TestBootstrap(t *testing.T) {
                       ]
                     }
                   },
-                  "stat_prefix": "stats"
+                  "stat_prefix": "stats",
+                  "normalize_path": true
                 }
               }
             ]
@@ -1134,7 +1140,8 @@ func TestBootstrap(t *testing.T) {
                       ]
                     }
                   },
-                  "stat_prefix": "stats"
+                  "stat_prefix": "stats",
+                  "normalize_path": true
                 }
               }
             ]

--- a/internal/envoy/listener.go
+++ b/internal/envoy/listener.go
@@ -102,6 +102,7 @@ func HTTPConnectionManager(routename, accessLogPath string) listener.Filter {
 					}),
 					"access_log":         accesslog(accessLogPath),
 					"use_remote_address": {Kind: &types.Value_BoolValue{BoolValue: true}}, // TODO(jbeda) should this ever be false?
+					"normalize_path":     {Kind: &types.Value_BoolValue{BoolValue: true}},
 				},
 			},
 		},


### PR DESCRIPTION
Updates #983

Turn on the normalise_paths option for all http_connection_manager
instances. This field is recognised by Envoy 1.9.1 and is necessary to
mitigate CVE-2019-9901.

Signed-off-by: Dave Cheney <dave@cheney.net>