### PR TITLE
internal/contour: auth.SdsSecretConfig for auth.CommonTlsContext

### DIFF
--- a/internal/contour/listener.go
+++ b/internal/contour/listener.go
@@ -21,7 +21,6 @@ import (
 	"github.com/gogo/protobuf/proto"
 	"github.com/heptio/contour/internal/dag"
 	"github.com/heptio/contour/internal/envoy"
-	"k8s.io/api/core/v1"
 )
 
 const (
@@ -33,6 +32,7 @@ const (
 	DEFAULT_HTTPS_ACCESS_LOG       = "/dev/stdout"
 	DEFAULT_HTTPS_LISTENER_ADDRESS = DEFAULT_HTTP_LISTENER_ADDRESS
 	DEFAULT_HTTPS_LISTENER_PORT    = 8443
+	DEFAULT_XDS_CLUSTER_NAME       = "contour"
 )
 
 // ListenerVisitorConfig holds configuration parameters for visitListeners.
@@ -65,6 +65,10 @@ type ListenerVisitorConfig struct {
 	// V1 or V2 preamble.
 	// If not set, defaults to false.
 	UseProxyProto bool
+
+	// Envoy's XDS gRPC API cluster name references.
+	// If not set, defaults to DEFAULT_XDS_CLUSTER_NAME.
+	XDSClusterName string
 }
 
 // httpAddress returns the port for the HTTP (non TLS)
@@ -119,6 +123,15 @@ func (lvc *ListenerVisitorConfig) httpsAccessLog() string {
 		return lvc.HTTPSAccessLog
 	}
 	return DEFAULT_HTTPS_ACCESS_LOG
+}
+
+// xdsClusterName returns the cluster name for Envoy's XDS gRPC API
+// or DEFAULT_XDS_CLUSTER_NAME if not configured.
+func (lvc *ListenerVisitorConfig) xdsClusterName() string {
+	if lvc.XDSClusterName != "" {
+		return lvc.XDSClusterName
+	}
+	return DEFAULT_XDS_CLUSTER_NAME
 }
 
 // ListenerCache manages the contents of the gRPC LDS cache.
@@ -261,8 +274,7 @@ func (v *listenerVisitor) visit(vertex dag.Vertex) {
 
 		// attach certificate data to this listener if provided.
 		if vh.Secret != nil {
-			data := vh.Secret.Data()
-			fc.TlsContext = envoy.DownstreamTLSContext(data[v1.TLSCertKey], data[v1.TLSPrivateKeyKey], vh.MinProtoVersion, alpnProtos...)
+			fc.TlsContext = envoy.DownstreamTLSContext(envoy.Secretname(vh.Secret), v.xdsClusterName(), vh.MinProtoVersion, alpnProtos...)
 		}
 
 		v.listeners[ENVOY_HTTPS_LISTENER].FilterChains = append(v.listeners[ENVOY_HTTPS_LISTENER].FilterChains, fc)

--- a/internal/contour/listener_test.go
+++ b/internal/contour/listener_test.go
@@ -470,8 +470,7 @@ func filterchain(filters ...listener.Filter) []listener.FilterChain {
 }
 
 func tlscontext(tlsMinProtoVersion auth.TlsParameters_TlsProtocol, alpnprotos ...string) *auth.DownstreamTlsContext {
-	data := secretdata("certificate", "key")
-	return envoy.DownstreamTLSContext(data[v1.TLSCertKey], data[v1.TLSPrivateKeyKey], tlsMinProtoVersion, alpnprotos...)
+	return envoy.DownstreamTLSContext("default/secret/735ad571c1", DEFAULT_XDS_CLUSTER_NAME, tlsMinProtoVersion, alpnprotos...)
 }
 
 func secretdata(cert, key string) map[string][]byte {

--- a/internal/e2e/lds_test.go
+++ b/internal/e2e/lds_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/gogo/protobuf/types"
 	"github.com/heptio/contour/apis/generated/clientset/versioned/fake"
 	"github.com/heptio/contour/internal/contour"
+	"github.com/heptio/contour/internal/dag"
 	"github.com/heptio/contour/internal/envoy"
 	"github.com/heptio/contour/internal/k8s"
 	"google.golang.org/grpc"
@@ -191,7 +192,7 @@ func TestTLSListener(t *testing.T) {
 				ListenerFilters: []listener.ListenerFilter{
 					envoy.TLSInspector(),
 				},
-				FilterChains: filterchaintls("kuard.example.com", envoy.HTTPConnectionManager("ingress_https", "/dev/stdout"), "h2", "http/1.1"),
+				FilterChains: filterchaintls("kuard.example.com", s1, envoy.HTTPConnectionManager("ingress_https", "/dev/stdout"), "h2", "http/1.1"),
 			}),
 		},
 		TypeUrl: listenerType,
