### PR TITLE
Always let glog write to stderr not files

### DIFF
--- a/cmd/contour/contour.go
+++ b/cmd/contour/contour.go
@@ -163,6 +163,11 @@ func main() {
 		// this point to avoid the Go flag package from rejecting flags which are defined
 		// in kingpin. See #371
 		flag.Parse()
+		// Always let glog logs to stderr rather than files. Otherwise,
+		// once it attempts to log to files under /tmp, will crash the
+		// whole process since the path may not be accessible in
+		// container environment. See #959
+		flag.Lookup("logtostderr").Value.Set("true")
 
 		reh.IngressRouteRootNamespaces = parseRootNamespaces(ingressrouteRootNamespaceFlag)
 


### PR DESCRIPTION
Related to #959

Client-go uses glog even though Contour by itself doesn't. In the
failure scenario, such as CRD types not registered, glog in client-go
attempts to log to files under /tmp, which may not even exist (e.g in
`scratch` Docker image) or not accessible (container started with
non-root user etc.). And when that happens it'll crash the whole Contour
process which should not happen.

This change overrides the glog flag to let it always dumping to stderr,
avoid logging to files which is not desired in container environment

Signed-off-by: Qiu Yu <unicell@gmail.com>