### PR TITLE
deployment: explicitly set the listening ports for doc purposes

### DIFF
--- a/deployment/deployment-grpc-v2/02-contour.yaml
+++ b/deployment/deployment-grpc-v2/02-contour.yaml
@@ -25,7 +25,7 @@ spec:
         imagePullPolicy: Always
         name: contour
         command: ["contour"]
-        args: ["serve", "--incluster"]
+        args: ["serve", "--incluster", "--envoy-service-http-port", "8080", "--envoy-service-https-port", "8443"]
       - image: docker.io/envoyproxy/envoy:v1.9.1
         name: envoy
         ports:

--- a/deployment/ds-grpc-v2/02-contour.yaml
+++ b/deployment/ds-grpc-v2/02-contour.yaml
@@ -26,7 +26,7 @@ spec:
         imagePullPolicy: Always
         name: contour
         command: ["contour"]
-        args: ["serve", "--incluster"]
+        args: ["serve", "--incluster", "--envoy-service-http-port", "8080", "--envoy-service-https-port", "8443"]
       - image: docker.io/envoyproxy/envoy:v1.9.1
         name: envoy
         ports:

--- a/deployment/ds-hostnet/02-contour.yaml
+++ b/deployment/ds-hostnet/02-contour.yaml
@@ -30,7 +30,7 @@ spec:
           name: contour
         name: contour
         command: ["contour"]
-        args: ["serve", "--incluster"]
+        args: ["serve", "--incluster", "--envoy-service-http-port", "8080", "--envoy-service-https-port", "8443"]
       - image: docker.io/envoyproxy/envoy:v1.9.1
         name: envoy
         ports:

--- a/deployment/render/daemonset-rbac.yaml
+++ b/deployment/render/daemonset-rbac.yaml
@@ -210,7 +210,7 @@ spec:
         imagePullPolicy: Always
         name: contour
         command: ["contour"]
-        args: ["serve", "--incluster"]
+        args: ["serve", "--incluster", "--envoy-service-http-port", "8080", "--envoy-service-https-port", "8443"]
       - image: docker.io/envoyproxy/envoy:v1.9.1
         name: envoy
         ports:

--- a/deployment/render/deployment-rbac.yaml
+++ b/deployment/render/deployment-rbac.yaml
@@ -209,7 +209,7 @@ spec:
         imagePullPolicy: Always
         name: contour
         command: ["contour"]
-        args: ["serve", "--incluster"]
+        args: ["serve", "--incluster", "--envoy-service-http-port", "8080", "--envoy-service-https-port", "8443"]
       - image: docker.io/envoyproxy/envoy:v1.9.1
         name: envoy
         ports:


### PR DESCRIPTION
There have been multiple cases in which users ask how to configure
Envoy's HTTP/HTTPS listening ports. By explicitly setting the
configuration flags in the deployment samples, users should have a
better sense of the flags that are available.

Fixes #1003 