### PR TITLE
internal/grpc: increment version_info on each response

### DIFF
--- a/internal/e2e/cds_test.go
+++ b/internal/e2e/cds_test.go
@@ -63,12 +63,12 @@ func TestClusterLongServiceName(t *testing.T) {
 
 	// check that it's been translated correctly.
 	assertEqual(t, &v2.DiscoveryResponse{
-		VersionInfo: "0",
+		VersionInfo: "2",
 		Resources: []types.Any{
 			any(t, cluster("default/kbujbkuh-c83ceb/8080/da39a3ee5e", "default/kbujbkuhdod66gjdmwmijz8xzgsx1nkfbrloezdjiulquzk4x3p0nnvpzi8r", "default_kbujbkuhdod66gjdmwmijz8xzgsx1nkfbrloezdjiulquzk4x3p0nnvpzi8r_8080")),
 		},
 		TypeUrl: clusterType,
-		Nonce:   "0",
+		Nonce:   "2",
 	}, streamCDS(t, cc))
 }
 
@@ -125,12 +125,12 @@ func TestClusterAddUpdateDelete(t *testing.T) {
 	rh.OnAdd(s1)
 
 	assertEqual(t, &v2.DiscoveryResponse{
-		VersionInfo: "0",
+		VersionInfo: "3",
 		Resources: []types.Any{
 			any(t, cluster("default/kuard/80/da39a3ee5e", "default/kuard", "default_kuard_80")),
 		},
 		TypeUrl: clusterType,
-		Nonce:   "0",
+		Nonce:   "3",
 	}, streamCDS(t, cc))
 
 	// s2 is the same as s2, but the service port has a name
@@ -146,12 +146,12 @@ func TestClusterAddUpdateDelete(t *testing.T) {
 
 	// check that we get two CDS records because the port is now named.
 	assertEqual(t, &v2.DiscoveryResponse{
-		VersionInfo: "0",
+		VersionInfo: "4",
 		Resources: []types.Any{
 			any(t, cluster("default/kuard/80/da39a3ee5e", "default/kuard/http", "default_kuard_80")),
 		},
 		TypeUrl: clusterType,
-		Nonce:   "0",
+		Nonce:   "4",
 	}, streamCDS(t, cc))
 
 	// s3 is like s2, but has a second named port. The k8s spec
@@ -177,13 +177,13 @@ func TestClusterAddUpdateDelete(t *testing.T) {
 	// check that we get four CDS records. Order is important
 	// because the CDS cache is sorted.
 	assertEqual(t, &v2.DiscoveryResponse{
-		VersionInfo: "0",
+		VersionInfo: "5",
 		Resources: []types.Any{
 			any(t, cluster("default/kuard/443/da39a3ee5e", "default/kuard/https", "default_kuard_443")),
 			any(t, cluster("default/kuard/80/da39a3ee5e", "default/kuard/http", "default_kuard_80")),
 		},
 		TypeUrl: clusterType,
-		Nonce:   "0",
+		Nonce:   "5",
 	}, streamCDS(t, cc))
 
 	// s4 is s3 with the http port removed.
@@ -202,12 +202,12 @@ func TestClusterAddUpdateDelete(t *testing.T) {
 	// check that we get two CDS records only, and that the 80 and http
 	// records have been removed even though the service object remains.
 	assertEqual(t, &v2.DiscoveryResponse{
-		VersionInfo: "0",
+		VersionInfo: "6",
 		Resources: []types.Any{
 			any(t, cluster("default/kuard/443/da39a3ee5e", "default/kuard/https", "default_kuard_443")),
 		},
 		TypeUrl: clusterType,
-		Nonce:   "0",
+		Nonce:   "6",
 	}, streamCDS(t, cc))
 }
 
@@ -262,13 +262,13 @@ func TestClusterRenameUpdateDelete(t *testing.T) {
 
 	rh.OnAdd(s1)
 	assertEqual(t, &v2.DiscoveryResponse{
-		VersionInfo: "0",
+		VersionInfo: "2",
 		Resources: []types.Any{
 			any(t, cluster("default/kuard/443/da39a3ee5e", "default/kuard/https", "default_kuard_443")),
 			any(t, cluster("default/kuard/80/da39a3ee5e", "default/kuard/http", "default_kuard_80")),
 		},
 		TypeUrl: clusterType,
-		Nonce:   "0",
+		Nonce:   "2",
 	}, streamCDS(t, cc))
 
 	// s2 removes the name on port 80, moves it to port 443 and deletes the https port
@@ -282,33 +282,33 @@ func TestClusterRenameUpdateDelete(t *testing.T) {
 
 	rh.OnUpdate(s1, s2)
 	assertEqual(t, &v2.DiscoveryResponse{
-		VersionInfo: "0",
+		VersionInfo: "3",
 		Resources: []types.Any{
 			any(t, cluster("default/kuard/443/da39a3ee5e", "default/kuard", "default_kuard_443")),
 		},
 		TypeUrl: clusterType,
-		Nonce:   "0",
+		Nonce:   "3",
 	}, streamCDS(t, cc))
 
 	// now replace s2 with s1 to check it works in the other direction.
 	rh.OnUpdate(s2, s1)
 	assertEqual(t, &v2.DiscoveryResponse{
-		VersionInfo: "0",
+		VersionInfo: "4",
 		Resources: []types.Any{
 			any(t, cluster("default/kuard/443/da39a3ee5e", "default/kuard/https", "default_kuard_443")),
 			any(t, cluster("default/kuard/80/da39a3ee5e", "default/kuard/http", "default_kuard_80")),
 		},
 		TypeUrl: clusterType,
-		Nonce:   "0",
+		Nonce:   "4",
 	}, streamCDS(t, cc))
 
 	// cleanup and check
 	rh.OnDelete(s1)
 	assertEqual(t, &v2.DiscoveryResponse{
-		VersionInfo: "0",
+		VersionInfo: "5",
 		Resources:   []types.Any{},
 		TypeUrl:     clusterType,
-		Nonce:       "0",
+		Nonce:       "5",
 	}, streamCDS(t, cc))
 }
 
@@ -341,12 +341,12 @@ func TestIssue243(t *testing.T) {
 		)
 		rh.OnAdd(s1)
 		assertEqual(t, &v2.DiscoveryResponse{
-			VersionInfo: "0",
+			VersionInfo: "2",
 			Resources: []types.Any{
 				any(t, cluster("default/kuard/80/da39a3ee5e", "default/kuard", "default_kuard_80")),
 			},
 			TypeUrl: clusterType,
-			Nonce:   "0",
+			Nonce:   "2",
 		}, streamCDS(t, cc))
 	})
 }
@@ -384,12 +384,12 @@ func TestIssue247(t *testing.T) {
 	)
 	rh.OnAdd(s1)
 	assertEqual(t, &v2.DiscoveryResponse{
-		VersionInfo: "0",
+		VersionInfo: "2",
 		Resources: []types.Any{
 			any(t, cluster("default/kuard/80/da39a3ee5e", "default/kuard", "default_kuard_80")),
 		},
 		TypeUrl: clusterType,
-		Nonce:   "0",
+		Nonce:   "2",
 	}, streamCDS(t, cc))
 }
 func TestCDSResourceFiltering(t *testing.T) {
@@ -443,32 +443,32 @@ func TestCDSResourceFiltering(t *testing.T) {
 	)
 	rh.OnAdd(s2)
 	assertEqual(t, &v2.DiscoveryResponse{
-		VersionInfo: "0",
+		VersionInfo: "3",
 		Resources: []types.Any{
 			// note, resources are sorted by Cluster.Name
 			any(t, cluster("default/httpbin/8080/da39a3ee5e", "default/httpbin", "default_httpbin_8080")),
 			any(t, cluster("default/kuard/80/da39a3ee5e", "default/kuard", "default_kuard_80")),
 		},
 		TypeUrl: clusterType,
-		Nonce:   "0",
+		Nonce:   "3",
 	}, streamCDS(t, cc))
 
 	// assert we can filter on one resource
 	assertEqual(t, &v2.DiscoveryResponse{
-		VersionInfo: "0",
+		VersionInfo: "3",
 		Resources: []types.Any{
 			any(t, cluster("default/kuard/80/da39a3ee5e", "default/kuard", "default_kuard_80")),
 		},
 		TypeUrl: clusterType,
-		Nonce:   "0",
+		Nonce:   "3",
 	}, streamCDS(t, cc, "default/kuard/80/da39a3ee5e"))
 
 	// assert a non matching filter returns no results
 	// note: streamCDS would stall at this point.
 	assertEqual(t, &v2.DiscoveryResponse{
-		VersionInfo: "0",
+		VersionInfo: "3",
 		TypeUrl:     clusterType,
-		Nonce:       "0",
+		Nonce:       "3",
 	}, streamCDS(t, cc, "default/httpbin/9000"))
 }
 
