### PR TITLE
set holdoff notifier last to now when zero valued

### DIFF
--- a/internal/contour/holdoff.go
+++ b/internal/contour/holdoff.go
@@ -50,6 +50,9 @@ func (hn *HoldoffNotifier) OnChange(builder *dag.Builder) {
 	if hn.timer != nil {
 		hn.timer.Stop()
 	}
+	if !hn.last.IsZero() {
+		hn.last = time.Now()
+	}
 	since := time.Since(hn.last)
 	if since > holdoffMaxDelay {
 		// update immediately


### PR DESCRIPTION
Setting `last` to `time.Now()` when zero will void triggering a forced
updated on start, while ensuring the forced update flow continues to
operate even under rapid change that would otherwise leave the timer
stopped.

Updates #499
Closes: #1020 

Signed-off-by: Matt Alberts <malberts@cloudflare.com>