### PR TITLE
internal/contour: add SecretCache and link to grpc

### DIFF
--- a/cmd/contour/contour.go
+++ b/cmd/contour/contour.go
@@ -222,12 +222,14 @@ func main() {
 				clusterType  = typePrefix + "Cluster"
 				routeType    = typePrefix + "RouteConfiguration"
 				listenerType = typePrefix + "Listener"
+				secretType   = typePrefix + "auth.Secret"
 			)
 			s := grpc.NewAPI(log, map[string]grpc.Cache{
 				clusterType:  &ch.ClusterCache,
 				routeType:    &ch.RouteCache,
 				listenerType: &ch.ListenerCache,
 				endpointType: et,
+				secretType:   &ch.SecretCache,
 			})
 			log.Println("started")
 			defer log.Println("stopped")

--- a/internal/contour/cachehandler.go
+++ b/internal/contour/cachehandler.go
@@ -30,6 +30,7 @@ type CacheHandler struct {
 	ListenerCache
 	RouteCache
 	ClusterCache
+	SecretCache
 
 	IngressRouteStatus *k8s.IngressRouteStatus
 	logrus.FieldLogger
@@ -45,6 +46,7 @@ func (ch *CacheHandler) OnChange(b *dag.Builder) {
 	defer timer.ObserveDuration()
 	dag := b.Build()
 	ch.setIngressRouteStatus(dag)
+	ch.updateSecrets(dag)
 	ch.updateListeners(dag)
 	ch.updateRoutes(dag)
 	ch.updateClusters(dag)
@@ -58,6 +60,11 @@ func (ch *CacheHandler) setIngressRouteStatus(st statusable) {
 			ch.Errorf("Error Setting Status of IngressRoute: ", err)
 		}
 	}
+}
+
+func (ch *CacheHandler) updateSecrets(root dag.Visitable) {
+	secrets := visitSecrets(root)
+	ch.SecretCache.Update(secrets)
 }
 
 func (ch *CacheHandler) updateListeners(root dag.Visitable) {

--- a/internal/contour/secret.go
+++ b/internal/contour/secret.go
@@ -1,0 +1,111 @@
+// Copyright © 2018 Heptio
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package contour
+
+import (
+	"sync"
+
+	"github.com/envoyproxy/go-control-plane/envoy/api/v2/auth"
+	"github.com/gogo/protobuf/proto"
+	"github.com/heptio/contour/internal/dag"
+	"github.com/heptio/contour/internal/envoy"
+)
+
+// SecretCache manages the contents of the gRPC SDS cache.
+type SecretCache struct {
+	mu      sync.Mutex
+	values  map[string]*auth.Secret
+	waiters []chan int
+	last    int
+}
+
+// Register registers ch to receive a value when Notify is called.
+// The value of last is the count of the times Notify has been called on this Cache.
+// It functions of a sequence counter, if the value of last supplied to Register
+// is less than the Cache's internal counter, then the caller has missed at least
+// one notification and will fire immediately.
+//
+// Sends by the broadcaster to ch must not block, therefor ch must have a capacity
+// of at least 1.
+func (c *SecretCache) Register(ch chan int, last int) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if last < c.last {
+		// notify this channel immediately
+		ch <- c.last
+		return
+	}
+	c.waiters = append(c.waiters, ch)
+}
+
+// Update replaces the contents of the cache with the supplied map.
+func (c *SecretCache) Update(v map[string]*auth.Secret) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.values = v
+	c.notify()
+}
+
+// notify notifies all registered waiters that an event has occurred.
+func (c *SecretCache) notify() {
+	c.last++
+
+	for _, ch := range c.waiters {
+		ch <- c.last
+	}
+	c.waiters = c.waiters[:0]
+}
+
+// Values returns a slice of the value stored in the cache.
+func (c *SecretCache) Values(filter func(string) bool) []proto.Message {
+	c.mu.Lock()
+	values := make([]proto.Message, 0, len(c.values))
+	for _, v := range c.values {
+		if filter(v.Name) {
+			values = append(values, v)
+		}
+	}
+	c.mu.Unlock()
+	return values
+}
+
+type secretVisitor struct {
+	secrets map[string]*auth.Secret
+}
+
+// visitSecrets produces a map of *auth.Secret
+func visitSecrets(root dag.Vertex) map[string]*auth.Secret {
+	sv := secretVisitor{
+		secrets: make(map[string]*auth.Secret),
+	}
+	sv.visit(root)
+	return sv.secrets
+}
+
+func (v *secretVisitor) visit(vertex dag.Vertex) {
+	switch svh := vertex.(type) {
+	case *dag.SecureVirtualHost:
+		if svh.Secret != nil {
+			name := envoy.Secretname(svh.Secret)
+			if _, ok := v.secrets[name]; !ok {
+				s := envoy.Secret(svh.Secret)
+				v.secrets[s.Name] = s
+			}
+		}
+	default:
+		vertex.Visit(v.visit)
+	}
+}

