### PR TITLE
remove AES128-* and AES256-* from permitted ciphers list

### DIFF
--- a/internal/envoy/auth.go
+++ b/internal/envoy/auth.go
@@ -18,6 +18,32 @@ import (
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 )
 
+var (
+	// This is the list of default ciphers used by contour 1.9.1. A handful are
+	// commented out, as they're arguably less secure. They're also unnecessary
+	// - most of the clients that might need to use the commented ciphers are
+	// unable to connect without TLS 1.0, which contour never enables.
+	//
+	// This list is ignored if the client and server negotiate TLS 1.3.
+	//
+	// The commented ciphers are left in place to simplify updating this list for future
+	// versions of envoy.
+	ciphers = []string{
+		"[ECDHE-ECDSA-AES128-GCM-SHA256|ECDHE-ECDSA-CHACHA20-POLY1305]",
+		"[ECDHE-RSA-AES128-GCM-SHA256|ECDHE-RSA-CHACHA20-POLY1305]",
+		"ECDHE-ECDSA-AES128-SHA",
+		"ECDHE-RSA-AES128-SHA",
+		//"AES128-GCM-SHA256",
+		//"AES128-SHA",
+		"ECDHE-ECDSA-AES256-GCM-SHA384",
+		"ECDHE-RSA-AES256-GCM-SHA384",
+		"ECDHE-ECDSA-AES256-SHA",
+		"ECDHE-RSA-AES256-SHA",
+		//"AES256-GCM-SHA384",
+		//"AES256-SHA",
+	}
+)
+
 // UpstreamTLSContext creates an auth.UpstreamTlsContext. By default
 // UpstreamTLSContext returns a HTTP/1.1 TLS enabled context. A list of
 // additional ALPN protocols can be provided.
@@ -36,6 +62,7 @@ func DownstreamTLSContext(cert, key []byte, tlsMinProtoVersion auth.TlsParameter
 			TlsParams: &auth.TlsParameters{
 				TlsMinimumProtocolVersion: tlsMinProtoVersion,
 				TlsMaximumProtocolVersion: auth.TlsParameters_TLSv1_3,
+				CipherSuites:              ciphers,
 			},
 			TlsCertificates: []*auth.TlsCertificate{{
 				CertificateChain: &core.DataSource{

--- a/internal/envoy/listener_test.go
+++ b/internal/envoy/listener_test.go
@@ -158,6 +158,16 @@ func TestDownstreamTLSContext(t *testing.T) {
 			TlsParams: &auth.TlsParameters{
 				TlsMinimumProtocolVersion: auth.TlsParameters_TLSv1_1,
 				TlsMaximumProtocolVersion: auth.TlsParameters_TLSv1_3,
+				CipherSuites: []string{
+					"[ECDHE-ECDSA-AES128-GCM-SHA256|ECDHE-ECDSA-CHACHA20-POLY1305]",
+					"[ECDHE-RSA-AES128-GCM-SHA256|ECDHE-RSA-CHACHA20-POLY1305]",
+					"ECDHE-ECDSA-AES128-SHA",
+					"ECDHE-RSA-AES128-SHA",
+					"ECDHE-ECDSA-AES256-GCM-SHA384",
+					"ECDHE-RSA-AES256-GCM-SHA384",
+					"ECDHE-ECDSA-AES256-SHA",
+					"ECDHE-RSA-AES256-SHA",
+				},
 			},
 			TlsCertificates: []*auth.TlsCertificate{{
 				CertificateChain: &core.DataSource{


### PR DESCRIPTION
The full list of ciphers that envoy permits by default are listed at [here](https://www.envoyproxy.io/docs/envoy/v1.9.1/api-v2/api/v2/auth/cert.proto.html?highlight=ciphers).

The defaults rate an "A" on qualy's ssl labs, however the AES128-* and AES256-* ciphers are marked as "weak". This appears to be for a combination of two reasons:

1. They don't support [Forward Secrecy](https://en.wikipedia.org/wiki/Forward_secrecy
)
2. They are easy to implement wrongly, exposing users to the [ROBOT attack](https://robotattack.org/
). Presumably boringssl (which envoy uses) has implemented them correctly, but it seems the general [recommendation is to avoid them if possible, just in case](https://community.qualys.com/thread/17971-tlsrsawithaes256cbcsha-comes-to-be-weak-cipher#comment-39790).

Removing these ciphers doesn't improve the overall qualy's score, but it does remove the "weak" flags from the list of supported ciphers.

In practice, this is unlikely to hurt client compatibility for users of contour. Most of the clients that might need to use the removed ciphers (like windows XP, java 6+7, and android <= 4.3) are unable to connect without TLS 1.0, which contour never enables.

This cipher list is also ignored when a connection negotiates TLS 1.3. I'm not sure why that is, but the [envoy docs seems pretty clear](https://www.envoyproxy.io/docs/envoy/v1.10.0/api-v2/api/v2/auth/cert.proto.html?highlight=ciphers):

> this setting has no effect when negotiating TLS 1.3

Closes #823