### PR TITLE
design: fix build

### DIFF
--- a/design/custom-request-timeout.md
+++ b/design/custom-request-timeout.md
@@ -18,7 +18,7 @@ This document describes the design of a new resource in IngressRoute for custom 
 Contour supports custom request timeout and custom retry attempts via [Ingress Annotations](https://github.com/heptio/contour/blob/master/docs/annotations.md).
 We wish to expose the same same functionality has been requested via IngressRoute as well.
 
-Additionally, request and retry behaviour apply to any interaction that 
+Additionally, request and retry behavior apply to any interaction that 
 
 # High-level design
 

--- a/go.mod
+++ b/go.mod
@@ -12,12 +12,14 @@ require (
 	github.com/google/go-cmp v0.2.0
 	github.com/google/gofuzz v0.0.0-20170612174753-24818f796faf // indirect
 	github.com/googleapis/gnostic v0.2.0 // indirect
+	github.com/gordonklaus/ineffassign v0.0.0-20180909121442-1003c8bd00dc // indirect
 	github.com/gregjones/httpcache v0.0.0-20181110185634-c63ab54fda8f // indirect
 	github.com/hashicorp/golang-lru v0.5.0 // indirect
 	github.com/heptio/workgroup v0.8.0-beta.1
 	github.com/imdario/mergo v0.3.7 // indirect
 	github.com/json-iterator/go v1.1.5 // indirect
 	github.com/lyft/protoc-gen-validate v0.0.12 // indirect
+	github.com/mdempsky/unconvert v0.0.0-20190117010209-2db5a8ead8e7 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742 // indirect
 	github.com/onsi/ginkgo v1.8.0 // indirect


### PR DESCRIPTION
Fix en-GB spelling in recently comitted design document. Also, give up
on the land war in asia over including test dependencies in go.mod.

Signed-off-by: Dave Cheney <dave@cheney.net>