--- a/internal/contour/secret_test.go
+++ b/internal/contour/secret_test.go
@@ -1,0 +1,487 @@
+package contour
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/envoyproxy/go-control-plane/envoy/api/v2/auth"
+	"github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
+	ingressroutev1 "github.com/heptio/contour/apis/contour/v1beta1"
+	"github.com/heptio/contour/internal/metrics"
+	"github.com/prometheus/client_golang/prometheus"
+	"k8s.io/api/core/v1"
+	"k8s.io/api/extensions/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+func TestSecretVisit(t *testing.T) {
+	tests := map[string]struct {
+		objs []interface{}
+		want map[string]*auth.Secret
+	}{
+		"nothing": {
+			objs: nil,
+			want: map[string]*auth.Secret{},
+		},
+		"unassociated secrets": {
+			objs: []interface{}{
+				&v1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "secret-a",
+						Namespace: "default",
+					},
+					Data: secretdata("cert", "key"),
+				},
+				&v1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "secret-b",
+						Namespace: "default",
+					},
+					Data: secretdata("cert", "key"),
+				},
+			},
+			want: map[string]*auth.Secret{},
+		},
+		"simple ingress with secret": {
+			objs: []interface{}{
+				&v1beta1.Ingress{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "simple",
+						Namespace: "default",
+					},
+					Spec: v1beta1.IngressSpec{
+						TLS: []v1beta1.IngressTLS{{
+							Hosts:      []string{"whatever.example.com"},
+							SecretName: "secret",
+						}},
+						Backend: &v1beta1.IngressBackend{
+							ServiceName: "kuard",
+							ServicePort: intstr.FromInt(8080),
+						},
+					},
+				},
+				&v1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "secret",
+						Namespace: "default",
+					},
+					Data: secretdata("cert", "key"),
+				},
+			},
+			want: secretmap(&auth.Secret{
+				Name: "default/secret/cd1b506996",
+				Type: &auth.Secret_TlsCertificate{
+					TlsCertificate: &auth.TlsCertificate{
+						PrivateKey: &core.DataSource{
+							Specifier: &core.DataSource_InlineBytes{
+								InlineBytes: []byte("key"),
+							},
+						},
+						CertificateChain: &core.DataSource{
+							Specifier: &core.DataSource_InlineBytes{
+								InlineBytes: []byte("cert"),
+							},
+						},
+					},
+				},
+			}),
+		},
+		"multiple ingresses with shared secret": {
+			objs: []interface{}{
+				&v1beta1.Ingress{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "simple-a",
+						Namespace: "default",
+					},
+					Spec: v1beta1.IngressSpec{
+						TLS: []v1beta1.IngressTLS{{
+							Hosts:      []string{"whatever.example.com"},
+							SecretName: "secret",
+						}},
+						Backend: &v1beta1.IngressBackend{
+							ServiceName: "kuard",
+							ServicePort: intstr.FromInt(8080),
+						},
+					},
+				},
+				&v1beta1.Ingress{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "simple-b",
+						Namespace: "default",
+					},
+					Spec: v1beta1.IngressSpec{
+						TLS: []v1beta1.IngressTLS{{
+							Hosts:      []string{"omg.example.com"},
+							SecretName: "secret",
+						}},
+						Backend: &v1beta1.IngressBackend{
+							ServiceName: "kuard",
+							ServicePort: intstr.FromInt(8080),
+						},
+					},
+				},
+				&v1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "secret",
+						Namespace: "default",
+					},
+					Data: secretdata("cert", "key"),
+				},
+			},
+			want: secretmap(&auth.Secret{
+				Name: "default/secret/cd1b506996",
+				Type: &auth.Secret_TlsCertificate{
+					TlsCertificate: &auth.TlsCertificate{
+						PrivateKey: &core.DataSource{
+							Specifier: &core.DataSource_InlineBytes{
+								InlineBytes: []byte("key"),
+							},
+						},
+						CertificateChain: &core.DataSource{
+							Specifier: &core.DataSource_InlineBytes{
+								InlineBytes: []byte("cert"),
+							},
+						},
+					},
+				},
+			}),
+		},
+		"multiple ingresses with different secrets": {
+			objs: []interface{}{
+				&v1beta1.Ingress{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "simple-a",
+						Namespace: "default",
+					},
+					Spec: v1beta1.IngressSpec{
+						TLS: []v1beta1.IngressTLS{{
+							Hosts:      []string{"whatever.example.com"},
+							SecretName: "secret-a",
+						}},
+						Backend: &v1beta1.IngressBackend{
+							ServiceName: "kuard",
+							ServicePort: intstr.FromInt(8080),
+						},
+					},
+				},
+				&v1beta1.Ingress{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "simple-b",
+						Namespace: "default",
+					},
+					Spec: v1beta1.IngressSpec{
+						TLS: []v1beta1.IngressTLS{{
+							Hosts:      []string{"omg.example.com"},
+							SecretName: "secret-b",
+						}},
+						Backend: &v1beta1.IngressBackend{
+							ServiceName: "kuard",
+							ServicePort: intstr.FromInt(8080),
+						},
+					},
+				},
+				&v1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "secret-a",
+						Namespace: "default",
+					},
+					Data: secretdata("cert-a", "key-a"),
+				},
+				&v1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "secret-b",
+						Namespace: "default",
+					},
+					Data: secretdata("cert-b", "key-b"),
+				},
+			},
+			want: secretmap(&auth.Secret{
+				Name: "default/secret-a/ff2a9f58ca",
+				Type: &auth.Secret_TlsCertificate{
+					TlsCertificate: &auth.TlsCertificate{
+						PrivateKey: &core.DataSource{
+							Specifier: &core.DataSource_InlineBytes{
+								InlineBytes: []byte("key-a"),
+							},
+						},
+						CertificateChain: &core.DataSource{
+							Specifier: &core.DataSource_InlineBytes{
+								InlineBytes: []byte("cert-a"),
+							},
+						},
+					},
+				},
+			}, &auth.Secret{
+				Name: "default/secret-b/0a068be4ba",
+				Type: &auth.Secret_TlsCertificate{
+					TlsCertificate: &auth.TlsCertificate{
+						PrivateKey: &core.DataSource{
+							Specifier: &core.DataSource_InlineBytes{
+								InlineBytes: []byte("key-b"),
+							},
+						},
+						CertificateChain: &core.DataSource{
+							Specifier: &core.DataSource_InlineBytes{
+								InlineBytes: []byte("cert-b"),
+							},
+						},
+					},
+				},
+			}),
+		},
+		"simple ingressroute with secret": {
+			objs: []interface{}{
+				&ingressroutev1.IngressRoute{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "simple",
+						Namespace: "default",
+					},
+					Spec: ingressroutev1.IngressRouteSpec{
+						VirtualHost: &ingressroutev1.VirtualHost{
+							Fqdn: "www.example.com",
+							TLS: &ingressroutev1.TLS{
+								SecretName: "secret",
+							},
+						},
+						Routes: []ingressroutev1.Route{
+							{
+								Services: []ingressroutev1.Service{
+									{
+										Name: "backend",
+										Port: 80,
+									},
+								},
+							},
+						},
+					},
+				},
+				&v1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "secret",
+						Namespace: "default",
+					},
+					Data: secretdata("cert", "key"),
+				},
+			},
+			want: secretmap(&auth.Secret{
+				Name: "default/secret/cd1b506996",
+				Type: &auth.Secret_TlsCertificate{
+					TlsCertificate: &auth.TlsCertificate{
+						PrivateKey: &core.DataSource{
+							Specifier: &core.DataSource_InlineBytes{
+								InlineBytes: []byte("key"),
+							},
+						},
+						CertificateChain: &core.DataSource{
+							Specifier: &core.DataSource_InlineBytes{
+								InlineBytes: []byte("cert"),
+							},
+						},
+					},
+				},
+			}),
+		},
+		"multiple ingressroutes with shared secret": {
+			objs: []interface{}{
+				&ingressroutev1.IngressRoute{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "simple-a",
+						Namespace: "default",
+					},
+					Spec: ingressroutev1.IngressRouteSpec{
+						VirtualHost: &ingressroutev1.VirtualHost{
+							Fqdn: "www.example.com",
+							TLS: &ingressroutev1.TLS{
+								SecretName: "secret",
+							},
+						},
+						Routes: []ingressroutev1.Route{
+							{
+								Services: []ingressroutev1.Service{
+									{
+										Name: "backend",
+										Port: 80,
+									},
+								},
+							},
+						},
+					},
+				},
+				&ingressroutev1.IngressRoute{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "simple-b",
+						Namespace: "default",
+					},
+					Spec: ingressroutev1.IngressRouteSpec{
+						VirtualHost: &ingressroutev1.VirtualHost{
+							Fqdn: "www.other.com",
+							TLS: &ingressroutev1.TLS{
+								SecretName: "secret",
+							},
+						},
+						Routes: []ingressroutev1.Route{
+							{
+								Services: []ingressroutev1.Service{
+									{
+										Name: "backend",
+										Port: 80,
+									},
+								},
+							},
+						},
+					},
+				},
+				&v1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "secret",
+						Namespace: "default",
+					},
+					Data: secretdata("cert", "key"),
+				},
+			},
+			want: secretmap(&auth.Secret{
+				Name: "default/secret/cd1b506996",
+				Type: &auth.Secret_TlsCertificate{
+					TlsCertificate: &auth.TlsCertificate{
+						PrivateKey: &core.DataSource{
+							Specifier: &core.DataSource_InlineBytes{
+								InlineBytes: []byte("key"),
+							},
+						},
+						CertificateChain: &core.DataSource{
+							Specifier: &core.DataSource_InlineBytes{
+								InlineBytes: []byte("cert"),
+							},
+						},
+					},
+				},
+			}),
+		},
+		"multiple ingressroutes with different secret": {
+			objs: []interface{}{
+				&ingressroutev1.IngressRoute{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "simple-a",
+						Namespace: "default",
+					},
+					Spec: ingressroutev1.IngressRouteSpec{
+						VirtualHost: &ingressroutev1.VirtualHost{
+							Fqdn: "www.example.com",
+							TLS: &ingressroutev1.TLS{
+								SecretName: "secret-a",
+							},
+						},
+						Routes: []ingressroutev1.Route{
+							{
+								Services: []ingressroutev1.Service{
+									{
+										Name: "backend",
+										Port: 80,
+									},
+								},
+							},
+						},
+					},
+				},
+				&ingressroutev1.IngressRoute{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "simple-b",
+						Namespace: "default",
+					},
+					Spec: ingressroutev1.IngressRouteSpec{
+						VirtualHost: &ingressroutev1.VirtualHost{
+							Fqdn: "www.other.com",
+							TLS: &ingressroutev1.TLS{
+								SecretName: "secret-b",
+							},
+						},
+						Routes: []ingressroutev1.Route{
+							{
+								Services: []ingressroutev1.Service{
+									{
+										Name: "backend",
+										Port: 80,
+									},
+								},
+							},
+						},
+					},
+				},
+				&v1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "secret-a",
+						Namespace: "default",
+					},
+					Data: secretdata("cert-a", "key-a"),
+				},
+				&v1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "secret-b",
+						Namespace: "default",
+					},
+					Data: secretdata("cert-b", "key-b"),
+				},
+			},
+			want: secretmap(&auth.Secret{
+				Name: "default/secret-a/ff2a9f58ca",
+				Type: &auth.Secret_TlsCertificate{
+					TlsCertificate: &auth.TlsCertificate{
+						PrivateKey: &core.DataSource{
+							Specifier: &core.DataSource_InlineBytes{
+								InlineBytes: []byte("key-a"),
+							},
+						},
+						CertificateChain: &core.DataSource{
+							Specifier: &core.DataSource_InlineBytes{
+								InlineBytes: []byte("cert-a"),
+							},
+						},
+					},
+				},
+			}, &auth.Secret{
+				Name: "default/secret-b/0a068be4ba",
+				Type: &auth.Secret_TlsCertificate{
+					TlsCertificate: &auth.TlsCertificate{
+						PrivateKey: &core.DataSource{
+							Specifier: &core.DataSource_InlineBytes{
+								InlineBytes: []byte("key-b"),
+							},
+						},
+						CertificateChain: &core.DataSource{
+							Specifier: &core.DataSource_InlineBytes{
+								InlineBytes: []byte("cert-b"),
+							},
+						},
+					},
+				},
+			}),
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			reh := ResourceEventHandler{
+				FieldLogger: testLogger(t),
+				Notifier:    new(nullNotifier),
+				Metrics:     metrics.NewMetrics(prometheus.NewRegistry()),
+			}
+			for _, o := range tc.objs {
+				reh.OnAdd(o)
+			}
+			root := reh.Build()
+			got := visitSecrets(root)
+			if !reflect.DeepEqual(tc.want, got) {
+				t.Fatalf("expected:\n%+v\ngot:\n%+v", tc.want, got)
+			}
+		})
+	}
+}
+
+func secretmap(secrets ...*auth.Secret) map[string]*auth.Secret {
+	m := make(map[string]*auth.Secret)
+	for _, s := range secrets {
+		m[s.Name] = s
+	}
+	return m
+}

