### PR TITLE
Fix static clusters stats output by enabling an 'AltStatName'

### DIFF
--- a/cmd/contour/contour.go
+++ b/cmd/contour/contour.go
@@ -60,6 +60,9 @@ func main() {
 	bootstrap.Flag("statsd-address", "statsd address").StringVar(&config.StatsdAddress)
 	bootstrap.Flag("statsd-port", "statsd port").IntVar(&config.StatsdPort)
 
+	// Get the running namespace passed via ENV var from the Kubernetes Downward API
+	config.Namespace = getEnv("CONTOUR_NAMESPACE", "heptio-contour")
+
 	cli := app.Command("cli", "A CLI client for the Heptio Contour Kubernetes ingress controller.")
 	var client Client
 	cli.Flag("contour", "contour host:port.").Default("127.0.0.1:8001").StringVar(&client.ContourAddr)
@@ -289,4 +292,12 @@ func parseRootNamespaces(rn string) []string {
 		ns = append(ns, strings.TrimSpace(s))
 	}
 	return ns
+}
+
+func getEnv(key, fallback string) string {
+	value, exists := os.LookupEnv(key)
+	if !exists {
+		value = fallback
+	}
+	return value
 }

--- a/deployment/deployment-grpc-v2/02-contour.yaml
+++ b/deployment/deployment-grpc-v2/02-contour.yaml
@@ -68,6 +68,11 @@ spec:
         volumeMounts:
         - name: contour-config
           mountPath: /config
+        env:
+        - name: CONTOUR_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
       volumes:
       - name: contour-config
         emptyDir: {}

--- a/deployment/ds-grpc-v2/02-contour.yaml
+++ b/deployment/ds-grpc-v2/02-contour.yaml
@@ -62,6 +62,11 @@ spec:
         volumeMounts:
         - name: contour-config
           mountPath: /config
+        env:
+        - name: CONTOUR_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
       volumes:
       - name: contour-config
         emptyDir: {}

--- a/deployment/ds-hostnet-split/03-envoy.yaml
+++ b/deployment/ds-hostnet-split/03-envoy.yaml
@@ -90,6 +90,11 @@ spec:
         volumeMounts:
         - name: contour-config
           mountPath: /config
+        env:
+        - name: CONTOUR_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
       automountServiceAccountToken: false
       volumes:
         - name: contour-config

--- a/deployment/ds-hostnet/02-contour.yaml
+++ b/deployment/ds-hostnet/02-contour.yaml
@@ -66,6 +66,11 @@ spec:
         volumeMounts:
         - name: contour-config
           mountPath: /config
+        env:
+        - name: CONTOUR_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
       volumes:
       - name: contour-config
         emptyDir: {}

--- a/deployment/render/daemonset-rbac.yaml
+++ b/deployment/render/daemonset-rbac.yaml
@@ -246,6 +246,11 @@ spec:
         volumeMounts:
         - name: contour-config
           mountPath: /config
+        env:
+        - name: CONTOUR_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
       volumes:
       - name: contour-config
         emptyDir: {}

--- a/deployment/render/deployment-rbac.yaml
+++ b/deployment/render/deployment-rbac.yaml
@@ -252,6 +252,11 @@ spec:
         volumeMounts:
         - name: contour-config
           mountPath: /config
+        env:
+        - name: CONTOUR_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
       volumes:
       - name: contour-config
         emptyDir: {}