@@ -227,7 +228,7 @@ func TestTLSListener(t *testing.T) {
 				ListenerFilters: []listener.ListenerFilter{
 					envoy.TLSInspector(),
 				},
-				FilterChains: filterchaintls("kuard.example.com", envoy.HTTPConnectionManager("ingress_https", "/dev/stdout"), "h2", "http/1.1"),
+				FilterChains: filterchaintls("kuard.example.com", s1, envoy.HTTPConnectionManager("ingress_https", "/dev/stdout"), "h2", "http/1.1"),
 			}),
 		},
 		TypeUrl: listenerType,
@@ -325,7 +326,7 @@ func TestIngressRouteTLSListener(t *testing.T) {
 		ListenerFilters: []listener.ListenerFilter{
 			envoy.TLSInspector(),
 		},
-		FilterChains: filterchaintls("kuard.example.com", envoy.HTTPConnectionManager("ingress_https", "/dev/stdout"), "h2", "http/1.1"),
+		FilterChains: filterchaintls("kuard.example.com", s1, envoy.HTTPConnectionManager("ingress_https", "/dev/stdout"), "h2", "http/1.1"),
 	}
 
 	l1.FilterChains[0].TlsContext.CommonTlsContext.TlsParams.TlsMinimumProtocolVersion = auth.TlsParameters_TLSv1_1
@@ -370,7 +371,7 @@ func TestIngressRouteTLSListener(t *testing.T) {
 		ListenerFilters: []listener.ListenerFilter{
 			envoy.TLSInspector(),
 		},
-		FilterChains: filterchaintls("kuard.example.com", envoy.HTTPConnectionManager("ingress_https", "/dev/stdout"), "h2", "http/1.1"),
+		FilterChains: filterchaintls("kuard.example.com", s1, envoy.HTTPConnectionManager("ingress_https", "/dev/stdout"), "h2", "http/1.1"),
 	}
 
 	l2.FilterChains[0].TlsContext.CommonTlsContext.TlsParams.TlsMinimumProtocolVersion = auth.TlsParameters_TLSv1_3
@@ -437,7 +438,7 @@ func TestLDSFilter(t *testing.T) {
 				ListenerFilters: []listener.ListenerFilter{
 					envoy.TLSInspector(),
 				},
-				FilterChains: filterchaintls("kuard.example.com", envoy.HTTPConnectionManager("ingress_https", "/dev/stdout"), "h2", "http/1.1"),
+				FilterChains: filterchaintls("kuard.example.com", s1, envoy.HTTPConnectionManager("ingress_https", "/dev/stdout"), "h2", "http/1.1"),
 			}),
 		},
 		TypeUrl: listenerType,
@@ -523,7 +524,7 @@ func TestLDSTLSMinimumProtocolVersion(t *testing.T) {
 				ListenerFilters: []listener.ListenerFilter{
 					envoy.TLSInspector(),
 				},
-				FilterChains: filterchaintls("kuard.example.com", envoy.HTTPConnectionManager("ingress_https", "/dev/stdout"), "h2", "http/1.1"),
+				FilterChains: filterchaintls("kuard.example.com", s1, envoy.HTTPConnectionManager("ingress_https", "/dev/stdout"), "h2", "http/1.1"),
 			}),
 		},
 		TypeUrl: listenerType,
