### PR TITLE
internal/dag: introduce dag.Cluster

### DIFF
--- a/internal/contour/cluster.go
+++ b/internal/contour/cluster.go
@@ -96,21 +96,23 @@ func visitClusters(root dag.Vertex) map[string]*v2.Cluster {
 }
 
 func (v *clusterVisitor) visit(vertex dag.Vertex) {
-	switch service := vertex.(type) {
-	case *dag.HTTPService:
-		name := envoy.Clustername(&service.TCPService)
-		if _, ok := v.clusters[name]; !ok {
-			c := envoy.Cluster(service)
-			v.clusters[c.Name] = c
+	if cluster, ok := vertex.(*dag.Cluster); ok {
+		switch upstream := cluster.Upstream.(type) {
+		case *dag.HTTPService:
+			name := envoy.Clustername(&upstream.TCPService)
+			if _, ok := v.clusters[name]; !ok {
+				c := envoy.Cluster(cluster)
+				v.clusters[c.Name] = c
+			}
+		case *dag.TCPService:
+			name := envoy.Clustername(upstream)
+			if _, ok := v.clusters[name]; !ok {
+				c := envoy.Cluster(cluster)
+				v.clusters[c.Name] = c
+			}
+		default:
+			// nothing
 		}
-	case *dag.TCPService:
-		name := envoy.Clustername(service)
-		if _, ok := v.clusters[name]; !ok {
-			c := envoy.Cluster(service)
-			v.clusters[c.Name] = c
-		}
-	default:
-		// nothing
 	}
 
 	// recurse into children of v

--- a/internal/contour/cluster.go
+++ b/internal/contour/cluster.go
@@ -97,15 +97,15 @@ func visitClusters(root dag.Vertex) map[string]*v2.Cluster {
 
 func (v *clusterVisitor) visit(vertex dag.Vertex) {
 	if cluster, ok := vertex.(*dag.Cluster); ok {
-		switch upstream := cluster.Upstream.(type) {
+		switch cluster.Upstream.(type) {
 		case *dag.HTTPService:
-			name := envoy.Clustername(&upstream.TCPService)
+			name := envoy.Clustername(cluster)
 			if _, ok := v.clusters[name]; !ok {
 				c := envoy.Cluster(cluster)
 				v.clusters[c.Name] = c
 			}
 		case *dag.TCPService:
-			name := envoy.Clustername(upstream)
+			name := envoy.Clustername(cluster)
 			if _, ok := v.clusters[name]; !ok {
 				c := envoy.Cluster(cluster)
 				v.clusters[c.Name] = c

--- a/internal/contour/route.go
+++ b/internal/contour/route.go
@@ -116,25 +116,13 @@ func (v *routeVisitor) visit(vertex dag.Vertex) {
 				vhost := envoy.VirtualHost(vh.Name, l.Port)
 				vh.Visit(func(v dag.Vertex) {
 					if r, ok := v.(*dag.Route); ok {
-						var svcs []*dag.TCPService
-						r.Visit(func(v dag.Vertex) {
-							cluster, ok := v.(*dag.Cluster)
-							if !ok {
-								return
-							}
-							cluster.Visit(func(v dag.Vertex) {
-								if s, ok := v.(*dag.HTTPService); ok {
-									svcs = append(svcs, &s.TCPService)
-								}
-							})
-						})
-						if len(svcs) < 1 {
+						if len(r.Clusters) < 1 {
 							// no services for this route, skip it.
 							return
 						}
 						rr := route.Route{
 							Match:  envoy.PrefixMatch(r.Prefix),
-							Action: envoy.RouteRoute(r, svcs),
+							Action: envoy.RouteRoute(r, r.Clusters),
 						}
 
 						if r.HTTPSUpgrade {
@@ -152,25 +140,13 @@ func (v *routeVisitor) visit(vertex dag.Vertex) {
 				vhost := envoy.VirtualHost(vh.VirtualHost.Name, l.Port)
 				vh.Visit(func(v dag.Vertex) {
 					if r, ok := v.(*dag.Route); ok {
-						var svcs []*dag.TCPService
-						r.Visit(func(v dag.Vertex) {
-							cluster, ok := v.(*dag.Cluster)
-							if !ok {
-								return
-							}
-							cluster.Visit(func(v dag.Vertex) {
-								if s, ok := v.(*dag.HTTPService); ok {
-									svcs = append(svcs, &s.TCPService)
-								}
-							})
-						})
-						if len(svcs) < 1 {
+						if len(r.Clusters) < 1 {
 							// no services for this route, skip it.
 							return
 						}
 						vhost.Routes = append(vhost.Routes, route.Route{
 							Match:  envoy.PrefixMatch(r.Prefix),
-							Action: envoy.RouteRoute(r, svcs),
+							Action: envoy.RouteRoute(r, r.Clusters),
 						})
 					}
 				})

--- a/internal/contour/route.go
+++ b/internal/contour/route.go
@@ -117,13 +117,16 @@ func (v *routeVisitor) visit(vertex dag.Vertex) {
 				vh.Visit(func(v dag.Vertex) {
 					if r, ok := v.(*dag.Route); ok {
 						var svcs []*dag.TCPService
-						r.Visit(func(s dag.Vertex) {
-							switch s := s.(type) {
-							case *dag.HTTPService:
-								svcs = append(svcs, &s.TCPService)
-							case *dag.TCPService:
-								svcs = append(svcs, s)
+						r.Visit(func(v dag.Vertex) {
+							cluster, ok := v.(*dag.Cluster)
+							if !ok {
+								return
 							}
+							cluster.Visit(func(v dag.Vertex) {
+								if s, ok := v.(*dag.HTTPService); ok {
+									svcs = append(svcs, &s.TCPService)
+								}
+							})
 						})
 						if len(svcs) < 1 {
 							// no services for this route, skip it.
@@ -150,13 +153,16 @@ func (v *routeVisitor) visit(vertex dag.Vertex) {
 				vh.Visit(func(v dag.Vertex) {
 					if r, ok := v.(*dag.Route); ok {
 						var svcs []*dag.TCPService
-						r.Visit(func(s dag.Vertex) {
-							switch s := s.(type) {
-							case *dag.HTTPService:
-								svcs = append(svcs, &s.TCPService)
-							case *dag.TCPService:
-								svcs = append(svcs, s)
+						r.Visit(func(v dag.Vertex) {
+							cluster, ok := v.(*dag.Cluster)
+							if !ok {
+								return
 							}
+							cluster.Visit(func(v dag.Vertex) {
+								if s, ok := v.(*dag.HTTPService); ok {
+									svcs = append(svcs, &s.TCPService)
+								}
+							})
 						})
 						if len(svcs) < 1 {
 							// no services for this route, skip it.

--- a/internal/contour/visitor_test.go
+++ b/internal/contour/visitor_test.go
@@ -41,13 +41,15 @@ func TestVisitClusters(t *testing.T) {
 						VirtualHost: dag.VirtualHost{
 							Name: "www.example.com",
 							TCPProxy: &dag.TCPProxy{
-								Services: []*dag.TCPService{{
-									Name:      "example",
-									Namespace: "default",
-									ServicePort: &v1.ServicePort{
-										Protocol:   "TCP",
-										Port:       443,
-										TargetPort: intstr.FromInt(8443),
+								Clusters: []*dag.Cluster{{
+									Upstream: &dag.TCPService{
+										Name:      "example",
+										Namespace: "default",
+										ServicePort: &v1.ServicePort{
+											Protocol:   "TCP",
+											Port:       443,
+											TargetPort: intstr.FromInt(8443),
+										},
 									},
 								}},
 							},
@@ -85,13 +87,15 @@ func TestVisitClusters(t *testing.T) {
 
 func TestVisitListeners(t *testing.T) {
 	p1 := &dag.TCPProxy{
-		Services: []*dag.TCPService{{
-			Name:      "example",
-			Namespace: "default",
-			ServicePort: &v1.ServicePort{
-				Protocol:   "TCP",
-				Port:       443,
-				TargetPort: intstr.FromInt(8443),
+		Clusters: []*dag.Cluster{{
+			Upstream: &dag.TCPService{
+				Name:      "example",
+				Namespace: "default",
+				ServicePort: &v1.ServicePort{
+					Protocol:   "TCP",
+					Port:       443,
+					TargetPort: intstr.FromInt(8443),
+				},
 			},
 		}},
 	}

--- a/internal/dag/builder.go
+++ b/internal/dag/builder.go
@@ -730,7 +730,9 @@ func (b *builder) processTCPProxy(ir *ingressroutev1.IngressRoute, visited []*in
 				b.setStatus(Status{Object: ir, Status: StatusInvalid, Description: fmt.Sprintf("tcpproxy: service %s/%s/%d: not found", ir.Namespace, service.Name, service.Port), Vhost: host})
 				return
 			}
-			proxy.Services = append(proxy.Services, s)
+			proxy.Clusters = append(proxy.Clusters, &Cluster{
+				Upstream: s,
+			})
 		}
 		b.lookupSecureVirtualHost(host).VirtualHost.TCPProxy = &proxy
 		b.setStatus(Status{Object: ir, Status: StatusValid, Description: "valid IngressRoute", Vhost: host})

--- a/internal/dag/builder.go
+++ b/internal/dag/builder.go
@@ -20,122 +20,21 @@ import (
 	"sort"
 	"strconv"
 	"strings"
-	"sync"
 	"time"
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/api/extensions/v1beta1"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"k8s.io/client-go/tools/cache"
 
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2/auth"
 	ingressroutev1 "github.com/heptio/contour/apis/contour/v1beta1"
 )
-
-// A KubernetesCache holds Kubernetes objects and associated configuration and produces
-// DAG values.
-type KubernetesCache struct {
-	// IngressRouteRootNamespaces specifies the namespaces where root
-	// IngressRoutes can be defined. If empty, roots can be defined in any
-	// namespace.
-	IngressRouteRootNamespaces []string
-
-	mu sync.RWMutex
-
-	ingresses     map[meta]*v1beta1.Ingress
-	ingressroutes map[meta]*ingressroutev1.IngressRoute
-	secrets       map[meta]*v1.Secret
-	delegations   map[meta]*ingressroutev1.TLSCertificateDelegation
-	services      map[meta]*v1.Service
-}
-
-// meta holds the name and namespace of a Kubernetes object.
-type meta struct {
-	name, namespace string
-}
 
 const (
 	StatusValid    = "valid"
 	StatusInvalid  = "invalid"
 	StatusOrphaned = "orphaned"
 )
-
-// Insert inserts obj into the KubernetesCache.
-// If an object with a matching type, name, and namespace exists, it will be overwritten.
-func (kc *KubernetesCache) Insert(obj interface{}) {
-	kc.mu.Lock()
-	defer kc.mu.Unlock()
-	switch obj := obj.(type) {
-	case *v1.Secret:
-		m := meta{name: obj.Name, namespace: obj.Namespace}
-		if kc.secrets == nil {
-			kc.secrets = make(map[meta]*v1.Secret)
-		}
-		kc.secrets[m] = obj
-	case *v1.Service:
-		m := meta{name: obj.Name, namespace: obj.Namespace}
-		if kc.services == nil {
-			kc.services = make(map[meta]*v1.Service)
-		}
-		kc.services[m] = obj
-	case *v1beta1.Ingress:
-		m := meta{name: obj.Name, namespace: obj.Namespace}
-		if kc.ingresses == nil {
-			kc.ingresses = make(map[meta]*v1beta1.Ingress)
-		}
-		kc.ingresses[m] = obj
-	case *ingressroutev1.IngressRoute:
-		m := meta{name: obj.Name, namespace: obj.Namespace}
-		if kc.ingressroutes == nil {
-			kc.ingressroutes = make(map[meta]*ingressroutev1.IngressRoute)
-		}
-		kc.ingressroutes[m] = obj
-	case *ingressroutev1.TLSCertificateDelegation:
-		m := meta{name: obj.Name, namespace: obj.Namespace}
-		if kc.delegations == nil {
-			kc.delegations = make(map[meta]*ingressroutev1.TLSCertificateDelegation)
-		}
-		kc.delegations[m] = obj
-
-	default:
-		// not an interesting object
-	}
-}
-
-// Remove removes obj from the KubernetesCache.
-// If no object with a matching type, name, and namespace exists in the DAG, no action is taken.
-func (kc *KubernetesCache) Remove(obj interface{}) {
-	switch obj := obj.(type) {
-	default:
-		kc.remove(obj)
-	case cache.DeletedFinalStateUnknown:
-		kc.Remove(obj.Obj) // recurse into ourselves with the tombstoned value
-	}
-}
-
-func (kc *KubernetesCache) remove(obj interface{}) {
-	kc.mu.Lock()
-	defer kc.mu.Unlock()
-	switch obj := obj.(type) {
-	case *v1.Secret:
-		m := meta{name: obj.Name, namespace: obj.Namespace}
-		delete(kc.secrets, m)
-	case *v1.Service:
-		m := meta{name: obj.Name, namespace: obj.Namespace}
-		delete(kc.services, m)
-	case *v1beta1.Ingress:
-		m := meta{name: obj.Name, namespace: obj.Namespace}
-		delete(kc.ingresses, m)
-	case *ingressroutev1.IngressRoute:
-		m := meta{name: obj.Name, namespace: obj.Namespace}
-		delete(kc.ingressroutes, m)
-	case *ingressroutev1.TLSCertificateDelegation:
-		m := meta{name: obj.Name, namespace: obj.Namespace}
-		delete(kc.delegations, m)
-	default:
-		// not interesting
-	}
-}
 
 // A Builder builds a *DAGs
 type Builder struct {

--- a/internal/dag/builder_test.go
+++ b/internal/dag/builder_test.go
@@ -1804,9 +1804,9 @@ func TestDAGInsert(t *testing.T) {
 							VirtualHost: VirtualHost{
 								Name: "kuard.example.com",
 								TCPProxy: &TCPProxy{
-									Services: []*TCPService{
+									Clusters: clusters(
 										tcpService(s1),
-									},
+									),
 								},
 							},
 							Secret:          secret(sec1),
@@ -1828,9 +1828,9 @@ func TestDAGInsert(t *testing.T) {
 							VirtualHost: VirtualHost{
 								Name: "kuard.example.com",
 								TCPProxy: &TCPProxy{
-									Services: []*TCPService{
+									Clusters: clusters(
 										tcpService(s1),
-									},
+									),
 								},
 							},
 						},
@@ -1851,9 +1851,9 @@ func TestDAGInsert(t *testing.T) {
 							VirtualHost: VirtualHost{
 								Name: "kuard.example.com",
 								TCPProxy: &TCPProxy{
-									Services: []*TCPService{
+									Clusters: clusters(
 										tcpService(s6),
-									},
+									),
 								},
 							},
 						},
@@ -3649,6 +3649,15 @@ func routeWebsocket(prefix string, services ...*HTTPService) *Route {
 	r := route(prefix, services...)
 	r.Websocket = true
 	return r
+}
+
+func clusters(services ...Service) (c []*Cluster) {
+	for _, s := range services {
+		c = append(c, &Cluster{
+			Upstream: s,
+		})
+	}
+	return c
 }
 
 func tcpService(s *v1.Service) *TCPService {

--- a/internal/dag/cache.go
+++ b/internal/dag/cache.go
@@ -1,0 +1,125 @@
+// Copyright © 2018 Heptio
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package dag provides a data model, in the form of a directed acyclic graph,
+// of the relationship between Kubernetes Ingress, Service, and Secret objects.
+package dag
+
+import (
+	"sync"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/api/extensions/v1beta1"
+	"k8s.io/client-go/tools/cache"
+
+	ingressroutev1 "github.com/heptio/contour/apis/contour/v1beta1"
+)
+
+// A KubernetesCache holds Kubernetes objects and associated configuration and produces
+// DAG values.
+type KubernetesCache struct {
+	// IngressRouteRootNamespaces specifies the namespaces where root
+	// IngressRoutes can be defined. If empty, roots can be defined in any
+	// namespace.
+	IngressRouteRootNamespaces []string
+
+	mu sync.RWMutex
+
+	ingresses     map[meta]*v1beta1.Ingress
+	ingressroutes map[meta]*ingressroutev1.IngressRoute
+	secrets       map[meta]*v1.Secret
+	delegations   map[meta]*ingressroutev1.TLSCertificateDelegation
+	services      map[meta]*v1.Service
+}
+
+// meta holds the name and namespace of a Kubernetes object.
+type meta struct {
+	name, namespace string
+}
+
+// Insert inserts obj into the KubernetesCache.
+// If an object with a matching type, name, and namespace exists, it will be overwritten.
+func (kc *KubernetesCache) Insert(obj interface{}) {
+	kc.mu.Lock()
+	defer kc.mu.Unlock()
+	switch obj := obj.(type) {
+	case *v1.Secret:
+		m := meta{name: obj.Name, namespace: obj.Namespace}
+		if kc.secrets == nil {
+			kc.secrets = make(map[meta]*v1.Secret)
+		}
+		kc.secrets[m] = obj
+	case *v1.Service:
+		m := meta{name: obj.Name, namespace: obj.Namespace}
+		if kc.services == nil {
+			kc.services = make(map[meta]*v1.Service)
+		}
+		kc.services[m] = obj
+	case *v1beta1.Ingress:
+		m := meta{name: obj.Name, namespace: obj.Namespace}
+		if kc.ingresses == nil {
+			kc.ingresses = make(map[meta]*v1beta1.Ingress)
+		}
+		kc.ingresses[m] = obj
+	case *ingressroutev1.IngressRoute:
+		m := meta{name: obj.Name, namespace: obj.Namespace}
+		if kc.ingressroutes == nil {
+			kc.ingressroutes = make(map[meta]*ingressroutev1.IngressRoute)
+		}
+		kc.ingressroutes[m] = obj
+	case *ingressroutev1.TLSCertificateDelegation:
+		m := meta{name: obj.Name, namespace: obj.Namespace}
+		if kc.delegations == nil {
+			kc.delegations = make(map[meta]*ingressroutev1.TLSCertificateDelegation)
+		}
+		kc.delegations[m] = obj
+
+	default:
+		// not an interesting object
+	}
+}
+
+// Remove removes obj from the KubernetesCache.
+// If no object with a matching type, name, and namespace exists in the DAG, no action is taken.
+func (kc *KubernetesCache) Remove(obj interface{}) {
+	switch obj := obj.(type) {
+	default:
+		kc.remove(obj)
+	case cache.DeletedFinalStateUnknown:
+		kc.Remove(obj.Obj) // recurse into ourselves with the tombstoned value
+	}
+}
+
+func (kc *KubernetesCache) remove(obj interface{}) {
+	kc.mu.Lock()
+	defer kc.mu.Unlock()
+	switch obj := obj.(type) {
+	case *v1.Secret:
+		m := meta{name: obj.Name, namespace: obj.Namespace}
+		delete(kc.secrets, m)
+	case *v1.Service:
+		m := meta{name: obj.Name, namespace: obj.Namespace}
+		delete(kc.services, m)
+	case *v1beta1.Ingress:
+		m := meta{name: obj.Name, namespace: obj.Namespace}
+		delete(kc.ingresses, m)
+	case *ingressroutev1.IngressRoute:
+		m := meta{name: obj.Name, namespace: obj.Namespace}
+		delete(kc.ingressroutes, m)
+	case *ingressroutev1.TLSCertificateDelegation:
+		m := meta{name: obj.Name, namespace: obj.Namespace}
+		delete(kc.delegations, m)
+	default:
+		// not interesting
+	}
+}

--- a/internal/dag/dag.go
+++ b/internal/dag/dag.go
@@ -187,12 +187,14 @@ func (l *Listener) Visit(f func(Vertex)) {
 
 // TCPProxy represents a cluster of TCP endpoints.
 type TCPProxy struct {
-	// Services to proxy decrypted traffic to.
-	Services []*TCPService
+
+	// Clusters is the, possibly weighted, set
+	// of upstream services to forward decrypted traffic.
+	Clusters []*Cluster
 }
 
 func (t *TCPProxy) Visit(f func(Vertex)) {
-	for _, s := range t.Services {
+	for _, s := range t.Clusters {
 		f(s)
 	}
 }
@@ -251,6 +253,19 @@ func (s *TCPService) toMeta() servicemeta {
 
 func (s *TCPService) Visit(func(Vertex)) {
 	// TCPServices are leaves in the DAG.
+}
+
+// Cluster holds the connetion specific parameters that apply to
+// traffic routed to an upstream service.
+type Cluster struct {
+
+	// Upstream is the backend Kubernetes service traffic arriving
+	// at this Cluster will be forwarded too.
+	Upstream Service
+}
+
+func (c Cluster) Visit(f func(Vertex)) {
+	f(c.Upstream)
 }
 
 // HTTPService represents a Kuberneres Service object which speaks

--- a/internal/dag/dag.go
+++ b/internal/dag/dag.go
@@ -48,8 +48,8 @@ func (d *DAG) Statuses() []Status {
 }
 
 type Route struct {
-	Prefix       string
-	httpServices map[servicemeta]*HTTPService
+	Prefix   string
+	Clusters map[servicemeta]*Cluster
 
 	// Should this route generate a 301 upgrade if accessed
 	// over HTTP?
@@ -94,14 +94,16 @@ type RetryPolicy struct {
 }
 
 func (r *Route) addHTTPService(s *HTTPService) {
-	if r.httpServices == nil {
-		r.httpServices = make(map[servicemeta]*HTTPService)
+	if r.Clusters == nil {
+		r.Clusters = make(map[servicemeta]*Cluster)
 	}
-	r.httpServices[s.toMeta()] = s
+	r.Clusters[s.toMeta()] = &Cluster{
+		Upstream: s,
+	}
 }
 
 func (r *Route) Visit(f func(Vertex)) {
-	for _, c := range r.httpServices {
+	for _, c := range r.Clusters {
 		f(c)
 	}
 }

--- a/internal/debug/dot.go
+++ b/internal/debug/dot.go
@@ -58,6 +58,8 @@ func (c *ctx) writeVertex(v dag.Vertex) {
 		fmt.Fprintf(c.w, `"%p" [shape=record, label="{tcpservice|%s/%s:%d}"]`+"\n", v, v.Namespace, v.Name, v.Port)
 	case *dag.TCPProxy:
 		fmt.Fprintf(c.w, `"%p" [shape=record, label="{tcpproxy}"]`+"\n", v)
+	case *dag.Cluster:
+		fmt.Fprintf(c.w, `"%p" [shape=record, label="{cluster}"]`+"\n", v)
 	}
 }
 

--- a/internal/debug/dot.go
+++ b/internal/debug/dot.go
@@ -18,6 +18,7 @@ import (
 	"io"
 
 	"github.com/heptio/contour/internal/dag"
+	"github.com/heptio/contour/internal/envoy"
 )
 
 // quick and dirty dot debugging package
@@ -59,7 +60,7 @@ func (c *ctx) writeVertex(v dag.Vertex) {
 	case *dag.TCPProxy:
 		fmt.Fprintf(c.w, `"%p" [shape=record, label="{tcpproxy}"]`+"\n", v)
 	case *dag.Cluster:
-		fmt.Fprintf(c.w, `"%p" [shape=record, label="{cluster}"]`+"\n", v)
+		fmt.Fprintf(c.w, `"%p" [shape=record, label="{cluster|{%s|weight %d}}"]`+"\n", v, envoy.Clustername(v), v.Weight)
 	}
 }
 

--- a/internal/e2e/rds_test.go
+++ b/internal/e2e/rds_test.go
@@ -2436,7 +2436,7 @@ func TestLoadBalancingStrategies(t *testing.T) {
 		Routes: []route.Route{
 			{
 				Match:  envoy.PrefixMatch("/a"),
-				Action: routeweightedcluster(wc[0], wc[1:]...),
+				Action: routeweightedcluster(wc...),
 			},
 		},
 	}}
@@ -2592,11 +2592,11 @@ func routecluster(cluster string) *route.Route_Route {
 	}
 }
 
-func routeweightedcluster(first weightedcluster, rest ...weightedcluster) *route.Route_Route {
+func routeweightedcluster(clusters ...weightedcluster) *route.Route_Route {
 	return &route.Route_Route{
 		Route: &route.RouteAction{
 			ClusterSpecifier: &route.RouteAction_WeightedClusters{
-				WeightedClusters: weightedclusters(append([]weightedcluster{first}, rest...)),
+				WeightedClusters: weightedclusters(clusters),
 			},
 		},
 	}

--- a/internal/envoy/cluster_test.go
+++ b/internal/envoy/cluster_test.go
@@ -47,12 +47,14 @@ func TestCluster(t *testing.T) {
 	}
 
 	tests := map[string]struct {
-		service dag.Service
+		cluster *dag.Cluster
 		want    *v2.Cluster
 	}{
 		"simple service": {
-			service: &dag.HTTPService{
-				TCPService: service(s1),
+			cluster: &dag.Cluster{
+				Upstream: &dag.HTTPService{
+					TCPService: service(s1),
+				},
 			},
 			want: &v2.Cluster{
 				Name:                 "default/kuard/443/da39a3ee5e",
@@ -68,9 +70,11 @@ func TestCluster(t *testing.T) {
 			},
 		},
 		"h2c upstream": {
-			service: &dag.HTTPService{
-				TCPService: service(s1),
-				Protocol:   "h2c",
+			cluster: &dag.Cluster{
+				Upstream: &dag.HTTPService{
+					TCPService: service(s1),
+					Protocol:   "h2c",
+				},
 			},
 			want: &v2.Cluster{
 				Name:                 "default/kuard/443/da39a3ee5e",
@@ -87,9 +91,11 @@ func TestCluster(t *testing.T) {
 			},
 		},
 		"h2 upstream": {
-			service: &dag.HTTPService{
-				TCPService: service(s1),
-				Protocol:   "h2",
+			cluster: &dag.Cluster{
+				Upstream: &dag.HTTPService{
+					TCPService: service(s1),
+					Protocol:   "h2",
+				},
 			},
 			want: &v2.Cluster{
 				Name:                 "default/kuard/443/da39a3ee5e",
@@ -107,9 +113,11 @@ func TestCluster(t *testing.T) {
 			},
 		},
 		"tls upstream": {
-			service: &dag.HTTPService{
-				TCPService: service(s1),
-				Protocol:   "tls",
+			cluster: &dag.Cluster{
+				Upstream: &dag.HTTPService{
+					TCPService: service(s1),
+					Protocol:   "tls",
+				},
 			},
 			want: &v2.Cluster{
 				Name:                 "default/kuard/443/da39a3ee5e",
@@ -126,11 +134,13 @@ func TestCluster(t *testing.T) {
 			},
 		},
 		"contour.heptio.com/max-connections": {
-			service: &dag.HTTPService{
-				TCPService: dag.TCPService{
-					Name: s1.Name, Namespace: s1.Namespace,
-					ServicePort:    &s1.Spec.Ports[0],
-					MaxConnections: 9000,
+			cluster: &dag.Cluster{
+				Upstream: &dag.HTTPService{
+					TCPService: dag.TCPService{
+						Name: s1.Name, Namespace: s1.Namespace,
+						ServicePort:    &s1.Spec.Ports[0],
+						MaxConnections: 9000,
+					},
 				},
 			},
 			want: &v2.Cluster{
@@ -152,11 +162,13 @@ func TestCluster(t *testing.T) {
 			},
 		},
 		"contour.heptio.com/max-pending-requests": {
-			service: &dag.HTTPService{
-				TCPService: dag.TCPService{
-					Name: s1.Name, Namespace: s1.Namespace,
-					ServicePort:        &s1.Spec.Ports[0],
-					MaxPendingRequests: 4096,
+			cluster: &dag.Cluster{
+				Upstream: &dag.HTTPService{
+					TCPService: dag.TCPService{
+						Name: s1.Name, Namespace: s1.Namespace,
+						ServicePort:        &s1.Spec.Ports[0],
+						MaxPendingRequests: 4096,
+					},
 				},
 			},
 			want: &v2.Cluster{
@@ -178,11 +190,13 @@ func TestCluster(t *testing.T) {
 			},
 		},
 		"contour.heptio.com/max-requests": {
-			service: &dag.HTTPService{
-				TCPService: dag.TCPService{
-					Name: s1.Name, Namespace: s1.Namespace,
-					ServicePort: &s1.Spec.Ports[0],
-					MaxRequests: 404,
+			cluster: &dag.Cluster{
+				Upstream: &dag.HTTPService{
+					TCPService: dag.TCPService{
+						Name: s1.Name, Namespace: s1.Namespace,
+						ServicePort: &s1.Spec.Ports[0],
+						MaxRequests: 404,
+					},
 				},
 			},
 			want: &v2.Cluster{
@@ -204,11 +218,13 @@ func TestCluster(t *testing.T) {
 			},
 		},
 		"contour.heptio.com/max-retries": {
-			service: &dag.HTTPService{
-				TCPService: dag.TCPService{
-					Name: s1.Name, Namespace: s1.Namespace,
-					ServicePort: &s1.Spec.Ports[0],
-					MaxRetries:  7,
+			cluster: &dag.Cluster{
+				Upstream: &dag.HTTPService{
+					TCPService: dag.TCPService{
+						Name: s1.Name, Namespace: s1.Namespace,
+						ServicePort: &s1.Spec.Ports[0],
+						MaxRetries:  7,
+					},
 				},
 			},
 			want: &v2.Cluster{
@@ -230,9 +246,11 @@ func TestCluster(t *testing.T) {
 			},
 		},
 		"tcp service": {
-			service: &dag.TCPService{
-				Name: s1.Name, Namespace: s1.Namespace,
-				ServicePort: &s1.Spec.Ports[0],
+			cluster: &dag.Cluster{
+				Upstream: &dag.TCPService{
+					Name: s1.Name, Namespace: s1.Namespace,
+					ServicePort: &s1.Spec.Ports[0],
+				},
 			},
 			want: &v2.Cluster{
 				Name:                 "default/kuard/443/da39a3ee5e",
@@ -248,11 +266,13 @@ func TestCluster(t *testing.T) {
 			},
 		},
 		"tcp service with healthcheck": {
-			service: &dag.TCPService{
-				Name: s1.Name, Namespace: s1.Namespace,
-				ServicePort: &s1.Spec.Ports[0],
-				HealthCheck: &ingressroutev1.HealthCheck{
-					Path: "/healthz",
+			cluster: &dag.Cluster{
+				Upstream: &dag.TCPService{
+					Name: s1.Name, Namespace: s1.Namespace,
+					ServicePort: &s1.Spec.Ports[0],
+					HealthCheck: &ingressroutev1.HealthCheck{
+						Path: "/healthz",
+					},
 				},
 			},
 			want: &v2.Cluster{
@@ -287,7 +307,7 @@ func TestCluster(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			got := Cluster(tc.service)
+			got := Cluster(tc.cluster)
 			if diff := cmp.Diff(tc.want, got); diff != "" {
 				t.Fatal(diff)
 			}

--- a/internal/envoy/cluster_test.go
+++ b/internal/envoy/cluster_test.go
@@ -317,52 +317,58 @@ func TestCluster(t *testing.T) {
 
 func TestClustername(t *testing.T) {
 	tests := map[string]struct {
-		service *dag.TCPService
+		cluster *dag.Cluster
 		want    string
 	}{
 		"simple": {
-			service: &dag.TCPService{
-				Name:      "backend",
-				Namespace: "default",
-				ServicePort: &v1.ServicePort{
-					Name:       "http",
-					Protocol:   "TCP",
-					Port:       80,
-					TargetPort: intstr.FromInt(6502),
+			cluster: &dag.Cluster{
+				Upstream: &dag.TCPService{
+					Name:      "backend",
+					Namespace: "default",
+					ServicePort: &v1.ServicePort{
+						Name:       "http",
+						Protocol:   "TCP",
+						Port:       80,
+						TargetPort: intstr.FromInt(6502),
+					},
 				},
 			},
 			want: "default/backend/80/da39a3ee5e",
 		},
 		"far too long": {
-			service: &dag.TCPService{
-				Name:      "must-be-in-want-of-a-wife",
-				Namespace: "it-is-a-truth-universally-acknowledged-that-a-single-man-in-possession-of-a-good-fortune",
-				ServicePort: &v1.ServicePort{
-					Name:       "http",
-					Protocol:   "TCP",
-					Port:       9999,
-					TargetPort: intstr.FromString("http-alt"),
+			cluster: &dag.Cluster{
+				Upstream: &dag.TCPService{
+					Name:      "must-be-in-want-of-a-wife",
+					Namespace: "it-is-a-truth-universally-acknowledged-that-a-single-man-in-possession-of-a-good-fortune",
+					ServicePort: &v1.ServicePort{
+						Name:       "http",
+						Protocol:   "TCP",
+						Port:       9999,
+						TargetPort: intstr.FromString("http-alt"),
+					},
 				},
 			},
 			want: "it-is-a--dea8b0/must-be--dea8b0/9999/da39a3ee5e",
 		},
 		"various healthcheck params": {
-			service: &dag.TCPService{
-				Name:      "backend",
-				Namespace: "default",
-				ServicePort: &v1.ServicePort{
-					Name:       "http",
-					Protocol:   "TCP",
-					Port:       80,
-					TargetPort: intstr.FromInt(6502),
-				},
-				LoadBalancerStrategy: "Maglev",
-				HealthCheck: &ingressroutev1.HealthCheck{
-					Path:                    "/healthz",
-					IntervalSeconds:         5,
-					TimeoutSeconds:          30,
-					UnhealthyThresholdCount: 3,
-					HealthyThresholdCount:   1,
+			cluster: &dag.Cluster{
+				Upstream: &dag.TCPService{
+					Name:      "backend",
+					Namespace: "default",
+					ServicePort: &v1.ServicePort{
+						Name:       "http",
+						Protocol:   "TCP",
+						Port:       80,
+						TargetPort: intstr.FromInt(6502),
+					},
+					LoadBalancerStrategy: "Maglev",
+					HealthCheck: &ingressroutev1.HealthCheck{
+						Path:                    "/healthz",
+						IntervalSeconds:         5,
+						TimeoutSeconds:          30,
+						UnhealthyThresholdCount: 3,
+						HealthyThresholdCount:   1,
+					},
 				},
 			},
 			want: "default/backend/80/32737eb011",
@@ -371,7 +377,7 @@ func TestClustername(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			got := Clustername(tc.service)
+			got := Clustername(tc.cluster)
 			if diff := cmp.Diff(tc.want, got); diff != "" {
 				t.Fatal(diff)
 			}

--- a/internal/envoy/listener.go
+++ b/internal/envoy/listener.go
@@ -119,7 +119,7 @@ func TCPProxy(statPrefix string, proxy *dag.TCPProxy, accessLogPath string) list
 				Config: &types.Struct{
 					Fields: map[string]*types.Value{
 						"stat_prefix": sv(statPrefix),
-						"cluster":     sv(Clustername(proxy.Clusters[0].Upstream.(*dag.TCPService))),
+						"cluster":     sv(Clustername(proxy.Clusters[0])),
 						"access_log":  accesslog(accessLogPath),
 					},
 				},
@@ -133,13 +133,12 @@ func TCPProxy(statPrefix string, proxy *dag.TCPProxy, accessLogPath string) list
 		sort.Stable(tcpServiceByName(clusters))
 		var l []*types.Value
 		for _, cluster := range clusters {
-			upstream := cluster.Upstream.(*dag.TCPService)
-			weight := upstream.Weight
+			weight := cluster.Weight
 			if weight == 0 {
 				weight = 1
 			}
 			l = append(l, st(map[string]*types.Value{
-				"name":   sv(Clustername(upstream)),
+				"name":   sv(Clustername(cluster)),
 				"weight": nv(float64(weight)),
 			}))
 		}
@@ -167,7 +166,7 @@ func (t tcpServiceByName) Swap(i, j int) { t[i], t[j] = t[j], t[i] }
 func (t tcpServiceByName) Less(i, j int) bool {
 	a, b := t[i].Upstream.(*dag.TCPService), t[j].Upstream.(*dag.TCPService)
 	if a.Name == b.Name {
-		return a.Weight < b.Weight
+		return t[i].Weight < t[j].Weight
 	}
 	return a.Name < b.Name
 }

--- a/internal/envoy/listener_test.go
+++ b/internal/envoy/listener_test.go
@@ -221,9 +221,9 @@ func TestTCPProxy(t *testing.T) {
 	}{
 		"single cluster": {
 			proxy: &dag.TCPProxy{
-				Services: []*dag.TCPService{
-					s1,
-				},
+				Clusters: []*dag.Cluster{{
+					Upstream: s1,
+				}},
 			},
 			want: listener.Filter{
 				Name: util.TCPProxy,
@@ -245,9 +245,11 @@ func TestTCPProxy(t *testing.T) {
 		},
 		"multiple cluster": {
 			proxy: &dag.TCPProxy{
-				Services: []*dag.TCPService{
-					s2, s1, // assert that these are sorted
-				},
+				Clusters: []*dag.Cluster{{
+					Upstream: s2,
+				}, {
+					Upstream: s1, // assert that these are sorted
+				}},
 			},
 			want: listener.Filter{
 				Name: util.TCPProxy,


### PR DESCRIPTION
Updates #813 

Background:

Around the 0.5/0.6 timeframe we added initial support for retries and health check strategy. The problem was we added these parameters on the dag.Service object; creating different versions of the same backend service depending on the properties of the path between the route and and the backend service.

This created two problems. The first is the linkage between the route and the service is the CDS cluster entry. We identify the cluster entry by name, and we have to pack all the properties of the _path_ from the route to the cluster into the cluster's name--different health check parameters to the same service, they have a different cluster name. The extra fun part is we only have 60 characters to encode all this information.

The second problem is tracking all the parameters that make up the cluster's name, more accurately, the hash suffix of the cluster. In effect each property of the CDS cluster that can be affected by IngressRoute is a different input into the clusters' hashed name, With #815 this list of inputs now grows to encompass a subjectAltName and the entire contents of a CA certificate and is past the point of being sustainable.

This PR:

With this background this PR introduce a new DAG edge, a Cluster object. The Cluster sits between a Route and a backend k8s Service. The Cluster holds all the parameters that encode _how_ we talk to a backend service, but _not_ the properties of the service itself; its name, namespace, port, and L7 protocol.

This PR only moves one parameter from dag.TCPService to dag.Cluster, the cluster's relative weighting (ironically this is the only Cluster property which does not contribute to the cluster's name hash). Future PRs will move the other retry, lb strategy, and healthcheck parameters. This also creates a place for the upcoming CA certificate and subjectAltName parameters.

![contour-dag](https://user-images.githubusercontent.com/7171/56361225-24f9a600-622a-11e9-89c7-8210adcad223.png)