--- a/internal/dag/dag.go
+++ b/internal/dag/dag.go
@@ -293,6 +293,16 @@ func (s *Secret) Data() map[string][]byte {
 	return s.Object.Data
 }
 
+// Cert returns the secret's tls certificate
+func (s *Secret) Cert() []byte {
+	return s.Object.Data[v1.TLSCertKey]
+}
+
+// PrivateKey returns the secret's tls private key
+func (s *Secret) PrivateKey() []byte {
+	return s.Object.Data[v1.TLSPrivateKeyKey]
+}
+
 func (s *Secret) toMeta() meta {
 	return meta{
 		name:      s.Name(),

--- a/internal/envoy/secret.go
+++ b/internal/envoy/secret.go
@@ -1,0 +1,39 @@
+package envoy
+
+import (
+	"crypto/sha1"
+	"fmt"
+
+	"github.com/envoyproxy/go-control-plane/envoy/api/v2/auth"
+	"github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
+	"github.com/heptio/contour/internal/dag"
+)
+
+// Secretname returns the name of the SDS secret for this secret.
+func Secretname(s *dag.Secret) string {
+	hash := sha1.Sum(s.Cert())
+	ns := s.Namespace()
+	name := s.Name()
+	return hashname(60, ns, name, fmt.Sprintf("%x", hash[:5]))
+}
+
+// Secret creates new v2auth.Secret from secret.
+func Secret(s *dag.Secret) *auth.Secret {
+	return &auth.Secret{
+		Name: Secretname(s),
+		Type: &auth.Secret_TlsCertificate{
+			TlsCertificate: &auth.TlsCertificate{
+				PrivateKey: &core.DataSource{
+					Specifier: &core.DataSource_InlineBytes{
+						InlineBytes: s.PrivateKey(),
+					},
+				},
+				CertificateChain: &core.DataSource{
+					Specifier: &core.DataSource_InlineBytes{
+						InlineBytes: s.Cert(),
+					},
+				},
+			},
+		},
+	}
+}

--- a/internal/envoy/secret_test.go
+++ b/internal/envoy/secret_test.go
@@ -1,0 +1,107 @@
+package envoy
+
+import (
+	"testing"
+
+	"github.com/envoyproxy/go-control-plane/envoy/api/v2/auth"
+	"github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
+	"github.com/google/go-cmp/cmp"
+	"github.com/heptio/contour/internal/dag"
+	"k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestSecret(t *testing.T) {
+	tests := map[string]struct {
+		secret *dag.Secret
+		want   *auth.Secret
+	}{
+		"simple secret": {
+			secret: &dag.Secret{
+				Object: &v1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "simple",
+						Namespace: "default",
+					},
+					Data: map[string][]byte{
+						v1.TLSCertKey:       []byte("cert"),
+						v1.TLSPrivateKeyKey: []byte("key"),
+					},
+				},
+			},
+			want: &auth.Secret{
+				Name: "default/simple/cd1b506996",
+				Type: &auth.Secret_TlsCertificate{
+					TlsCertificate: &auth.TlsCertificate{
+						PrivateKey: &core.DataSource{
+							Specifier: &core.DataSource_InlineBytes{
+								InlineBytes: []byte("key"),
+							},
+						},
+						CertificateChain: &core.DataSource{
+							Specifier: &core.DataSource_InlineBytes{
+								InlineBytes: []byte("cert"),
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := Secret(tc.secret)
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Fatal(diff)
+			}
+		})
+	}
+}
+
+func TestSecretname(t *testing.T) {
+	tests := map[string]struct {
+		secret *dag.Secret
+		want   string
+	}{
+		"simple": {
+			secret: &dag.Secret{
+				Object: &v1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "simple",
+						Namespace: "default",
+					},
+					Data: map[string][]byte{
+						v1.TLSCertKey:       []byte("cert"),
+						v1.TLSPrivateKeyKey: []byte("key"),
+					},
+				},
+			},
+			want: "default/simple/cd1b506996",
+		},
+		"far too long": {
+			secret: &dag.Secret{
+				Object: &v1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "must-be-in-want-of-a-wife",
+						Namespace: "it-is-a-truth-universally-acknowledged-that-a-single-man-in-possession-of-a-good-fortune",
+					},
+					Data: map[string][]byte{
+						v1.TLSCertKey:       []byte("cert"),
+						v1.TLSPrivateKeyKey: []byte("key"),
+					},
+				},
+			},
+			want: "it-is-a-truth-7e164b/must-be-in-wa-7e164b/cd1b506996",
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := Secretname(tc.secret)
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Fatal(diff)
+			}
+		})
+	}
+}

--- a/internal/grpc/server.go
+++ b/internal/grpc/server.go
@@ -58,6 +58,9 @@ func NewAPI(log logrus.FieldLogger, cacheMap map[string]Cache) *grpc.Server {
 				routeType: &RDS{
 					Cache: cacheMap[routeType],
 				},
+				secretType: &SDS{
+					Cache: cacheMap[secretType],
+				},
 			},
 		},
 	}


### PR DESCRIPTION
Addresses the second high-level design bullet point, creating a
SecretCache to be used by Contour to internally identify any changes.
The cache is also registered as a resource type for the gRPC server,
allowing it to respond to requests.
    
Updates: #898
Signed-off-by: Matt Alberts <malberts@cloudflare.com>