@@ -556,7 +557,7 @@ func TestLDSTLSMinimumProtocolVersion(t *testing.T) {
 		ListenerFilters: []listener.ListenerFilter{
 			envoy.TLSInspector(),
 		},
-		FilterChains: filterchaintls("kuard.example.com", envoy.HTTPConnectionManager("ingress_https", "/dev/stdout"), "h2", "http/1.1"),
+		FilterChains: filterchaintls("kuard.example.com", s1, envoy.HTTPConnectionManager("ingress_https", "/dev/stdout"), "h2", "http/1.1"),
 	}
 	// easier to patch this up than add more params to filterchaintls
 	l1.FilterChains[0].TlsContext.CommonTlsContext.TlsParams.TlsMinimumProtocolVersion = auth.TlsParameters_TLSv1_3
@@ -672,7 +673,7 @@ func TestLDSIngressHTTPSUseProxyProtocol(t *testing.T) {
 			envoy.ProxyProtocol(),
 			envoy.TLSInspector(),
 		},
-		FilterChains: filterchaintls("kuard.example.com", envoy.HTTPConnectionManager("ingress_https", "/dev/stdout"), "h2", "http/1.1"),
+		FilterChains: filterchaintls("kuard.example.com", s1, envoy.HTTPConnectionManager("ingress_https", "/dev/stdout"), "h2", "http/1.1"),
 	}
 	assertEqual(t, &v2.DiscoveryResponse{
 		VersionInfo: "2",
@@ -754,7 +755,7 @@ func TestLDSCustomAddressAndPort(t *testing.T) {
 		ListenerFilters: []listener.ListenerFilter{
 			envoy.TLSInspector(),
 		},
-		FilterChains: filterchaintls("kuard.example.com", envoy.HTTPConnectionManager("ingress_https", "/dev/stdout"), "h2", "http/1.1"),
+		FilterChains: filterchaintls("kuard.example.com", s1, envoy.HTTPConnectionManager("ingress_https", "/dev/stdout"), "h2", "http/1.1"),
 	}
 	assertEqual(t, &v2.DiscoveryResponse{
 		VersionInfo: "2",
@@ -825,7 +826,7 @@ func TestLDSCustomAccessLogPaths(t *testing.T) {
 		ListenerFilters: []listener.ListenerFilter{
 			envoy.TLSInspector(),
 		},
-		FilterChains: filterchaintls("kuard.example.com", envoy.HTTPConnectionManager("ingress_https", "/tmp/https_access.log"), "h2", "http/1.1"),
+		FilterChains: filterchaintls("kuard.example.com", s1, envoy.HTTPConnectionManager("ingress_https", "/tmp/https_access.log"), "h2", "http/1.1"),
 	}
 	assertEqual(t, &v2.DiscoveryResponse{
 		VersionInfo: "2",
@@ -1008,7 +1009,7 @@ func TestIngressRouteHTTPS(t *testing.T) {
 		ListenerFilters: []listener.ListenerFilter{
 			envoy.TLSInspector(),
 		},
-		FilterChains: filterchaintls("example.com", envoy.HTTPConnectionManager("ingress_https", "/dev/stdout"), "h2", "http/1.1"),
+		FilterChains: filterchaintls("example.com", s1, envoy.HTTPConnectionManager("ingress_https", "/dev/stdout"), "h2", "http/1.1"),
 	}
 	assertEqual(t, &v2.DiscoveryResponse{
 		VersionInfo: "2",
@@ -1144,7 +1145,7 @@ func TestLDSIngressRouteTCPForward(t *testing.T) {
 	ingressHTTPS := &v2.Listener{
 		Name:         "ingress_https",
 		Address:      *envoy.SocketAddress("0.0.0.0", 8443),
-		FilterChains: filterchaintls("kuard-tcp.example.com", tcpproxy("ingress_https", "default/correct-backend/80/da39a3ee5e")),
+		FilterChains: filterchaintls("kuard-tcp.example.com", s1, tcpproxy("ingress_https", "default/correct-backend/80/da39a3ee5e")),
 		ListenerFilters: []listener.ListenerFilter{
 			envoy.TLSInspector(),
 		},
@@ -1173,8 +1174,7 @@ func TestIngressRouteTLSCertificateDelegation(t *testing.T) {
 		Nonce:       "0",
 	}, streamLDS(t, cc))
 
-	// add a secret object secret/wildcard.
-	rh.OnAdd(&v1.Secret{
+	s1 := &v1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "wildcard",
 			Namespace: "secret",
@@ -1183,7 +1183,10 @@ func TestIngressRouteTLSCertificateDelegation(t *testing.T) {
 			v1.TLSCertKey:       []byte("certificate"),
 			v1.TLSPrivateKeyKey: []byte("key"),
 		},
-	})
+	}
+
+	// add a secret object secret/wildcard.
+	rh.OnAdd(s1)
 
 	// add an ingressroute in a different namespace mentioning secret/wildcard.
 	rh.OnAdd(&ingressroutev1.IngressRoute{
@@ -1247,7 +1250,7 @@ func TestIngressRouteTLSCertificateDelegation(t *testing.T) {
 		ListenerFilters: []listener.ListenerFilter{
 			envoy.TLSInspector(),
 		},
-		FilterChains: filterchaintls("example.com", envoy.HTTPConnectionManager("ingress_https", "/dev/stdout"), "h2", "http/1.1"),
+		FilterChains: filterchaintls("example.com", s1, envoy.HTTPConnectionManager("ingress_https", "/dev/stdout"), "h2", "http/1.1"),
 	}
 
 	assertEqual(t, &v2.DiscoveryResponse{
@@ -1366,7 +1369,7 @@ func filterchain(filters ...listener.Filter) []listener.FilterChain {
 	return []listener.FilterChain{fc}
 }
 
-func filterchaintls(domain string, filter listener.Filter, alpn ...string) []listener.FilterChain {
+func filterchaintls(domain string, secret *v1.Secret, filter listener.Filter, alpn ...string) []listener.FilterChain {
 	fc := listener.FilterChain{
 		Filters: []listener.Filter{
 			filter,
@@ -1375,7 +1378,7 @@ func filterchaintls(domain string, filter listener.Filter, alpn ...string) []lis
 	fc.FilterChainMatch = &listener.FilterChainMatch{
 		ServerNames: []string{domain},
 	}
-	fc.TlsContext = envoy.DownstreamTLSContext([]byte("certificate"), []byte("key"), auth.TlsParameters_TLSv1_1, alpn...)
+	fc.TlsContext = envoy.DownstreamTLSContext(envoy.Secretname(&dag.Secret{Object: secret}), "contour", auth.TlsParameters_TLSv1_1, alpn...)
 	return []listener.FilterChain{fc}
 }
 

--- a/internal/envoy/auth.go
+++ b/internal/envoy/auth.go
@@ -15,7 +15,6 @@ package envoy
 
 import (
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2/auth"
-	"github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 )
 
 var (
@@ -56,7 +55,7 @@ func UpstreamTLSContext(alpnProtocols ...string) *auth.UpstreamTlsContext {
 }
 
 // DownstreamTLSContext creates a new DownstreamTlsContext.
-func DownstreamTLSContext(cert, key []byte, tlsMinProtoVersion auth.TlsParameters_TlsProtocol, alpnProtos ...string) *auth.DownstreamTlsContext {
+func DownstreamTLSContext(secretName, clusterName string, tlsMinProtoVersion auth.TlsParameters_TlsProtocol, alpnProtos ...string) *auth.DownstreamTlsContext {
 	return &auth.DownstreamTlsContext{
 		CommonTlsContext: &auth.CommonTlsContext{
 			TlsParams: &auth.TlsParameters{
@@ -64,17 +63,9 @@ func DownstreamTLSContext(cert, key []byte, tlsMinProtoVersion auth.TlsParameter
 				TlsMaximumProtocolVersion: auth.TlsParameters_TLSv1_3,
 				CipherSuites:              ciphers,
 			},
-			TlsCertificates: []*auth.TlsCertificate{{
-				CertificateChain: &core.DataSource{
-					Specifier: &core.DataSource_InlineBytes{
-						InlineBytes: cert,
-					},
-				},
-				PrivateKey: &core.DataSource{
-					Specifier: &core.DataSource_InlineBytes{
-						InlineBytes: key,
-					},
-				},
+			TlsCertificateSdsSecretConfigs: []*auth.SdsSecretConfig{{
+				Name:      secretName,
+				SdsConfig: ConfigSource(clusterName),
 			}},
 			AlpnProtocols: alpnProtos,
 		},

--- a/internal/envoy/bootstrap.go
+++ b/internal/envoy/bootstrap.go
@@ -34,8 +34,8 @@ import (
 func Bootstrap(c *BootstrapConfig) *bootstrap.Bootstrap {
 	b := &bootstrap.Bootstrap{
 		DynamicResources: &bootstrap.Bootstrap_DynamicResources{
-			LdsConfig: ConfigSource("contour"),
-			CdsConfig: ConfigSource("contour"),
+			LdsConfig: ConfigSource(stringOrDefault(c.XDSClusterName, "contour")),
+			CdsConfig: ConfigSource(stringOrDefault(c.XDSClusterName, "contour")),
 		},
 		StaticResources: &bootstrap.Bootstrap_StaticResources{
 			Listeners: []api.Listener{{
@@ -203,6 +203,10 @@ type BootstrapConfig struct {
 	// XDSAddress is the TCP address of the gRPC XDS management server.
 	// Defaults to 127.0.0.1.
 	XDSAddress string
+
+	// XDSClusterName is the name reference for the gROC XDS management server.
+	// Defaults to contour.
+	XDSClusterName string
 
 	// XDSGRPCPort is the management server port that provides the v2 gRPC API.
 	// Defaults to 8001.

--- a/internal/envoy/listener_test.go
+++ b/internal/envoy/listener_test.go
@@ -149,10 +149,10 @@ func TestSocketAddress(t *testing.T) {
 
 func TestDownstreamTLSContext(t *testing.T) {
 	const (
-		cert = "foo"
-		key  = "secret"
+		secret  = "default/tls-cert"
+		cluster = "contour"
 	)
-	got := DownstreamTLSContext([]byte(cert), []byte(key), auth.TlsParameters_TLSv1_1, "h2", "http/1.1")
+	got := DownstreamTLSContext(secret, cluster, auth.TlsParameters_TLSv1_1, "h2", "http/1.1")
 	want := &auth.DownstreamTlsContext{
 		CommonTlsContext: &auth.CommonTlsContext{
 			TlsParams: &auth.TlsParameters{
@@ -169,15 +169,20 @@ func TestDownstreamTLSContext(t *testing.T) {
 					"ECDHE-RSA-AES256-SHA",
 				},
 			},
-			TlsCertificates: []*auth.TlsCertificate{{
-				CertificateChain: &core.DataSource{
-					Specifier: &core.DataSource_InlineBytes{
-						InlineBytes: []byte(cert),
-					},
-				},
-				PrivateKey: &core.DataSource{
-					Specifier: &core.DataSource_InlineBytes{
-						InlineBytes: []byte(key),
+			TlsCertificateSdsSecretConfigs: []*auth.SdsSecretConfig{{
+				Name: secret,
+				SdsConfig: &core.ConfigSource{
+					ConfigSourceSpecifier: &core.ConfigSource_ApiConfigSource{
+						ApiConfigSource: &core.ApiConfigSource{
+							ApiType: core.ApiConfigSource_GRPC,
+							GrpcServices: []*core.GrpcService{{
+								TargetSpecifier: &core.GrpcService_EnvoyGrpc_{
+									EnvoyGrpc: &core.GrpcService_EnvoyGrpc{
+										ClusterName: cluster,
+									},
+								},
+							}},
+						},
 					},
 				},
 			}},


### PR DESCRIPTION
Addresses the non-goals of the high-level design for secret discovery,
converting auth.CommonTlsContext from TlsCertificates with inline bytes
for secret data to TlsCertificateSdsSecretConfigs for secret references
from the xDS gRPC server.
    
Updates: #898
Signed-off-by: Matt Alberts <malberts@cloudflare.com>