### PR TITLE
design: add design document template

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,6 +75,9 @@ It follows from the previous section, so if you haven't set up your Go workspace
 This project operates according to the _talk, then code_ rule.
 If you plan to submit a pull request for anything more than a typo or obvious bug fix, first you _should_ [raise an issue][6] to discuss your proposal, before submitting any code.
 
+Depending on the size of the feature you may be expected to first write a design proposal.
+A proposal template is [available here](https://github.com/heptio/contour/tree/master/design/design-document-tmpl.md)
+
 ### Pre commit CI
 
 Before a change is submitted it should pass all the pre commit CI jobs.

--- a/design/design-document-tmpl.md
+++ b/design/design-document-tmpl.md
@@ -1,0 +1,48 @@
+# Design proposal template (replace with your proposal's title)
+
+Status: {Draft,Accepted,Declined}
+
+One to two sentences that describes the goal of this proposal.
+The reader should be able to tell by the title, and the opening paragraph, if this document is relevant to them.
+
+_Note_: The preferred style for design documents is one sentence per line.
+*Do not wrap lines*.
+This aids in review of the document as changes to a line are not obscured by the reflowing those changes caused and has a side effect of avoiding debate about one or two space after a period.
+
+## Goals
+
+- A short list of things which will be accomplished by implementing this proposal.
+- Two things is ok.
+- Three is pushing it.
+- More than three goals suggests that the proposal's scope is too large.
+
+## Non Goals
+
+- A short list of items which are:
+- a. out of scope
+- b. follow on items which are deliberately excluded from this proposal.
+
+## Background
+
+One to two paragraphs of exposition to set the context for this proposal.
+
+## High-Level Design
+
+One to two paragraphs that describe the high level changes that will be made to implement this proposal.
+
+## Detailed Design
+
+A detailed design describing how the changes to the product should be made.
+
+The names of types, fields, interfaces, and methods should be agreed on here, not debated in code review.
+The same applies to changes in CRDs, YAML examples, and so on.
+
+Ideally the changes should be made in sequence so that the work required to implement this design can be done incrementally, possibly in parallel.
+
+## Alternatives Considered
+
+If there are alternative high level or detailed designs that were not pursued they should be called out here with a brief explanation of why they were not pursued.
+
+## Security Considerations
+
+If this proposal has an impact to the security of the product, its users, or data stored or transmitted via the product, they must be addressed here.


### PR DESCRIPTION
Every time I go to write a design document I find myself cribbing the
pieces off a previous one.

Add a design document template and make mention of it in the
contribution guidelines.

Signed-off-by: Dave Cheney <dave@cheney.net>