### PR TITLE
cmd/contour: adds sds cli

### DIFF
--- a/cmd/contour/cli.go
+++ b/cmd/contour/cli.go
@@ -29,6 +29,7 @@ const (
 	clusterType  = typePrefix + "Cluster"
 	routeType    = typePrefix + "RouteConfiguration"
 	listenerType = typePrefix + "Listener"
+	secretType   = typePrefix + "auth.Secret"
 )
 
 type Client struct {

--- a/cmd/contour/contour.go
+++ b/cmd/contour/contour.go
@@ -76,6 +76,8 @@ func main() {
 	lds.Arg("resources", "LDS resource filter").StringsVar(&resources)
 	rds := cli.Command("rds", "watch routes.")
 	rds.Arg("resources", "RDS resource filter").StringsVar(&resources)
+	sds := cli.Command("sds", "watch secrets.")
+	sds.Arg("resources", "SDS resource filter").StringsVar(&resources)
 
 	serve := app.Command("serve", "Serve xDS API traffic")
 	inCluster := serve.Flag("incluster", "use in cluster configuration.").Bool()
@@ -156,6 +158,9 @@ func main() {
 	case rds.FullCommand():
 		stream := client.RouteStream()
 		watchstream(stream, routeType, resources)
+	case sds.FullCommand():
+		stream := client.RouteStream()
+		watchstream(stream, secretType, resources)
 	case serve.FullCommand():
 		log.Infof("args: %v", args)
 		var g workgroup.Group


### PR DESCRIPTION
Addresses the third high-level design bullet point, support sds in the
contour cli for debugging.
    
Updates: #898
Signed-off-by: Matt Alberts <malberts@cloudflare.com>