@@ -509,7 +509,7 @@ func TestClusterCircuitbreakerAnnotations(t *testing.T) {
 
 	// check that it's been translated correctly.
 	assertEqual(t, &v2.DiscoveryResponse{
-		VersionInfo: "0",
+		VersionInfo: "2",
 		Resources: []types.Any{
 			any(t, &v2.Cluster{
 				Name:                 "default/kuard/8080/da39a3ee5e",
@@ -533,7 +533,7 @@ func TestClusterCircuitbreakerAnnotations(t *testing.T) {
 			}),
 		},
 		TypeUrl: clusterType,
-		Nonce:   "0",
+		Nonce:   "2",
 	}, streamCDS(t, cc))
 
 	// update s1 with slightly weird values
@@ -555,7 +555,7 @@ func TestClusterCircuitbreakerAnnotations(t *testing.T) {
 
 	// check that it's been translated correctly.
 	assertEqual(t, &v2.DiscoveryResponse{
-		VersionInfo: "0",
+		VersionInfo: "3",
 		Resources: []types.Any{
 			any(t, &v2.Cluster{
 				Name:                 "default/kuard/8080/da39a3ee5e",
@@ -576,7 +576,7 @@ func TestClusterCircuitbreakerAnnotations(t *testing.T) {
 			}),
 		},
 		TypeUrl: clusterType,
-		Nonce:   "0",
+		Nonce:   "3",
 	}, streamCDS(t, cc))
 }
 
@@ -626,12 +626,12 @@ func TestClusterPerServiceParameters(t *testing.T) {
 	})
 
 	assertEqual(t, &v2.DiscoveryResponse{
-		VersionInfo: "0",
+		VersionInfo: "2",
 		Resources: []types.Any{
 			any(t, cluster("default/kuard/80/da39a3ee5e", "default/kuard", "default_kuard_80")),
 		},
 		TypeUrl: clusterType,
-		Nonce:   "0",
+		Nonce:   "2",
 	}, streamCDS(t, cc))
 }
 
@@ -681,7 +681,7 @@ func TestClusterLoadBalancerStrategyPerRoute(t *testing.T) {
 	})
 
 	assertEqual(t, &v2.DiscoveryResponse{
-		VersionInfo: "0",
+		VersionInfo: "2",
 		Resources: []types.Any{
 			any(t, &v2.Cluster{
 				Name:                 "default/kuard/80/58d888c08a",
@@ -709,7 +709,7 @@ func TestClusterLoadBalancerStrategyPerRoute(t *testing.T) {
 			}),
 		},
 		TypeUrl: clusterType,
-		Nonce:   "0",
+		Nonce:   "2",
 	}, streamCDS(t, cc))
 }
 
@@ -753,12 +753,12 @@ func TestClusterWithHealthChecks(t *testing.T) {
 	})
 
 	assertEqual(t, &v2.DiscoveryResponse{
-		VersionInfo: "0",
+		VersionInfo: "2",
 		Resources: []types.Any{
 			any(t, clusterWithHealthCheck("default/kuard/80/bc862a33ca", "default/kuard", "default_kuard_80", "/healthz", true)),
 		},
 		TypeUrl: clusterType,
-		Nonce:   "0",
+		Nonce:   "2",
 	}, streamCDS(t, cc))
 }
 
@@ -804,12 +804,12 @@ func TestClusterServiceTLSBackend(t *testing.T) {
 	want := tlscluster("default/kuard/443/da39a3ee5e", "default/kuard/securebackend", "default_kuard_443")
 
 	assertEqual(t, &v2.DiscoveryResponse{
-		VersionInfo: "0",
+		VersionInfo: "2",
 		Resources: []types.Any{
 			any(t, want),
 		},
 		TypeUrl: clusterType,
-		Nonce:   "0",
+		Nonce:   "2",
 	}, streamCDS(t, cc))
 }
 