--- a/internal/envoy/bootstrap_test.go
+++ b/internal/envoy/bootstrap_test.go
@@ -28,7 +28,7 @@ func TestBootstrap(t *testing.T) {
 		want   string
 	}{
 		"default configuration": {
-			config: BootstrapConfig{},
+			config: BootstrapConfig{Namespace: "testing-ns"},
 			want: `{
   "static_resources": {
     "listeners": [
@@ -75,7 +75,7 @@ func TestBootstrap(t *testing.T) {
                             "prefix": "/stats"
                           },
                           "route": {
-                            "cluster": "service_stats"
+                            "cluster": "service-stats"
                           }
                         }
                       ]
@@ -93,6 +93,7 @@ func TestBootstrap(t *testing.T) {
     "clusters": [
       {
         "name": "contour",
+        "alt_stat_name": "testing-ns_contour_8001",
         "type": "STRICT_DNS",
         "connect_timeout": "5s",
         "load_assignment": {
@@ -134,11 +135,12 @@ func TestBootstrap(t *testing.T) {
         "http2_protocol_options": {}
       },
       {
-        "name": "service_stats",
+        "name": "service-stats",
+        "alt_stat_name": "testing-ns_service-stats_9001",
         "type": "LOGICAL_DNS",
         "connect_timeout": "0.250s",
         "load_assignment": {
-          "cluster_name": "service_stats",
+          "cluster_name": "service-stats",
           "endpoints": [   
             {                          
               "lb_endpoints": [
@@ -199,6 +201,7 @@ func TestBootstrap(t *testing.T) {
 		"--statsd-enabled": {
 			config: BootstrapConfig{
 				StatsdEnabled: true,
+				Namespace:     "testing-ns",
 			},
 			want: `{
   "static_resources": {
@@ -246,7 +249,7 @@ func TestBootstrap(t *testing.T) {
                             "prefix": "/stats"
                           },
                           "route": {
-                            "cluster": "service_stats"
+                            "cluster": "service-stats"
                           }
                         }
                       ]
@@ -264,6 +267,7 @@ func TestBootstrap(t *testing.T) {
     "clusters": [
       {
         "name": "contour",
+        "alt_stat_name": "testing-ns_contour_8001",
         "type": "STRICT_DNS",
         "connect_timeout": "5s",
         "load_assignment": {
@@ -305,11 +309,12 @@ func TestBootstrap(t *testing.T) {
         "http2_protocol_options": {}
       },
       {
-        "name": "service_stats",
+        "name": "service-stats",
+        "alt_stat_name": "testing-ns_service-stats_9001",
         "type": "LOGICAL_DNS",
         "connect_timeout": "0.250s",
         "load_assignment": {
-          "cluster_name": "service_stats",
+          "cluster_name": "service-stats",
           "endpoints": [   
             {                          
               "lb_endpoints": [
@@ -386,6 +391,7 @@ func TestBootstrap(t *testing.T) {
 				StatsdEnabled: true,
 				StatsdAddress: "8.8.8.8",
 				StatsdPort:    9200,
+				Namespace:     "testing-ns",
 			},
 			want: `{
   "static_resources": {
@@ -433,7 +439,7 @@ func TestBootstrap(t *testing.T) {
                             "prefix": "/stats"
                           },
                           "route": {
-                            "cluster": "service_stats"
+                            "cluster": "service-stats"
                           }
                         }
                       ]
@@ -451,6 +457,7 @@ func TestBootstrap(t *testing.T) {
     "clusters": [
       {
         "name": "contour",
+        "alt_stat_name": "testing-ns_contour_8001",
         "type": "STRICT_DNS",
         "connect_timeout": "5s",
         "load_assignment": {
@@ -492,11 +499,12 @@ func TestBootstrap(t *testing.T) {
         "http2_protocol_options": {}
       },
       {
-        "name": "service_stats",
+        "name": "service-stats",
+        "alt_stat_name": "testing-ns_service-stats_9001",
         "type": "LOGICAL_DNS",
         "connect_timeout": "0.250s",
         "load_assignment": {
-          "cluster_name": "service_stats",
+          "cluster_name": "service-stats",
           "endpoints": [   
             {                          
               "lb_endpoints": [
@@ -572,6 +580,7 @@ func TestBootstrap(t *testing.T) {
 			config: BootstrapConfig{
 				AdminAddress: "8.8.8.8",
 				AdminPort:    9200,
+				Namespace:    "testing-ns",
 			},
 			want: `{
   "static_resources": {
@@ -619,7 +628,7 @@ func TestBootstrap(t *testing.T) {
                             "prefix": "/stats"
                           },
                           "route": {
-                            "cluster": "service_stats"
+                            "cluster": "service-stats"
                           }
                         }
                       ]
@@ -637,6 +646,7 @@ func TestBootstrap(t *testing.T) {
     "clusters": [
       {
         "name": "contour",
+        "alt_stat_name": "testing-ns_contour_8001",
         "type": "STRICT_DNS",
         "connect_timeout": "5s",
         "load_assignment": {
@@ -678,11 +688,12 @@ func TestBootstrap(t *testing.T) {
         "http2_protocol_options": {}
       },
       {
-        "name": "service_stats",
+        "name": "service-stats",
+        "alt_stat_name": "testing-ns_service-stats_9200",
         "type": "LOGICAL_DNS",
         "connect_timeout": "0.250s",
         "load_assignment": {
-          "cluster_name": "service_stats",
+          "cluster_name": "service-stats",
           "endpoints": [   
             {                          
               "lb_endpoints": [
@@ -743,6 +754,7 @@ func TestBootstrap(t *testing.T) {
 		"AdminAccessLogPath": { // TODO(dfc) doesn't appear to be exposed via contour bootstrap
 			config: BootstrapConfig{
 				AdminAccessLogPath: "/var/log/admin.log",
+				Namespace:          "testing-ns",
 			},
 			want: `{
   "static_resources": {
@@ -790,7 +802,7 @@ func TestBootstrap(t *testing.T) {
                             "prefix": "/stats"
                           },
                           "route": {
-                            "cluster": "service_stats"
+                            "cluster": "service-stats"
                           }
                         }
                       ]
@@ -808,6 +820,7 @@ func TestBootstrap(t *testing.T) {
     "clusters": [
       {
         "name": "contour",
+        "alt_stat_name": "testing-ns_contour_8001",
         "type": "STRICT_DNS",
         "connect_timeout": "5s",
         "load_assignment": {
@@ -849,11 +862,12 @@ func TestBootstrap(t *testing.T) {
         "http2_protocol_options": {}
       },
       {
-        "name": "service_stats",
+        "name": "service-stats",
+        "alt_stat_name": "testing-ns_service-stats_9001",
         "type": "LOGICAL_DNS",
         "connect_timeout": "0.250s",
         "load_assignment": {
-          "cluster_name": "service_stats",
+          "cluster_name": "service-stats",
           "endpoints": [   
             {                          
               "lb_endpoints": [
@@ -915,6 +929,7 @@ func TestBootstrap(t *testing.T) {
 			config: BootstrapConfig{
 				XDSAddress:  "8.8.8.8",
 				XDSGRPCPort: 9200,
+				Namespace:   "testing-ns",
 			},
 			want: `{
   "static_resources": {
@@ -962,7 +977,7 @@ func TestBootstrap(t *testing.T) {
                             "prefix": "/stats"
                           },
                           "route": {
-                            "cluster": "service_stats"
+                            "cluster": "service-stats"
                           }
                         }
                       ]
@@ -980,6 +995,7 @@ func TestBootstrap(t *testing.T) {
     "clusters": [
       {
         "name": "contour",
+        "alt_stat_name": "testing-ns_contour_9200",
         "type": "STRICT_DNS",
         "connect_timeout": "5s",
         "load_assignment": {
@@ -1021,11 +1037,12 @@ func TestBootstrap(t *testing.T) {
         "http2_protocol_options": {}
       },
       {
-        "name": "service_stats",
+        "name": "service-stats",
+        "alt_stat_name": "testing-ns_service-stats_9001",
         "type": "LOGICAL_DNS",
         "connect_timeout": "0.250s",
         "load_assignment": {
-          "cluster_name": "service_stats",
+          "cluster_name": "service-stats",
           "endpoints": [   
             {                          
               "lb_endpoints": [
@@ -1087,6 +1104,7 @@ func TestBootstrap(t *testing.T) {
 			config: BootstrapConfig{
 				StatsAddress: "8.8.8.8",
 				StatsPort:    9200,
+				Namespace:    "testing-ns",
 			},
 			want: `{
   "static_resources": {
@@ -1134,7 +1152,7 @@ func TestBootstrap(t *testing.T) {
                             "prefix": "/stats"
                           },
                           "route": {
-                            "cluster": "service_stats"
+                            "cluster": "service-stats"
                           }
                         }
                       ]
@@ -1152,6 +1170,7 @@ func TestBootstrap(t *testing.T) {
     "clusters": [
       {
         "name": "contour",
+        "alt_stat_name": "testing-ns_contour_8001",
         "type": "STRICT_DNS",
         "connect_timeout": "5s",
         "load_assignment": {
@@ -1193,11 +1212,12 @@ func TestBootstrap(t *testing.T) {
         "http2_protocol_options": {}
       },
       {
-        "name": "service_stats",
+        "name": "service-stats",
+        "alt_stat_name": "testing-ns_service-stats_9001",
         "type": "LOGICAL_DNS",
         "connect_timeout": "0.250s",
         "load_assignment": {
-          "cluster_name": "service_stats",
+          "cluster_name": "service-stats",
           "endpoints": [   
             {                          
               "lb_endpoints": [
@@ -1258,6 +1278,7 @@ func TestBootstrap(t *testing.T) {
 	}
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
+
 			got := Bootstrap(&tc.config)
 			want := new(bootstrap.Bootstrap)
 			unmarshal(t, tc.want, want)

--- a/internal/envoy/config.go
+++ b/internal/envoy/config.go
@@ -106,7 +106,7 @@ static_resources:
           max_pending_requests: 100000
           max_requests: 60000000
           max_retries: 50
-  - name: service_stats
+  - name: service-stats
     connect_timeout: 0.250s
     type: LOGICAL_DNS
     lb_policy: ROUND_ROBIN
@@ -136,7 +136,7 @@ static_resources:
                         - match:
                             prefix: /stats
                           route:
-                            cluster: service_stats
+                            cluster: service-stats
                 http_filters:
                   - name: envoy.health_check
                     config:


### PR DESCRIPTION
Fixes #1008 by adding `AltStatName` to static clusters (contour & service-stats). Also renames `service_stats` cluster to `service-stats` to handle upstream parsing in dashboards. 

Signed-off-by: Steve Sloka <slokas@vmware.com>