### PR TITLE
Dockerfile: use gocenter.io as proxy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM golang:1.12.1 AS build
 WORKDIR /contour
 
+ENV GOPROXY=https://gocenter.io
 COPY go.mod ./
 RUN go mod download
 


### PR DESCRIPTION
This matches travis.yml.

Signed-off-by: Dave Cheney <dave@cheney.net>