--- a/internal/e2e/eds_test.go
+++ b/internal/e2e/eds_test.go
@@ -57,7 +57,7 @@ func TestAddRemoveEndpoints(t *testing.T) {
 
 	// check that it's been translated correctly.
 	assertEqual(t, &v2.DiscoveryResponse{
-		VersionInfo: "0",
+		VersionInfo: "1",
 		Resources: []types.Any{
 			any(t, clusterloadassignment(
 				"super-long-namespace-name-oh-boy/what-a-descriptive-service-name-you-must-be-so-proud/http",
@@ -71,17 +71,17 @@ func TestAddRemoveEndpoints(t *testing.T) {
 			)),
 		},
 		TypeUrl: endpointType,
-		Nonce:   "0",
+		Nonce:   "1",
 	}, streamEDS(t, cc))
 
 	// remove e1 and check that the EDS cache is now empty.
 	rh.OnDelete(e1)
 
 	assertEqual(t, &v2.DiscoveryResponse{
-		VersionInfo: "0",
+		VersionInfo: "2",
 		Resources:   []types.Any{},
 		TypeUrl:     endpointType,
-		Nonce:       "0",
+		Nonce:       "2",
 	}, streamEDS(t, cc))
 }
 
@@ -139,7 +139,7 @@ func TestAddEndpointComplicated(t *testing.T) {
 	rh.OnAdd(e1)
 
 	assertEqual(t, &v2.DiscoveryResponse{
-		VersionInfo: "0",
+		VersionInfo: "1",
 		Resources: []types.Any{
 			any(t, clusterloadassignment(
 				"default/kuard/admin",
@@ -153,7 +153,7 @@ func TestAddEndpointComplicated(t *testing.T) {
 			)),
 		},
 		TypeUrl: endpointType,
-		Nonce:   "0",
+		Nonce:   "1",
 	}, streamEDS(t, cc))
 }
 
@@ -199,7 +199,7 @@ func TestEndpointFilter(t *testing.T) {
 	rh.OnAdd(e1)
 
 	assertEqual(t, &v2.DiscoveryResponse{
-		VersionInfo: "0",
+		VersionInfo: "1",
 		Resources: []types.Any{
 			any(t, clusterloadassignment(
 				"default/kuard/foo",
@@ -208,13 +208,13 @@ func TestEndpointFilter(t *testing.T) {
 			)),
 		},
 		TypeUrl: endpointType,
-		Nonce:   "0",
+		Nonce:   "1",
 	}, streamEDS(t, cc, "default/kuard/foo"))
 
 	assertEqual(t, &v2.DiscoveryResponse{
-		VersionInfo: "0",
+		VersionInfo: "1",
 		TypeUrl:     endpointType,
-		Nonce:       "0",
+		Nonce:       "1",
 	}, streamEDS(t, cc, "default/kuard/bar"))
 
 }
@@ -235,12 +235,12 @@ func TestIssue602(t *testing.T) {
 
 	// Assert endpoint was added
 	assertEqual(t, &v2.DiscoveryResponse{
-		VersionInfo: "0",
+		VersionInfo: "1",
 		Resources: []types.Any{
 			any(t, clusterloadassignment("default/simple", envoy.LBEndpoint("192.168.183.24", 8080))),
 		},
 		TypeUrl: endpointType,
-		Nonce:   "0",
+		Nonce:   "1",
 	}, streamEDS(t, cc))
 
 	// e2 is the same as e1, but without endpoint subsets
@@ -248,10 +248,10 @@ func TestIssue602(t *testing.T) {
 	rh.OnUpdate(e1, e2)
 
 	assertEqual(t, &v2.DiscoveryResponse{
-		VersionInfo: "0",
+		VersionInfo: "2",
 		Resources:   []types.Any{},
 		TypeUrl:     endpointType,
-		Nonce:       "0",
+		Nonce:       "2",
 	}, streamEDS(t, cc))
 }
 

--- a/internal/e2e/lds_test.go
+++ b/internal/e2e/lds_test.go
@@ -67,7 +67,7 @@ func TestNonTLSListener(t *testing.T) {
 	// add it and assert that we now have a ingress_http listener
 	rh.OnAdd(i1)
 	assertEqual(t, &v2.DiscoveryResponse{
-		VersionInfo: "0",
+		VersionInfo: "1",
 		Resources: []types.Any{
 			any(t, &v2.Listener{
 				Name:         "ingress_http",
@@ -76,7 +76,7 @@ func TestNonTLSListener(t *testing.T) {
 			}),
 		},
 		TypeUrl: listenerType,
-		Nonce:   "0",
+		Nonce:   "1",
 	}, streamLDS(t, cc))
 
 	// i2 is the same as i1 but has the kubernetes.io/ingress.allow-http: "false" annotation
@@ -96,10 +96,10 @@ func TestNonTLSListener(t *testing.T) {
 	// update i1 to i2 and verify that ingress_http has gone.
 	rh.OnUpdate(i1, i2)
 	assertEqual(t, &v2.DiscoveryResponse{
-		VersionInfo: "0",
+		VersionInfo: "2",
 		Resources:   []types.Any{},
 		TypeUrl:     listenerType,
-		Nonce:       "0",
+		Nonce:       "2",
 	}, streamLDS(t, cc))
 
 	// i3 is similar to i2, but uses the ingress.kubernetes.io/force-ssl-redirect: "true" annotation
@@ -120,7 +120,7 @@ func TestNonTLSListener(t *testing.T) {
 	// update i2 to i3 and check that ingress_http has returned
 	rh.OnUpdate(i2, i3)
 	assertEqual(t, &v2.DiscoveryResponse{
-		VersionInfo: "0",
+		VersionInfo: "3",
 		Resources: []types.Any{
 			any(t, &v2.Listener{
 				Name:         "ingress_http",
@@ -129,7 +129,7 @@ func TestNonTLSListener(t *testing.T) {
 			}),
 		},
 		TypeUrl: listenerType,
-		Nonce:   "0",
+		Nonce:   "3",
 	}, streamLDS(t, cc))
 }
 
@@ -169,16 +169,16 @@ func TestTLSListener(t *testing.T) {
 
 	// assert that there are no active listeners
 	assertEqual(t, &v2.DiscoveryResponse{
-		VersionInfo: "0",
+		VersionInfo: "1",
 		Resources:   []types.Any{},
 		TypeUrl:     listenerType,
-		Nonce:       "0",
+		Nonce:       "1",
 	}, streamLDS(t, cc))
 
 	// add ingress and assert the existence of ingress_http and ingres_https
 	rh.OnAdd(i1)
 	assertEqual(t, &v2.DiscoveryResponse{
-		VersionInfo: "0",
+		VersionInfo: "2",
 		Resources: []types.Any{
 			any(t, &v2.Listener{
 				Name:         "ingress_http",
@@ -195,7 +195,7 @@ func TestTLSListener(t *testing.T) {
 			}),
 		},
 		TypeUrl: listenerType,
-		Nonce:   "0",
+		Nonce:   "2",
 	}, streamLDS(t, cc))
 
 	// i2 is the same as i1 but has the kubernetes.io/ingress.allow-http: "false" annotation
@@ -219,7 +219,7 @@ func TestTLSListener(t *testing.T) {
 	// update i1 to i2 and verify that ingress_http has gone.
 	rh.OnUpdate(i1, i2)
 	assertEqual(t, &v2.DiscoveryResponse{
-		VersionInfo: "0",
+		VersionInfo: "3",
 		Resources: []types.Any{
 			any(t, &v2.Listener{
 				Name:    "ingress_https",
@@ -231,16 +231,16 @@ func TestTLSListener(t *testing.T) {
 			}),
 		},
 		TypeUrl: listenerType,
-		Nonce:   "0",
+		Nonce:   "3",
 	}, streamLDS(t, cc))
 
 	// delete secret and assert that ingress_https is removed
 	rh.OnDelete(s1)
 	assertEqual(t, &v2.DiscoveryResponse{
-		VersionInfo: "0",
+		VersionInfo: "4",
 		Resources:   []types.Any{},
 		TypeUrl:     listenerType,
-		Nonce:       "0",
+		Nonce:       "4",
 	}, streamLDS(t, cc))
 }
 
@@ -313,10 +313,10 @@ func TestIngressRouteTLSListener(t *testing.T) {
 
 	// assert that there are no active listeners
 	assertEqual(t, &v2.DiscoveryResponse{
-		VersionInfo: "0",
+		VersionInfo: "1",
 		Resources:   []types.Any{},
 		TypeUrl:     listenerType,
-		Nonce:       "0",
+		Nonce:       "1",
 	}, streamLDS(t, cc))
 
 	l1 := &v2.Listener{
@@ -333,7 +333,7 @@ func TestIngressRouteTLSListener(t *testing.T) {
 	// add ingress and assert the existence of ingress_http and ingres_https
 	rh.OnAdd(i1)
 	assertEqual(t, &v2.DiscoveryResponse{
-		VersionInfo: "0",
+		VersionInfo: "2",
 		Resources: []types.Any{
 			any(t, &v2.Listener{
 				Name:         "ingress_http",
@@ -343,13 +343,13 @@ func TestIngressRouteTLSListener(t *testing.T) {
 			any(t, l1),
 		},
 		TypeUrl: listenerType,
-		Nonce:   "0",
+		Nonce:   "2",
 	}, streamLDS(t, cc))
 
 	// delete secret and assert that ingress_https is removed
 	rh.OnDelete(s1)
 	assertEqual(t, &v2.DiscoveryResponse{
-		VersionInfo: "0",
+		VersionInfo: "3",
 		Resources: []types.Any{
 			any(t, &v2.Listener{
 				Name:         "ingress_http",
@@ -358,7 +358,7 @@ func TestIngressRouteTLSListener(t *testing.T) {
 			}),
 		},
 		TypeUrl: listenerType,
-		Nonce:   "0",
+		Nonce:   "3",
 	}, streamLDS(t, cc))
 
 	rh.OnDelete(i1)
@@ -378,7 +378,7 @@ func TestIngressRouteTLSListener(t *testing.T) {
 	// add ingress and assert the existence of ingress_http and ingres_https
 	rh.OnAdd(i2)
 	assertEqual(t, &v2.DiscoveryResponse{
-		VersionInfo: "0",
+		VersionInfo: "6",
 		Resources: []types.Any{
 			any(t, &v2.Listener{
 				Name:         "ingress_http",
@@ -388,7 +388,7 @@ func TestIngressRouteTLSListener(t *testing.T) {
 			any(t, l2),
 		},
 		TypeUrl: listenerType,
-		Nonce:   "0",
+		Nonce:   "6",
 	}, streamLDS(t, cc))
 }
 
@@ -429,7 +429,7 @@ func TestLDSFilter(t *testing.T) {
 	// add ingress and fetch ingress_https
 	rh.OnAdd(i1)
 	assertEqual(t, &v2.DiscoveryResponse{
-		VersionInfo: "0",
+		VersionInfo: "2",
 		Resources: []types.Any{
 			any(t, &v2.Listener{
 				Name:    "ingress_https",
@@ -441,12 +441,12 @@ func TestLDSFilter(t *testing.T) {
 			}),
 		},
 		TypeUrl: listenerType,
-		Nonce:   "0",
+		Nonce:   "2",
 	}, streamLDS(t, cc, "ingress_https"))
 
 	// fetch ingress_http
 	assertEqual(t, &v2.DiscoveryResponse{
-		VersionInfo: "0",
+		VersionInfo: "2",
 		Resources: []types.Any{
 
 			any(t, &v2.Listener{
@@ -456,13 +456,14 @@ func TestLDSFilter(t *testing.T) {
 			}),
 		},
 		TypeUrl: listenerType,
-		Nonce:   "0",
+		Nonce:   "2",
 	}, streamLDS(t, cc, "ingress_http"))
 
 	// fetch something non existent.
 	assertEqual(t, &v2.DiscoveryResponse{
-		VersionInfo: "0",
-		TypeUrl:     listenerType, Nonce: "0",
+		VersionInfo: "2",
+		TypeUrl:     listenerType,
+		Nonce:       "2",
 	}, streamLDS(t, cc, "HTTP"))
 }
 
@@ -514,7 +515,7 @@ func TestLDSTLSMinimumProtocolVersion(t *testing.T) {
 	// add ingress and fetch ingress_https
 	rh.OnAdd(i1)
 	assertEqual(t, &v2.DiscoveryResponse{
-		VersionInfo: "0",
+		VersionInfo: "3",
 		Resources: []types.Any{
 			any(t, &v2.Listener{
 				Name:    "ingress_https",
@@ -526,7 +527,7 @@ func TestLDSTLSMinimumProtocolVersion(t *testing.T) {
 			}),
 		},
 		TypeUrl: listenerType,
-		Nonce:   "0",
+		Nonce:   "3",
 	}, streamLDS(t, cc, "ingress_https"))
 
 	i2 := &v1beta1.Ingress{
@@ -561,12 +562,12 @@ func TestLDSTLSMinimumProtocolVersion(t *testing.T) {
 	l1.FilterChains[0].TlsContext.CommonTlsContext.TlsParams.TlsMinimumProtocolVersion = auth.TlsParameters_TLSv1_3
 
 	assertEqual(t, &v2.DiscoveryResponse{
-		VersionInfo: "0",
+		VersionInfo: "4",
 		Resources: []types.Any{
 			any(t, l1),
 		},
 		TypeUrl: listenerType,
-		Nonce:   "0",
+		Nonce:   "4",
 	}, streamLDS(t, cc, "ingress_https"))
 }
 
@@ -600,7 +601,7 @@ func TestLDSIngressHTTPUseProxyProtocol(t *testing.T) {
 	// the proxy protocol (the true param to filterchain)
 	rh.OnAdd(i1)
 	assertEqual(t, &v2.DiscoveryResponse{
-		VersionInfo: "0",
+		VersionInfo: "1",
 		Resources: []types.Any{
 			any(t, &v2.Listener{
 				Name:    "ingress_http",
@@ -612,7 +613,7 @@ func TestLDSIngressHTTPUseProxyProtocol(t *testing.T) {
 			}),
 		},
 		TypeUrl: listenerType,
-		Nonce:   "0",
+		Nonce:   "1",
 	}, streamLDS(t, cc))
 }
 
@@ -654,10 +655,10 @@ func TestLDSIngressHTTPSUseProxyProtocol(t *testing.T) {
 
 	// assert that there are no active listeners
 	assertEqual(t, &v2.DiscoveryResponse{
-		VersionInfo: "0",
+		VersionInfo: "1",
 		Resources:   []types.Any{},
 		TypeUrl:     listenerType,
-		Nonce:       "0",
+		Nonce:       "1",
 	}, streamLDS(t, cc))
 
 	// add ingress and assert the existence of ingress_http and ingres_https and both
@@ -674,7 +675,7 @@ func TestLDSIngressHTTPSUseProxyProtocol(t *testing.T) {
 		FilterChains: filterchaintls("kuard.example.com", envoy.HTTPConnectionManager("ingress_https", "/dev/stdout"), "h2", "http/1.1"),
 	}
 	assertEqual(t, &v2.DiscoveryResponse{
-		VersionInfo: "0",
+		VersionInfo: "2",
 		Resources: []types.Any{
 			any(t, &v2.Listener{
 				Name:    "ingress_http",
@@ -687,7 +688,7 @@ func TestLDSIngressHTTPSUseProxyProtocol(t *testing.T) {
 			any(t, ingress_https),
 		},
 		TypeUrl: listenerType,
-		Nonce:   "0",
+		Nonce:   "2",
 	}, streamLDS(t, cc))
 }
 
@@ -732,10 +733,10 @@ func TestLDSCustomAddressAndPort(t *testing.T) {
 
 	// assert that there are no active listeners
 	assertEqual(t, &v2.DiscoveryResponse{
-		VersionInfo: "0",
+		VersionInfo: "1",
 		Resources:   []types.Any{},
 		TypeUrl:     listenerType,
-		Nonce:       "0",
+		Nonce:       "1",
 	}, streamLDS(t, cc))
 
 	// add ingress and assert the existence of ingress_http and ingres_https and both
@@ -756,13 +757,13 @@ func TestLDSCustomAddressAndPort(t *testing.T) {
 		FilterChains: filterchaintls("kuard.example.com", envoy.HTTPConnectionManager("ingress_https", "/dev/stdout"), "h2", "http/1.1"),
 	}
 	assertEqual(t, &v2.DiscoveryResponse{
-		VersionInfo: "0",
+		VersionInfo: "2",
 		Resources: []types.Any{
 			any(t, ingress_http),
 			any(t, ingress_https),
 		},
 		TypeUrl: listenerType,
-		Nonce:   "0",
+		Nonce:   "2",
 	}, streamLDS(t, cc))
 }
 
@@ -805,10 +806,10 @@ func TestLDSCustomAccessLogPaths(t *testing.T) {
 
 	// assert that there are no active listeners
 	assertEqual(t, &v2.DiscoveryResponse{
-		VersionInfo: "0",
+		VersionInfo: "1",
 		Resources:   []types.Any{},
 		TypeUrl:     listenerType,
-		Nonce:       "0",
+		Nonce:       "1",
 	}, streamLDS(t, cc))
 
 	rh.OnAdd(i1)
@@ -827,13 +828,13 @@ func TestLDSCustomAccessLogPaths(t *testing.T) {
 		FilterChains: filterchaintls("kuard.example.com", envoy.HTTPConnectionManager("ingress_https", "/tmp/https_access.log"), "h2", "http/1.1"),
 	}
 	assertEqual(t, &v2.DiscoveryResponse{
-		VersionInfo: "0",
+		VersionInfo: "2",
 		Resources: []types.Any{
 			any(t, ingress_http),
 			any(t, ingress_https),
 		},
 		TypeUrl: listenerType,
-		Nonce:   "0",
+		Nonce:   "2",
 	}, streamLDS(t, cc))
 }
 
@@ -877,7 +878,7 @@ func TestLDSIngressRouteInsideRootNamespaces(t *testing.T) {
 
 	// assert there is an active listener
 	assertEqual(t, &v2.DiscoveryResponse{
-		VersionInfo: "0",
+		VersionInfo: "1",
 		Resources: []types.Any{
 			any(t, &v2.Listener{
 				Name:         "ingress_http",
@@ -886,7 +887,7 @@ func TestLDSIngressRouteInsideRootNamespaces(t *testing.T) {
 			}),
 		},
 		TypeUrl: listenerType,
-		Nonce:   "0",
+		Nonce:   "1",
 	}, streamLDS(t, cc))
 }
 
@@ -930,10 +931,10 @@ func TestLDSIngressRouteOutsideRootNamespaces(t *testing.T) {
 
 	// assert that there are no active listeners
 	assertEqual(t, &v2.DiscoveryResponse{
-		VersionInfo: "0",
+		VersionInfo: "1",
 		Resources:   []types.Any{},
 		TypeUrl:     listenerType,
-		Nonce:       "0",
+		Nonce:       "1",
 	}, streamLDS(t, cc))
 }
 
@@ -1010,13 +1011,13 @@ func TestIngressRouteHTTPS(t *testing.T) {
 		FilterChains: filterchaintls("example.com", envoy.HTTPConnectionManager("ingress_https", "/dev/stdout"), "h2", "http/1.1"),
 	}
 	assertEqual(t, &v2.DiscoveryResponse{
-		VersionInfo: "0",
+		VersionInfo: "2",
 		Resources: []types.Any{
 			any(t, ingressHTTP),
 			any(t, ingressHTTPS),
 		},
 		TypeUrl: listenerType,
-		Nonce:   "0",
+		Nonce:   "2",
 	}, streamLDS(t, cc))
 }
 
@@ -1079,12 +1080,12 @@ func TestLDSIngressRouteTCPProxyTLSPassthrough(t *testing.T) {
 	}
 
 	assertEqual(t, &v2.DiscoveryResponse{
-		VersionInfo: "0",
+		VersionInfo: "2",
 		Resources: []types.Any{
 			any(t, ingressHTTPS),
 		},
 		TypeUrl: listenerType,
-		Nonce:   "0",
+		Nonce:   "2",
 	}, streamLDS(t, cc))
 }
 
@@ -1150,12 +1151,12 @@ func TestLDSIngressRouteTCPForward(t *testing.T) {
 	}
 
 	assertEqual(t, &v2.DiscoveryResponse{
-		VersionInfo: "0",
+		VersionInfo: "3",
 		Resources: []types.Any{
 			any(t, ingressHTTPS),
 		},
 		TypeUrl: listenerType,
-		Nonce:   "0",
+		Nonce:   "3",
 	}, streamLDS(t, cc))
 }
 
@@ -1215,12 +1216,12 @@ func TestIngressRouteTLSCertificateDelegation(t *testing.T) {
 
 	// assert there is no ingress_https because there is no matching secret.
 	assertEqual(t, &v2.DiscoveryResponse{
-		VersionInfo: "0",
+		VersionInfo: "2",
 		Resources: []types.Any{
 			any(t, ingress_http),
 		},
 		TypeUrl: listenerType,
-		Nonce:   "0",
+		Nonce:   "2",
 	}, streamLDS(t, cc))
 
 	// t1 is a TLSCertificateDelegation that permits default to access secret/wildcard
@@ -1250,13 +1251,13 @@ func TestIngressRouteTLSCertificateDelegation(t *testing.T) {
 	}
 
 	assertEqual(t, &v2.DiscoveryResponse{
-		VersionInfo: "0",
+		VersionInfo: "3",
 		Resources: []types.Any{
 			any(t, ingress_http),
 			any(t, ingress_https),
 		},
 		TypeUrl: listenerType,
-		Nonce:   "0",
+		Nonce:   "3",
 	}, streamLDS(t, cc))
 
 	// t2 is a TLSCertificateDelegation that permits access to secret/wildcard from all namespaces.
@@ -1277,13 +1278,13 @@ func TestIngressRouteTLSCertificateDelegation(t *testing.T) {
 	rh.OnUpdate(t1, t2)
 
 	assertEqual(t, &v2.DiscoveryResponse{
-		VersionInfo: "0",
+		VersionInfo: "4",
 		Resources: []types.Any{
 			any(t, ingress_http),
 			any(t, ingress_https),
 		},
 		TypeUrl: listenerType,
-		Nonce:   "0",
+		Nonce:   "4",
 	}, streamLDS(t, cc))
 
 	// t3 is a TLSCertificateDelegation that permits access to secret/different all namespaces.
@@ -1304,12 +1305,12 @@ func TestIngressRouteTLSCertificateDelegation(t *testing.T) {
 	rh.OnUpdate(t2, t3)
 
 	assertEqual(t, &v2.DiscoveryResponse{
-		VersionInfo: "0",
+		VersionInfo: "5",
 		Resources: []types.Any{
 			any(t, ingress_http),
 		},
 		TypeUrl: listenerType,
-		Nonce:   "0",
+		Nonce:   "5",
 	}, streamLDS(t, cc))
 
 	// t4 is a TLSCertificateDelegation that permits access to secret/wildcard from the kube-secret namespace.
@@ -1330,12 +1331,12 @@ func TestIngressRouteTLSCertificateDelegation(t *testing.T) {
 	rh.OnUpdate(t3, t4)
 
 	assertEqual(t, &v2.DiscoveryResponse{
-		VersionInfo: "0",
+		VersionInfo: "6",
 		Resources: []types.Any{
 			any(t, ingress_http),
 		},
 		TypeUrl: listenerType,
-		Nonce:   "0",
+		Nonce:   "6",
 	}, streamLDS(t, cc))
 
 }

--- a/internal/e2e/rds_test.go
+++ b/internal/e2e/rds_test.go
@@ -99,7 +99,7 @@ func TestEditIngress(t *testing.T) {
 
 	// check that it's been translated correctly.
 	assertEqual(t, &v2.DiscoveryResponse{
-		VersionInfo: "0",
+		VersionInfo: "2",
 		Resources: []types.Any{
 			any(t, &v2.RouteConfiguration{
 				Name: "ingress_http",
@@ -117,7 +117,7 @@ func TestEditIngress(t *testing.T) {
 			}),
 		},
 		TypeUrl: routeType,
-		Nonce:   "0",
+		Nonce:   "2",
 	}, streamRDS(t, cc))
 
 	// update old to new
@@ -142,7 +142,7 @@ func TestEditIngress(t *testing.T) {
 
 	// check that ingress_http has been updated.
 	assertEqual(t, &v2.DiscoveryResponse{
-		VersionInfo: "0",
+		VersionInfo: "3",
 		Resources: []types.Any{
 			any(t, &v2.RouteConfiguration{
 				Name: "ingress_http",
@@ -160,7 +160,7 @@ func TestEditIngress(t *testing.T) {
 			}),
 		},
 		TypeUrl: routeType,
-		Nonce:   "0",
+		Nonce:   "3",
 	}, streamRDS(t, cc))
 }
 
@@ -221,7 +221,7 @@ func TestIngressPathRouteWithoutHost(t *testing.T) {
 
 	// check that it's been translated correctly.
 	assertEqual(t, &v2.DiscoveryResponse{
-		VersionInfo: "0",
+		VersionInfo: "2",
 		Resources: []types.Any{
 			any(t, &v2.RouteConfiguration{
 				Name: "ingress_http",
@@ -239,7 +239,7 @@ func TestIngressPathRouteWithoutHost(t *testing.T) {
 			}),
 		},
 		TypeUrl: routeType,
-		Nonce:   "0",
+		Nonce:   "2",
 	}, streamRDS(t, cc))
 }
 
@@ -301,7 +301,7 @@ func TestEditIngressInPlace(t *testing.T) {
 	rh.OnAdd(s2)
 
 	assertEqual(t, &v2.DiscoveryResponse{
-		VersionInfo: "0",
+		VersionInfo: "3",
 		Resources: []types.Any{
 			any(t, &v2.RouteConfiguration{
 				Name: "ingress_http",
@@ -319,7 +319,7 @@ func TestEditIngressInPlace(t *testing.T) {
 			}),
 		},
 		TypeUrl: routeType,
-		Nonce:   "0",
+		Nonce:   "3",
 	}, streamRDS(t, cc))
 
 	// i2 is like i1 but adds a second route
@@ -350,7 +350,7 @@ func TestEditIngressInPlace(t *testing.T) {
 	}
 	rh.OnUpdate(i1, i2)
 	assertEqual(t, &v2.DiscoveryResponse{
-		VersionInfo: "0",
+		VersionInfo: "4",
 		Resources: []types.Any{
 			any(t, &v2.RouteConfiguration{
 				Name: "ingress_http",
@@ -371,7 +371,7 @@ func TestEditIngressInPlace(t *testing.T) {
 			}),
 		},
 		TypeUrl: routeType,
-		Nonce:   "0",
+		Nonce:   "4",
 	}, streamRDS(t, cc))
 
 	// i3 is like i2, but adds the ingress.kubernetes.io/force-ssl-redirect: "true" annotation
@@ -407,7 +407,7 @@ func TestEditIngressInPlace(t *testing.T) {
 	}
 	rh.OnUpdate(i2, i3)
 	assertEqual(t, &v2.DiscoveryResponse{
-		VersionInfo: "0",
+		VersionInfo: "5",
 		Resources: []types.Any{
 			any(t, &v2.RouteConfiguration{
 				Name: "ingress_http",
@@ -425,7 +425,7 @@ func TestEditIngressInPlace(t *testing.T) {
 			any(t, &v2.RouteConfiguration{Name: "ingress_https"}),
 		},
 		TypeUrl: routeType,
-		Nonce:   "0",
+		Nonce:   "5",
 	}, streamRDS(t, cc))
 
 	rh.OnAdd(&v1.Secret{
@@ -477,7 +477,7 @@ func TestEditIngressInPlace(t *testing.T) {
 	}
 	rh.OnUpdate(i3, i4)
 	assertEqual(t, &v2.DiscoveryResponse{
-		VersionInfo: "0",
+		VersionInfo: "7",
 		Resources: []types.Any{
 			any(t, &v2.RouteConfiguration{
 				Name: "ingress_http",
@@ -507,7 +507,7 @@ func TestEditIngressInPlace(t *testing.T) {
 				}}}),
 		},
 		TypeUrl: routeType,
-		Nonce:   "0",
+		Nonce:   "7",
 	}, streamRDS(t, cc))
 }
 
@@ -544,7 +544,7 @@ func TestRequestTimeout(t *testing.T) {
 		},
 	}
 	rh.OnAdd(i1)
-	assertRDS(t, cc, []route.VirtualHost{{
+	assertRDS(t, cc, "2", []route.VirtualHost{{
 		Name:    "*",
 		Domains: []string{"*"},
 		Routes: []route.Route{{
@@ -565,7 +565,7 @@ func TestRequestTimeout(t *testing.T) {
 		},
 	}
 	rh.OnUpdate(i1, i2)
-	assertRDS(t, cc, []route.VirtualHost{{
+	assertRDS(t, cc, "3", []route.VirtualHost{{
 		Name:    "*",
 		Domains: []string{"*"},
 		Routes: []route.Route{{
@@ -586,7 +586,7 @@ func TestRequestTimeout(t *testing.T) {
 		},
 	}
 	rh.OnUpdate(i2, i3)
-	assertRDS(t, cc, []route.VirtualHost{{
+	assertRDS(t, cc, "4", []route.VirtualHost{{
 		Name:    "*",
 		Domains: []string{"*"},
 		Routes: []route.Route{{
@@ -607,7 +607,7 @@ func TestRequestTimeout(t *testing.T) {
 		},
 	}
 	rh.OnUpdate(i3, i4)
-	assertRDS(t, cc, []route.VirtualHost{{
+	assertRDS(t, cc, "5", []route.VirtualHost{{
 		Name:    "*",
 		Domains: []string{"*"},
 		Routes: []route.Route{{
@@ -718,7 +718,7 @@ func TestSSLRedirectOverlay(t *testing.T) {
 		},
 	})
 
-	assertRDS(t, cc, []route.VirtualHost{{ // ingress_http
+	assertRDS(t, cc, "5", []route.VirtualHost{{ // ingress_http
 		Name:    "example.com",
 		Domains: []string{"example.com", "example.com:80"},
 		Routes: []route.Route{{
@@ -791,7 +791,7 @@ func TestIssue257(t *testing.T) {
 	}
 	rh.OnAdd(s1)
 
-	assertRDS(t, cc, []route.VirtualHost{{
+	assertRDS(t, cc, "2", []route.VirtualHost{{
 		Name:    "*",
 		Domains: []string{"*"},
 		Routes: []route.Route{{
@@ -844,7 +844,7 @@ func TestIssue257(t *testing.T) {
 	}
 	rh.OnUpdate(i1, i2)
 
-	assertRDS(t, cc, []route.VirtualHost{{
+	assertRDS(t, cc, "3", []route.VirtualHost{{
 		Name:    "kuard.db.gd-ms.com",
 		Domains: []string{"kuard.db.gd-ms.com", "kuard.db.gd-ms.com:80"},
 		Routes: []route.Route{{
@@ -956,7 +956,7 @@ func TestRDSFilter(t *testing.T) {
 	rh.OnAdd(s2)
 
 	assertEqual(t, &v2.DiscoveryResponse{
-		VersionInfo: "0",
+		VersionInfo: "5",
 		Resources: []types.Any{
 			any(t, &v2.RouteConfiguration{
 				Name: "ingress_http",
@@ -974,11 +974,11 @@ func TestRDSFilter(t *testing.T) {
 			}),
 		},
 		TypeUrl: routeType,
-		Nonce:   "0",
+		Nonce:   "5",
 	}, streamRDS(t, cc, "ingress_http"))
 
 	assertEqual(t, &v2.DiscoveryResponse{
-		VersionInfo: "0",
+		VersionInfo: "5",
 		Resources: []types.Any{
 			any(t, &v2.RouteConfiguration{
 				Name: "ingress_https",
@@ -996,7 +996,7 @@ func TestRDSFilter(t *testing.T) {
 			}),
 		},
 		TypeUrl: routeType,
-		Nonce:   "0",
+		Nonce:   "5",
 	}, streamRDS(t, cc, "ingress_https"))
 }
 
@@ -1044,7 +1044,7 @@ func TestWebsocketIngress(t *testing.T) {
 		},
 	})
 
-	assertRDS(t, cc, []route.VirtualHost{{
+	assertRDS(t, cc, "2", []route.VirtualHost{{
 		Name:    "websocket.hello.world",
 		Domains: []string{"websocket.hello.world", "websocket.hello.world:80"},
 		Routes: []route.Route{{
@@ -1103,7 +1103,7 @@ func TestWebsocketIngressRoute(t *testing.T) {
 		},
 	})
 
-	assertRDS(t, cc, []route.VirtualHost{{
+	assertRDS(t, cc, "2", []route.VirtualHost{{
 		Name:    "websocket.hello.world",
 		Domains: []string{"websocket.hello.world", "websocket.hello.world:80"},
 		Routes: []route.Route{{
@@ -1167,7 +1167,7 @@ func TestPrefixRewriteIngressRoute(t *testing.T) {
 		},
 	})
 
-	assertRDS(t, cc, []route.VirtualHost{{
+	assertRDS(t, cc, "2", []route.VirtualHost{{
 		Name:    "prefixrewrite.hello.world",
 		Domains: []string{"prefixrewrite.hello.world", "prefixrewrite.hello.world:80"},
 		Routes: []route.Route{{
@@ -1264,7 +1264,7 @@ func TestDefaultBackendDoesNotOverwriteNamedHost(t *testing.T) {
 	})
 
 	assertEqual(t, &v2.DiscoveryResponse{
-		VersionInfo: "0",
+		VersionInfo: "3",
 		Resources: []types.Any{
 			any(t, &v2.RouteConfiguration{
 				Name: "ingress_http",
@@ -1289,7 +1289,7 @@ func TestDefaultBackendDoesNotOverwriteNamedHost(t *testing.T) {
 			}),
 		},
 		TypeUrl: routeType,
-		Nonce:   "0",
+		Nonce:   "3",
 	}, streamRDS(t, cc, "ingress_http"))
 }
 
@@ -1338,7 +1338,7 @@ func TestRDSIngressRouteInsideRootNamespaces(t *testing.T) {
 	rh.OnAdd(ir1)
 
 	assertEqual(t, &v2.DiscoveryResponse{
-		VersionInfo: "0",
+		VersionInfo: "2",
 		Resources: []types.Any{
 			any(t, &v2.RouteConfiguration{
 				Name: "ingress_http",
@@ -1353,7 +1353,7 @@ func TestRDSIngressRouteInsideRootNamespaces(t *testing.T) {
 			}),
 		},
 		TypeUrl: routeType,
-		Nonce:   "0",
+		Nonce:   "2",
 	}, streamRDS(t, cc, "ingress_http"))
 }
 
@@ -1402,14 +1402,14 @@ func TestRDSIngressRouteOutsideRootNamespaces(t *testing.T) {
 	rh.OnAdd(ir1)
 
 	assertEqual(t, &v2.DiscoveryResponse{
-		VersionInfo: "0",
+		VersionInfo: "2",
 		Resources: []types.Any{
 			any(t, &v2.RouteConfiguration{
 				Name: "ingress_http",
 			}),
 		},
 		TypeUrl: routeType,
-		Nonce:   "0",
+		Nonce:   "2",
 	}, streamRDS(t, cc, "ingress_http"))
 }
 
@@ -1458,7 +1458,7 @@ func TestRDSIngressRouteClassAnnotation(t *testing.T) {
 	}
 
 	rh.OnAdd(ir1)
-	assertRDS(t, cc, []route.VirtualHost{{
+	assertRDS(t, cc, "2", []route.VirtualHost{{
 		Name:    "www.example.com",
 		Domains: []string{"www.example.com", "www.example.com:80"},
 		Routes: []route.Route{{
@@ -1491,7 +1491,7 @@ func TestRDSIngressRouteClassAnnotation(t *testing.T) {
 		},
 	}
 	rh.OnUpdate(ir1, ir2)
-	assertRDS(t, cc, nil, nil)
+	assertRDS(t, cc, "3", nil, nil)
 
 	ir3 := &ingressroutev1.IngressRoute{
 		ObjectMeta: metav1.ObjectMeta{
@@ -1517,7 +1517,7 @@ func TestRDSIngressRouteClassAnnotation(t *testing.T) {
 		},
 	}
 	rh.OnUpdate(ir2, ir3)
-	assertRDS(t, cc, nil, nil)
+	assertRDS(t, cc, "3", nil, nil)
 
 	ir4 := &ingressroutev1.IngressRoute{
 		ObjectMeta: metav1.ObjectMeta{
@@ -1543,7 +1543,7 @@ func TestRDSIngressRouteClassAnnotation(t *testing.T) {
 		},
 	}
 	rh.OnUpdate(ir3, ir4)
-	assertRDS(t, cc, []route.VirtualHost{{
+	assertRDS(t, cc, "4", []route.VirtualHost{{
 		Name:    "www.example.com",
 		Domains: []string{"www.example.com", "www.example.com:80"},
 		Routes: []route.Route{{
@@ -1577,7 +1577,7 @@ func TestRDSIngressRouteClassAnnotation(t *testing.T) {
 	}
 	rh.OnUpdate(ir4, ir5)
 
-	assertRDS(t, cc, []route.VirtualHost{{
+	assertRDS(t, cc, "5", []route.VirtualHost{{
 		Name:    "www.example.com",
 		Domains: []string{"www.example.com", "www.example.com:80"},
 		Routes: []route.Route{{
@@ -1587,7 +1587,7 @@ func TestRDSIngressRouteClassAnnotation(t *testing.T) {
 	}}, nil)
 
 	rh.OnUpdate(ir5, ir3)
-	assertRDS(t, cc, nil, nil)
+	assertRDS(t, cc, "6", nil, nil)
 }
 
 // Test DAGAdapter.IngressClass setting works, this could be done
@@ -1626,7 +1626,7 @@ func TestRDSIngressClassAnnotation(t *testing.T) {
 		},
 	}
 	rh.OnAdd(i1)
-	assertRDS(t, cc, []route.VirtualHost{{
+	assertRDS(t, cc, "2", []route.VirtualHost{{
 		Name:    "*",
 		Domains: []string{"*"},
 		Routes: []route.Route{{
@@ -1651,7 +1651,7 @@ func TestRDSIngressClassAnnotation(t *testing.T) {
 		},
 	}
 	rh.OnUpdate(i1, i2)
-	assertRDS(t, cc, nil, nil)
+	assertRDS(t, cc, "3", nil, nil)
 
 	i3 := &v1beta1.Ingress{
 		ObjectMeta: metav1.ObjectMeta{
@@ -1669,7 +1669,7 @@ func TestRDSIngressClassAnnotation(t *testing.T) {
 		},
 	}
 	rh.OnUpdate(i2, i3)
-	assertRDS(t, cc, nil, nil)
+	assertRDS(t, cc, "3", nil, nil)
 
 	i4 := &v1beta1.Ingress{
 		ObjectMeta: metav1.ObjectMeta{
@@ -1687,7 +1687,7 @@ func TestRDSIngressClassAnnotation(t *testing.T) {
 		},
 	}
 	rh.OnUpdate(i3, i4)
-	assertRDS(t, cc, []route.VirtualHost{{
+	assertRDS(t, cc, "4", []route.VirtualHost{{
 		Name:    "*",
 		Domains: []string{"*"},
 		Routes: []route.Route{{
@@ -1712,7 +1712,7 @@ func TestRDSIngressClassAnnotation(t *testing.T) {
 		},
 	}
 	rh.OnUpdate(i4, i5)
-	assertRDS(t, cc, []route.VirtualHost{{
+	assertRDS(t, cc, "5", []route.VirtualHost{{
 		Name:    "*",
 		Domains: []string{"*"},
 		Routes: []route.Route{{
@@ -1722,7 +1722,7 @@ func TestRDSIngressClassAnnotation(t *testing.T) {
 	}}, nil)
 
 	rh.OnUpdate(i5, i3)
-	assertRDS(t, cc, nil, nil)
+	assertRDS(t, cc, "6", nil, nil)
 }
 
 // issue 523, check for data races caused by accidentally
@@ -1845,7 +1845,7 @@ func TestRDSIngressSpecMissingHTTPKey(t *testing.T) {
 	}
 	rh.OnAdd(s1)
 
-	assertRDS(t, cc, []route.VirtualHost{{
+	assertRDS(t, cc, "2", []route.VirtualHost{{
 		Name:    "test2.test.com",
 		Domains: []string{"test2.test.com", "test2.test.com:80"},
 		Routes: []route.Route{{
@@ -1892,7 +1892,7 @@ func TestRouteWithAServiceWeight(t *testing.T) {
 	}
 
 	rh.OnAdd(ir1)
-	assertRDS(t, cc, []route.VirtualHost{{
+	assertRDS(t, cc, "2", []route.VirtualHost{{
 		Name:    "test2.test.com",
 		Domains: []string{"test2.test.com", "test2.test.com:80"},
 		Routes: []route.Route{{
@@ -1924,7 +1924,7 @@ func TestRouteWithAServiceWeight(t *testing.T) {
 	}
 
 	rh.OnUpdate(ir1, ir2)
-	assertRDS(t, cc, []route.VirtualHost{{
+	assertRDS(t, cc, "3", []route.VirtualHost{{
 		Name:    "test2.test.com",
 		Domains: []string{"test2.test.com", "test2.test.com:80"},
 		Routes: []route.Route{{
@@ -1991,7 +1991,7 @@ func TestRouteWithTLS(t *testing.T) {
 
 	// check that ingress_http has been updated.
 	assertEqual(t, &v2.DiscoveryResponse{
-		VersionInfo: "0",
+		VersionInfo: "3",
 		Resources: []types.Any{
 			any(t, &v2.RouteConfiguration{
 				Name: "ingress_http",
@@ -2015,7 +2015,7 @@ func TestRouteWithTLS(t *testing.T) {
 				}}}),
 		},
 		TypeUrl: routeType,
-		Nonce:   "0",
+		Nonce:   "3",
 	}, streamRDS(t, cc))
 }
 func TestRouteWithTLS_InsecurePaths(t *testing.T) {
@@ -2094,7 +2094,7 @@ func TestRouteWithTLS_InsecurePaths(t *testing.T) {
 
 	// check that ingress_http has been updated.
 	assertEqual(t, &v2.DiscoveryResponse{
-		VersionInfo: "0",
+		VersionInfo: "4",
 		Resources: []types.Any{
 			any(t, &v2.RouteConfiguration{
 				Name: "ingress_http",
@@ -2128,7 +2128,7 @@ func TestRouteWithTLS_InsecurePaths(t *testing.T) {
 				}}}),
 		},
 		TypeUrl: routeType,
-		Nonce:   "0",
+		Nonce:   "4",
 	}, streamRDS(t, cc))
 }
 
@@ -2166,7 +2166,7 @@ func TestRouteRetryAnnotations(t *testing.T) {
 		},
 	}
 	rh.OnAdd(i1)
-	assertRDS(t, cc, []route.VirtualHost{{
+	assertRDS(t, cc, "2", []route.VirtualHost{{
 		Name:    "*",
 		Domains: []string{"*"},
 		Routes: []route.Route{{
@@ -2247,7 +2247,7 @@ func TestLoadBalancingStrategies(t *testing.T) {
 			},
 		},
 	}}
-	assertRDS(t, cc, want, nil)
+	assertRDS(t, cc, "7", want, nil)
 }
 
 // issue#887 rds generates the correct routing tables when
@@ -2317,7 +2317,7 @@ func TestBuilderExternalPort(t *testing.T) {
 
 	// check that it's been translated correctly.
 	assertEqual(t, &v2.DiscoveryResponse{
-		VersionInfo: "0",
+		VersionInfo: "3",
 		Resources: []types.Any{
 			any(t, &v2.RouteConfiguration{
 				Name: "ingress_http",
@@ -2343,14 +2343,14 @@ func TestBuilderExternalPort(t *testing.T) {
 			}),
 		},
 		TypeUrl: routeType,
-		Nonce:   "0",
+		Nonce:   "3",
 	}, streamRDS(t, cc))
 }
 
-func assertRDS(t *testing.T, cc *grpc.ClientConn, ingress_http, ingress_https []route.VirtualHost) {
+func assertRDS(t *testing.T, cc *grpc.ClientConn, versioninfo string, ingress_http, ingress_https []route.VirtualHost) {
 	t.Helper()
 	assertEqual(t, &v2.DiscoveryResponse{
-		VersionInfo: "0",
+		VersionInfo: versioninfo,
 		Resources: []types.Any{
 			any(t, &v2.RouteConfiguration{
 				Name:         "ingress_http",
@@ -2362,7 +2362,7 @@ func assertRDS(t *testing.T, cc *grpc.ClientConn, ingress_http, ingress_https []
 			}),
 		},
 		TypeUrl: routeType,
-		Nonce:   "0",
+		Nonce:   versioninfo,
 	}, streamRDS(t, cc))
 }
 

--- a/internal/grpc/xds.go
+++ b/internal/grpc/xds.go
@@ -16,6 +16,7 @@ package grpc
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"sync/atomic"
 
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2"
@@ -100,7 +101,7 @@ func (xh *xdsHandler) stream(st grpcStream) (err error) {
 			log.Info("stream_wait")
 
 			// now we wait for a notification, if this is the first time through the loop
-			// then last will be zero and that will trigger a notification immediately.
+			// then last will be less than zero and that will trigger a notification immediately.
 			r.Register(ch, last)
 			select {
 			case last = <-ch:
@@ -117,10 +118,10 @@ func (xh *xdsHandler) stream(st grpcStream) (err error) {
 				}
 
 				resp := &v2.DiscoveryResponse{
-					VersionInfo: "0",
+					VersionInfo: strconv.Itoa(last),
 					Resources:   resources,
 					TypeUrl:     r.TypeURL(),
-					Nonce:       "0",
+					Nonce:       strconv.Itoa(last),
 				}
 				if err := st.Send(resp); err != nil {
 					return err


### PR DESCRIPTION
Updates #499
Updates #273

Previously each response sent to Envoy set the version_info field to
"0". The xDS documentation says that the version_info field should
change if the result returned by the management server has changed.
The xDS protocol does not place constraints on what the version_info
field should contain, other than it is a string. Internally the
Cache.Register method maintains a count of updates to the cache, so this
PR uses the string form of this counter for the version_info field in
the response.

The nonce field on the response message is used in the ACK/NACK protocol
from Envoy back to the management server which Contour doesn't
implement, but it seems reasonable to also use the string form of the
cache counter in both the version_info and nonce fields.

Signed-off-by: Dave Cheney <dave@cheney.net>