### PR TITLE
internal/envoy: Pass a slice of *dag.TCPService to envoy.RouteRoute

### DIFF
--- a/internal/contour/route.go
+++ b/internal/contour/route.go
@@ -116,9 +116,12 @@ func (v *routeVisitor) visit(vertex dag.Vertex) {
 				vhost := envoy.VirtualHost(vh.Name, l.Port)
 				vh.Visit(func(v dag.Vertex) {
 					if r, ok := v.(*dag.Route); ok {
-						var svcs []*dag.HTTPService
+						var svcs []*dag.TCPService
 						r.Visit(func(s dag.Vertex) {
-							if s, ok := s.(*dag.HTTPService); ok {
+							switch s := s.(type) {
+							case *dag.HTTPService:
+								svcs = append(svcs, &s.TCPService)
+							case *dag.TCPService:
 								svcs = append(svcs, s)
 							}
 						})
@@ -146,9 +149,12 @@ func (v *routeVisitor) visit(vertex dag.Vertex) {
 				vhost := envoy.VirtualHost(vh.VirtualHost.Name, l.Port)
 				vh.Visit(func(v dag.Vertex) {
 					if r, ok := v.(*dag.Route); ok {
-						var svcs []*dag.HTTPService
+						var svcs []*dag.TCPService
 						r.Visit(func(s dag.Vertex) {
-							if s, ok := s.(*dag.HTTPService); ok {
+							switch s := s.(type) {
+							case *dag.HTTPService:
+								svcs = append(svcs, &s.TCPService)
+							case *dag.TCPService:
 								svcs = append(svcs, s)
 							}
 						})

--- a/internal/envoy/route.go
+++ b/internal/envoy/route.go
@@ -26,7 +26,7 @@ import (
 // RouteRoute creates a route.Route_Route for the services supplied.
 // If len(services) is greater than one, the route's action will be a
 // weighted cluster.
-func RouteRoute(r *dag.Route, services []*dag.HTTPService) *route.Route_Route {
+func RouteRoute(r *dag.Route, services []*dag.TCPService) *route.Route_Route {
 	ra := route.RouteAction{
 		RetryPolicy:   retryPolicy(r),
 		Timeout:       timeout(r),
@@ -44,7 +44,7 @@ func RouteRoute(r *dag.Route, services []*dag.HTTPService) *route.Route_Route {
 	switch len(services) {
 	case 1:
 		ra.ClusterSpecifier = &route.RouteAction_Cluster{
-			Cluster: Clustername(&services[0].TCPService),
+			Cluster: Clustername(services[0]),
 		}
 		ra.RequestHeadersToAdd = headers(
 			appendHeader("x-request-start", "t=%START_TIME(%s.%3f)%"),
@@ -110,13 +110,13 @@ func UpgradeHTTPS() *route.Route_Redirect {
 }
 
 // weightedClusters returns a route.WeightedCluster for multiple services.
-func weightedClusters(services []*dag.HTTPService) *route.WeightedCluster {
+func weightedClusters(services []*dag.TCPService) *route.WeightedCluster {
 	var wc route.WeightedCluster
 	var total int
 	for _, service := range services {
 		total += service.Weight
 		wc.Clusters = append(wc.Clusters, &route.WeightedCluster_ClusterWeight{
-			Name:   Clustername(&service.TCPService),
+			Name:   Clustername(service),
 			Weight: u32(service.Weight),
 			RequestHeadersToAdd: headers(
 				appendHeader("x-request-start", "t=%START_TIME(%s.%3f)%"),

--- a/internal/envoy/route_test.go
+++ b/internal/envoy/route_test.go
@@ -42,16 +42,14 @@ func TestRouteRoute(t *testing.T) {
 	}
 	tests := map[string]struct {
 		route    *dag.Route
-		services []*dag.HTTPService
+		services []*dag.TCPService
 		want     *route.Route_Route
 	}{
 		"single service": {
 			route: &dag.Route{
 				Prefix: "/",
 			},
-			services: []*dag.HTTPService{{
-				TCPService: service(s1),
-			}},
+			services: services(s1),
 			want: &route.Route_Route{
 				Route: &route.RouteAction{
 					ClusterSpecifier: &route.RouteAction_Cluster{
@@ -67,9 +65,7 @@ func TestRouteRoute(t *testing.T) {
 				Prefix:    "/",
 				Websocket: true,
 			},
-			services: []*dag.HTTPService{{
-				TCPService: service(s1),
-			}},
+			services: services(s1),
 			want: &route.Route_Route{
 				Route: &route.RouteAction{
 					ClusterSpecifier: &route.RouteAction_Cluster{
@@ -88,18 +84,15 @@ func TestRouteRoute(t *testing.T) {
 			route: &dag.Route{
 				Prefix: "/",
 			},
-			services: []*dag.HTTPService{{
-				TCPService: dag.TCPService{
-					Name:        s1.Name,
-					Namespace:   s1.Namespace,
-					ServicePort: &s1.Spec.Ports[0],
-					Weight:      90,
-				},
+			services: []*dag.TCPService{{
+				Name:        s1.Name,
+				Namespace:   s1.Namespace,
+				ServicePort: &s1.Spec.Ports[0],
+				Weight:      90,
 			}, {
-				TCPService: dag.TCPService{
-					Name: s1.Name, Namespace: s1.Namespace, // it's valid to mention the same service several times per route.
-					ServicePort: &s1.Spec.Ports[0],
-				},
+				Name:        s1.Name,
+				Namespace:   s1.Namespace, // it's valid to mention the same service several times per route.
+				ServicePort: &s1.Spec.Ports[0],
 			}},
 			want: &route.Route_Route{
 				Route: &route.RouteAction{
@@ -125,15 +118,15 @@ func TestRouteRoute(t *testing.T) {
 				Prefix:    "/",
 				Websocket: true,
 			},
-			services: []*dag.HTTPService{{
-				TCPService: dag.TCPService{
-					Name:        s1.Name,
-					Namespace:   s1.Namespace,
-					ServicePort: &s1.Spec.Ports[0],
-					Weight:      90,
-				},
+			services: []*dag.TCPService{{
+				Name:        s1.Name,
+				Namespace:   s1.Namespace,
+				ServicePort: &s1.Spec.Ports[0],
+				Weight:      90,
 			}, {
-				TCPService: service(s1), // it's valid to mention the same service several times per route.
+				Name:        s1.Name,
+				Namespace:   s1.Namespace, // it's valid to mention the same service several times per route.
+				ServicePort: &s1.Spec.Ports[0],
 			}},
 			want: &route.Route_Route{
 				Route: &route.RouteAction{
@@ -164,9 +157,7 @@ func TestRouteRoute(t *testing.T) {
 					PerTryTimeout: 10 * time.Second, // ignored
 				},
 			},
-			services: []*dag.HTTPService{{
-				TCPService: service(s1),
-			}},
+			services: services(s1),
 			want: &route.Route_Route{
 				Route: &route.RouteAction{
 					ClusterSpecifier: &route.RouteAction_Cluster{
@@ -185,9 +176,7 @@ func TestRouteRoute(t *testing.T) {
 					PerTryTimeout: 100 * time.Millisecond,
 				},
 			},
-			services: []*dag.HTTPService{{
-				TCPService: service(s1),
-			}},
+			services: services(s1),
 			want: &route.Route_Route{
 				Route: &route.RouteAction{
 					ClusterSpecifier: &route.RouteAction_Cluster{
@@ -211,9 +200,7 @@ func TestRouteRoute(t *testing.T) {
 					Timeout: 90 * time.Second,
 				},
 			},
-			services: []*dag.HTTPService{{
-				TCPService: service(s1),
-			}},
+			services: services(s1),
 			want: &route.Route_Route{
 				Route: &route.RouteAction{
 					ClusterSpecifier: &route.RouteAction_Cluster{
@@ -233,9 +220,7 @@ func TestRouteRoute(t *testing.T) {
 					Timeout: -1,
 				},
 			},
-			services: []*dag.HTTPService{{
-				TCPService: service(s1),
-			}},
+			services: services(s1),
 			want: &route.Route_Route{
 				Route: &route.RouteAction{
 					ClusterSpecifier: &route.RouteAction_Cluster{
@@ -262,25 +247,21 @@ func TestRouteRoute(t *testing.T) {
 
 func TestWeightedClusters(t *testing.T) {
 	tests := map[string]struct {
-		services []*dag.HTTPService
+		services []*dag.TCPService
 		want     *route.WeightedCluster
 	}{
 		"multiple services w/o weights": {
-			services: []*dag.HTTPService{{
-				TCPService: dag.TCPService{
-					Name:      "kuard",
-					Namespace: "default",
-					ServicePort: &v1.ServicePort{
-						Port: 8080,
-					},
+			services: []*dag.TCPService{{
+				Name:      "kuard",
+				Namespace: "default",
+				ServicePort: &v1.ServicePort{
+					Port: 8080,
 				},
 			}, {
-				TCPService: dag.TCPService{
-					Name:      "nginx",
-					Namespace: "default",
-					ServicePort: &v1.ServicePort{
-						Port: 8080,
-					},
+				Name:      "nginx",
+				Namespace: "default",
+				ServicePort: &v1.ServicePort{
+					Port: 8080,
 				},
 			}},
 			want: &route.WeightedCluster{
@@ -297,24 +278,20 @@ func TestWeightedClusters(t *testing.T) {
 			},
 		},
 		"multiple weighted services": {
-			services: []*dag.HTTPService{{
-				TCPService: dag.TCPService{
-					Name:      "kuard",
-					Namespace: "default",
-					ServicePort: &v1.ServicePort{
-						Port: 8080,
-					},
-					Weight: 80,
+			services: []*dag.TCPService{{
+				Name:      "kuard",
+				Namespace: "default",
+				ServicePort: &v1.ServicePort{
+					Port: 8080,
 				},
+				Weight: 80,
 			}, {
-				TCPService: dag.TCPService{
-					Name:      "nginx",
-					Namespace: "default",
-					ServicePort: &v1.ServicePort{
-						Port: 8080,
-					},
-					Weight: 20,
+				Name:      "nginx",
+				Namespace: "default",
+				ServicePort: &v1.ServicePort{
+					Port: 8080,
 				},
+				Weight: 20,
 			}},
 			want: &route.WeightedCluster{
 				Clusters: []*route.WeightedCluster_ClusterWeight{{
@@ -330,31 +307,25 @@ func TestWeightedClusters(t *testing.T) {
 			},
 		},
 		"multiple weighted services and one with no weight specified": {
-			services: []*dag.HTTPService{{
-				TCPService: dag.TCPService{
-					Name:      "kuard",
-					Namespace: "default",
-					ServicePort: &v1.ServicePort{
-						Port: 8080,
-					},
-					Weight: 80,
+			services: []*dag.TCPService{{
+				Name:      "kuard",
+				Namespace: "default",
+				ServicePort: &v1.ServicePort{
+					Port: 8080,
 				},
+				Weight: 80,
 			}, {
-				TCPService: dag.TCPService{
-					Name:      "nginx",
-					Namespace: "default",
-					ServicePort: &v1.ServicePort{
-						Port: 8080,
-					},
-					Weight: 20,
+				Name:      "nginx",
+				Namespace: "default",
+				ServicePort: &v1.ServicePort{
+					Port: 8080,
 				},
+				Weight: 20,
 			}, {
-				TCPService: dag.TCPService{
-					Name:      "notraffic",
-					Namespace: "default",
-					ServicePort: &v1.ServicePort{
-						Port: 8080,
-					},
+				Name:      "notraffic",
+				Namespace: "default",
+				ServicePort: &v1.ServicePort{
+					Port: 8080,
 				},
 			}},
 			want: &route.WeightedCluster{
@@ -446,4 +417,12 @@ func TestUpgradeHTTPS(t *testing.T) {
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Fatal(diff)
 	}
+}
+
+func services(svcs ...*v1.Service) (v []*dag.TCPService) {
+	for _, s := range svcs {
+		x := service(s)
+		v = append(v, &x)
+	}
+	return v
 }


### PR DESCRIPTION
There is nothing in dag.HTTPService that envoy.RouteRoute cares about so
adjust the signature to take a slice of dag.TCPService.

This will make the upcoming introduction of dag.Cluster easier.

Signed-off-by: Dave Cheney <dave@cheney.net>