### PR TITLE
Add prometheus annotations for contour container

### DIFF
--- a/deployment/common/service.yaml
+++ b/deployment/common/service.yaml
@@ -11,6 +11,11 @@ metadata:
   # for information about enabling the PROXY protocol on the ELB to recover
   # the original remote IP address.
   service.beta.kubernetes.io/aws-load-balancer-backend-protocol: tcp
+
+  # Scrape metrics for the contour container
+  # The envoy container is scraped by annotations on the pod spec
+  prometheus.io/port: "8000"
+  prometheus.io/scrape: "true"
 spec:
  ports:
  - port: 80

--- a/deployment/deployment-grpc-v2/02-contour.yaml
+++ b/deployment/deployment-grpc-v2/02-contour.yaml
@@ -17,8 +17,7 @@ spec:
       annotations:
         prometheus.io/scrape: "true"
         prometheus.io/port: "8002"
-        prometheus.io/path: "/stats"
-        prometheus.io/format: "prometheus"
+        prometheus.io/path: "/stats/prometheus"
     spec:
       containers:
       - image: gcr.io/heptio-images/contour:master

--- a/deployment/ds-grpc-v2/02-contour.yaml
+++ b/deployment/ds-grpc-v2/02-contour.yaml
@@ -18,8 +18,7 @@ spec:
       annotations:
         prometheus.io/scrape: "true"
         prometheus.io/port: "8002"
-        prometheus.io/path: "/stats"
-        prometheus.io/format: "prometheus"
+        prometheus.io/path: "/stats/prometheus"
     spec:
       containers:
       - image: gcr.io/heptio-images/contour:master

--- a/deployment/ds-hostnet/02-contour.yaml
+++ b/deployment/ds-hostnet/02-contour.yaml
@@ -18,8 +18,7 @@ spec:
       annotations:
         prometheus.io/scrape: "true"
         prometheus.io/port: "8002"
-        prometheus.io/path: "/stats"
-        prometheus.io/format: "prometheus"
+        prometheus.io/path: "/stats/prometheus"
     spec:
       hostNetwork: true
       containers:

--- a/deployment/ds-hostnet/02-service.yaml
+++ b/deployment/ds-hostnet/02-service.yaml
@@ -5,6 +5,10 @@ metadata:
  namespace: heptio-contour
  annotations:
    service.beta.kubernetes.io/aws-load-balancer-type: nlb
+   # Scrape metrics for the contour container
+   # The envoy container is scraped by annotations on the pod spec
+   prometheus.io/port: "8000"
+   prometheus.io/scrape: "true"
 spec:
  ports:
  - port: 80

--- a/deployment/render/daemonset-rbac.yaml
+++ b/deployment/render/daemonset-rbac.yaml
@@ -202,8 +202,7 @@ spec:
       annotations:
         prometheus.io/scrape: "true"
         prometheus.io/port: "8002"
-        prometheus.io/path: "/stats"
-        prometheus.io/format: "prometheus"
+        prometheus.io/path: "/stats/prometheus"
     spec:
       containers:
       - image: gcr.io/heptio-images/contour:master

--- a/deployment/render/daemonset-rbac.yaml
+++ b/deployment/render/daemonset-rbac.yaml
@@ -327,6 +327,11 @@ metadata:
   # for information about enabling the PROXY protocol on the ELB to recover
   # the original remote IP address.
   service.beta.kubernetes.io/aws-load-balancer-backend-protocol: tcp
+
+  # Scrape metrics for the contour container
+  # The envoy container is scraped by annotations on the pod spec
+  prometheus.io/port: "8000"
+  prometheus.io/scrape: "true"
 spec:
  ports:
  - port: 80

--- a/deployment/render/deployment-rbac.yaml
+++ b/deployment/render/deployment-rbac.yaml
@@ -201,8 +201,7 @@ spec:
       annotations:
         prometheus.io/scrape: "true"
         prometheus.io/port: "8002"
-        prometheus.io/path: "/stats"
-        prometheus.io/format: "prometheus"
+        prometheus.io/path: "/stats/prometheus"
     spec:
       containers:
       - image: gcr.io/heptio-images/contour:master

--- a/deployment/render/deployment-rbac.yaml
+++ b/deployment/render/deployment-rbac.yaml
@@ -344,6 +344,11 @@ metadata:
   # for information about enabling the PROXY protocol on the ELB to recover
   # the original remote IP address.
   service.beta.kubernetes.io/aws-load-balancer-backend-protocol: tcp
+
+  # Scrape metrics for the contour container
+  # The envoy container is scraped by annotations on the pod spec
+  prometheus.io/port: "8000"
+  prometheus.io/scrape: "true"
 spec:
  ports:
  - port: 80


### PR DESCRIPTION
This PR adds two patches: one to be consistent and always /stats/prometheus to scrape envoy metrics (more info in the commit message) and another that enables metrics for all types of deployments (updates # 1035).

The description for the commit that Update #1035 follows, the other was a small fix that I found while doing this.

The deployments has annotations to scrape metrics only for envoy. This
patch adds annotations to scrape metrics for the contour container too.

The annotations are added to the contour k8s service. This is for two 
reasons:

 * The pod spec annotations only support to specify one container,
AFAIK, and are already used for metrics for the envoy container

 * This seems like the easiest way to work-around the just mentioned
annotations limitation while being a trivial patch and that works out of
the box on all setups.

With this patch, metrics for the contour container even when envoy and 
contour are co-located in the same pod work out of the box.

Updates: #1035

Signed-off-by: Rodrigo Campos <rodrigo@kinvolk.io>