### PR TITLE
Updated go-control-plane to v0.7.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,8 @@ go 1.12
 require (
 	cloud.google.com/go v0.37.4 // indirect
 	github.com/client9/misspell v0.3.4
-	github.com/envoyproxy/go-control-plane v0.6.9
+	github.com/envoyproxy/go-control-plane v0.7.1
+	github.com/envoyproxy/protoc-gen-validate v0.0.14 // indirect
 	github.com/evanphx/json-patch v4.1.0+incompatible
 	github.com/ghodss/yaml v1.0.0 // indirect
 	github.com/gogo/googleapis v1.1.0 // indirect

--- a/internal/contour/route.go
+++ b/internal/contour/route.go
@@ -121,12 +121,14 @@ func (v *routeVisitor) visit(vertex dag.Vertex) {
 							return
 						}
 						rr := route.Route{
-							Match:  envoy.PrefixMatch(r.Prefix),
-							Action: envoy.RouteRoute(r, r.Clusters),
+							Match:               envoy.PrefixMatch(r.Prefix),
+							Action:              envoy.RouteRoute(r, r.Clusters),
+							RequestHeadersToAdd: envoy.RouteHeaders(),
 						}
 
 						if r.HTTPSUpgrade {
 							rr.Action = envoy.UpgradeHTTPS()
+							rr.RequestHeadersToAdd = nil
 						}
 						vhost.Routes = append(vhost.Routes, rr)
 					}
@@ -145,8 +147,9 @@ func (v *routeVisitor) visit(vertex dag.Vertex) {
 							return
 						}
 						vhost.Routes = append(vhost.Routes, route.Route{
-							Match:  envoy.PrefixMatch(r.Prefix),
-							Action: envoy.RouteRoute(r, r.Clusters),
+							Match:               envoy.PrefixMatch(r.Prefix),
+							Action:              envoy.RouteRoute(r, r.Clusters),
+							RequestHeadersToAdd: envoy.RouteHeaders(),
 						})
 					}
 				})
@@ -193,14 +196,3 @@ func (l longestRouteFirst) Less(i, j int) bool {
 }
 
 func u32(val int) *types.UInt32Value { return &types.UInt32Value{Value: uint32(val)} }
-
-var bvTrue = types.BoolValue{Value: true}
-
-// bv returns a pointer to a true types.BoolValue if val is true,
-// otherwise it returns nil.
-func bv(val bool) *types.BoolValue {
-	if val {
-		return &bvTrue
-	}
-	return nil
-}

--- a/internal/contour/route_test.go
+++ b/internal/contour/route_test.go
@@ -18,7 +18,6 @@ import (
 	"time"
 
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2"
-	"github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
 	"github.com/google/go-cmp/cmp"
 	ingressroutev1 "github.com/heptio/contour/apis/contour/v1beta1"
@@ -82,8 +81,9 @@ func TestRouteVisit(t *testing.T) {
 						Name:    "*",
 						Domains: []string{"*"},
 						Routes: []route.Route{{
-							Match:  envoy.PrefixMatch("/"),
-							Action: routecluster("default/kuard/8080/da39a3ee5e"),
+							Match:               envoy.PrefixMatch("/"),
+							Action:              routecluster("default/kuard/8080/da39a3ee5e"),
+							RequestHeadersToAdd: envoy.RouteHeaders(),
 						}},
 					}},
 				},
@@ -135,8 +135,9 @@ func TestRouteVisit(t *testing.T) {
 						Name:    "www.example.com",
 						Domains: []string{"www.example.com", "www.example.com:80"},
 						Routes: []route.Route{{
-							Match:  envoy.PrefixMatch("/"),
-							Action: routecluster("default/backend/80/da39a3ee5e"),
+							Match:               envoy.PrefixMatch("/"),
+							Action:              routecluster("default/backend/80/da39a3ee5e"),
+							RequestHeadersToAdd: envoy.RouteHeaders(),
 						}},
 					}},
 				},
@@ -191,8 +192,9 @@ func TestRouteVisit(t *testing.T) {
 						Name:    "*", // default backend
 						Domains: []string{"*"},
 						Routes: []route.Route{{
-							Match:  envoy.PrefixMatch("/"),
-							Action: routecluster("default/kuard/8080/da39a3ee5e"),
+							Match:               envoy.PrefixMatch("/"),
+							Action:              routecluster("default/kuard/8080/da39a3ee5e"),
+							RequestHeadersToAdd: envoy.RouteHeaders(),
 						}},
 					}},
 				},
@@ -257,8 +259,9 @@ func TestRouteVisit(t *testing.T) {
 						Name:    "www.example.com",
 						Domains: []string{"www.example.com", "www.example.com:80"},
 						Routes: []route.Route{{
-							Match:  envoy.PrefixMatch("/"),
-							Action: routecluster("default/kuard/8080/da39a3ee5e"),
+							Match:               envoy.PrefixMatch("/"),
+							Action:              routecluster("default/kuard/8080/da39a3ee5e"),
+							RequestHeadersToAdd: envoy.RouteHeaders(),
 						}},
 					}},
 				},
@@ -268,8 +271,9 @@ func TestRouteVisit(t *testing.T) {
 						Name:    "www.example.com",
 						Domains: []string{"www.example.com", "www.example.com:443"},
 						Routes: []route.Route{{
-							Match:  envoy.PrefixMatch("/"),
-							Action: routecluster("default/kuard/8080/da39a3ee5e"),
+							Match:               envoy.PrefixMatch("/"),
+							Action:              routecluster("default/kuard/8080/da39a3ee5e"),
+							RequestHeadersToAdd: envoy.RouteHeaders(),
 						}},
 					}},
 				},
@@ -345,8 +349,9 @@ func TestRouteVisit(t *testing.T) {
 						Name:    "www.example.com",
 						Domains: []string{"www.example.com", "www.example.com:443"},
 						Routes: []route.Route{{
-							Match:  envoy.PrefixMatch("/"),
-							Action: routecluster("default/backend/8080/da39a3ee5e"),
+							Match:               envoy.PrefixMatch("/"),
+							Action:              routecluster("default/backend/8080/da39a3ee5e"),
+							RequestHeadersToAdd: envoy.RouteHeaders(),
 						}},
 					}},
 				},
@@ -414,8 +419,9 @@ func TestRouteVisit(t *testing.T) {
 						Name:    "www.example.com",
 						Domains: []string{"www.example.com", "www.example.com:443"},
 						Routes: []route.Route{{
-							Match:  envoy.PrefixMatch("/"),
-							Action: routecluster("default/kuard/8080/da39a3ee5e"),
+							Match:               envoy.PrefixMatch("/"),
+							Action:              routecluster("default/kuard/8080/da39a3ee5e"),
+							RequestHeadersToAdd: envoy.RouteHeaders(),
 						}},
 					}},
 				},
@@ -497,8 +503,9 @@ func TestRouteVisit(t *testing.T) {
 						Name:    "www.example.com",
 						Domains: []string{"www.example.com", "www.example.com:443"},
 						Routes: []route.Route{{
-							Match:  envoy.PrefixMatch("/"),
-							Action: routecluster("default/kuard/8080/da39a3ee5e"),
+							Match:               envoy.PrefixMatch("/"),
+							Action:              routecluster("default/kuard/8080/da39a3ee5e"),
+							RequestHeadersToAdd: envoy.RouteHeaders(),
 						}},
 					}},
 				},
@@ -559,11 +566,13 @@ func TestRouteVisit(t *testing.T) {
 						Name:    "www.example.com",
 						Domains: []string{"www.example.com", "www.example.com:80"},
 						Routes: []route.Route{{
-							Match:  envoy.PrefixMatch("/ws1"),
-							Action: websocketroute("default/kuard/8080/da39a3ee5e"),
+							Match:               envoy.PrefixMatch("/ws1"),
+							Action:              websocketroute("default/kuard/8080/da39a3ee5e"),
+							RequestHeadersToAdd: envoy.RouteHeaders(),
 						}, {
-							Match:  envoy.PrefixMatch("/"),
-							Action: routecluster("default/kuard/8080/da39a3ee5e"),
+							Match:               envoy.PrefixMatch("/"),
+							Action:              routecluster("default/kuard/8080/da39a3ee5e"),
+							RequestHeadersToAdd: envoy.RouteHeaders(),
 						}},
 					}},
 				},
@@ -610,8 +619,9 @@ func TestRouteVisit(t *testing.T) {
 						Name:    "*",
 						Domains: []string{"*"},
 						Routes: []route.Route{{
-							Match:  envoy.PrefixMatch("/"),
-							Action: routetimeout("default/kuard/8080/da39a3ee5e", duration(0)),
+							Match:               envoy.PrefixMatch("/"),
+							Action:              routetimeout("default/kuard/8080/da39a3ee5e", duration(0)),
+							RequestHeadersToAdd: envoy.RouteHeaders(),
 						}},
 					}},
 				},
@@ -658,8 +668,9 @@ func TestRouteVisit(t *testing.T) {
 						Name:    "*",
 						Domains: []string{"*"},
 						Routes: []route.Route{{
-							Match:  envoy.PrefixMatch("/"),
-							Action: routetimeout("default/kuard/8080/da39a3ee5e", duration(0)),
+							Match:               envoy.PrefixMatch("/"),
+							Action:              routetimeout("default/kuard/8080/da39a3ee5e", duration(0)),
+							RequestHeadersToAdd: envoy.RouteHeaders(),
 						}},
 					}},
 				},
@@ -706,8 +717,9 @@ func TestRouteVisit(t *testing.T) {
 						Name:    "*",
 						Domains: []string{"*"},
 						Routes: []route.Route{{
-							Match:  envoy.PrefixMatch("/"),
-							Action: routetimeout("default/kuard/8080/da39a3ee5e", duration(90*time.Second)),
+							Match:               envoy.PrefixMatch("/"),
+							Action:              routetimeout("default/kuard/8080/da39a3ee5e", duration(90*time.Second)),
+							RequestHeadersToAdd: envoy.RouteHeaders(),
 						}},
 					}},
 				},
@@ -762,8 +774,9 @@ func TestRouteVisit(t *testing.T) {
 						Name:    "d31bb322ca62bb395acad00b3cbf45a3aa1010ca28dca7cddb4f7db786fa",
 						Domains: []string{"my-very-very-long-service-host-name.subdomain.boring-dept.my.company", "my-very-very-long-service-host-name.subdomain.boring-dept.my.company:80"},
 						Routes: []route.Route{{
-							Match:  envoy.PrefixMatch("/"),
-							Action: routecluster("default/kuard/80/da39a3ee5e"),
+							Match:               envoy.PrefixMatch("/"),
+							Action:              routecluster("default/kuard/80/da39a3ee5e"),
+							RequestHeadersToAdd: envoy.RouteHeaders(),
 						}},
 					}},
 				},
@@ -807,8 +820,9 @@ func TestRouteVisit(t *testing.T) {
 						Name:    "*",
 						Domains: []string{"*"},
 						Routes: []route.Route{{
-							Match:  envoy.PrefixMatch("/"),
-							Action: routecluster("default/kuard/8080/da39a3ee5e"),
+							Match:               envoy.PrefixMatch("/"),
+							Action:              routecluster("default/kuard/8080/da39a3ee5e"),
+							RequestHeadersToAdd: envoy.RouteHeaders(),
 						}},
 					}},
 				},
@@ -935,8 +949,9 @@ func TestRouteVisit(t *testing.T) {
 						Name:    "*",
 						Domains: []string{"*"},
 						Routes: []route.Route{{
-							Match:  envoy.PrefixMatch("/"),
-							Action: routecluster("default/kuard/8080/da39a3ee5e"),
+							Match:               envoy.PrefixMatch("/"),
+							Action:              routecluster("default/kuard/8080/da39a3ee5e"),
+							RequestHeadersToAdd: envoy.RouteHeaders(),
 						}},
 					}},
 				},
@@ -983,8 +998,9 @@ func TestRouteVisit(t *testing.T) {
 						Name:    "*",
 						Domains: []string{"*"},
 						Routes: []route.Route{{
-							Match:  envoy.PrefixMatch("/"),
-							Action: routecluster("default/kuard/8080/da39a3ee5e"),
+							Match:               envoy.PrefixMatch("/"),
+							Action:              routecluster("default/kuard/8080/da39a3ee5e"),
+							RequestHeadersToAdd: envoy.RouteHeaders(),
 						}},
 					}},
 				},
@@ -1036,8 +1052,9 @@ func TestRouteVisit(t *testing.T) {
 						Name:    "www.example.com",
 						Domains: []string{"www.example.com", "www.example.com:80"},
 						Routes: []route.Route{{
-							Match:  envoy.PrefixMatch("/"),
-							Action: routecluster("default/kuard/8080/da39a3ee5e"),
+							Match:               envoy.PrefixMatch("/"),
+							Action:              routecluster("default/kuard/8080/da39a3ee5e"),
+							RequestHeadersToAdd: envoy.RouteHeaders(),
 						}},
 					}},
 				},
@@ -1188,8 +1205,9 @@ func TestRouteVisit(t *testing.T) {
 						Name:    "www.example.com",
 						Domains: []string{"www.example.com", "www.example.com:80"},
 						Routes: []route.Route{{
-							Match:  envoy.PrefixMatch("/"),
-							Action: routecluster("default/kuard/8080/da39a3ee5e"),
+							Match:               envoy.PrefixMatch("/"),
+							Action:              routecluster("default/kuard/8080/da39a3ee5e"),
+							RequestHeadersToAdd: envoy.RouteHeaders(),
 						}},
 					}},
 				},
@@ -1244,8 +1262,9 @@ func TestRouteVisit(t *testing.T) {
 						Name:    "www.example.com",
 						Domains: []string{"www.example.com", "www.example.com:80"},
 						Routes: []route.Route{{
-							Match:  envoy.PrefixMatch("/"),
-							Action: routecluster("default/kuard/8080/da39a3ee5e"),
+							Match:               envoy.PrefixMatch("/"),
+							Action:              routecluster("default/kuard/8080/da39a3ee5e"),
+							RequestHeadersToAdd: envoy.RouteHeaders(),
 						}},
 					}},
 				},
@@ -1292,8 +1311,9 @@ func TestRouteVisit(t *testing.T) {
 						Name:    "*",
 						Domains: []string{"*"},
 						Routes: []route.Route{{
-							Match:  envoy.PrefixMatch("/"),
-							Action: routeretry("default/kuard/8080/da39a3ee5e", "50x,gateway-error", 0, 0),
+							Match:               envoy.PrefixMatch("/"),
+							Action:              routeretry("default/kuard/8080/da39a3ee5e", "50x,gateway-error", 0, 0),
+							RequestHeadersToAdd: envoy.RouteHeaders(),
 						}},
 					}},
 				},
@@ -1341,8 +1361,9 @@ func TestRouteVisit(t *testing.T) {
 						Name:    "*",
 						Domains: []string{"*"},
 						Routes: []route.Route{{
-							Match:  envoy.PrefixMatch("/"),
-							Action: routeretry("default/kuard/8080/da39a3ee5e", "50x,gateway-error", 7, 0),
+							Match:               envoy.PrefixMatch("/"),
+							Action:              routeretry("default/kuard/8080/da39a3ee5e", "50x,gateway-error", 7, 0),
+							RequestHeadersToAdd: envoy.RouteHeaders(),
 						}},
 					}},
 				},
@@ -1390,8 +1411,9 @@ func TestRouteVisit(t *testing.T) {
 						Name:    "*",
 						Domains: []string{"*"},
 						Routes: []route.Route{{
-							Match:  envoy.PrefixMatch("/"),
-							Action: routeretry("default/kuard/8080/da39a3ee5e", "50x,gateway-error", 0, 150*time.Millisecond),
+							Match:               envoy.PrefixMatch("/"),
+							Action:              routeretry("default/kuard/8080/da39a3ee5e", "50x,gateway-error", 0, 150*time.Millisecond),
+							RequestHeadersToAdd: envoy.RouteHeaders(),
 						}},
 					}},
 				},
@@ -1400,7 +1422,6 @@ func TestRouteVisit(t *testing.T) {
 				},
 			},
 		},
-
 		"ingressroute no weights defined": {
 			objs: []interface{}{
 				&ingressroutev1.IngressRoute{
@@ -1475,6 +1496,7 @@ func TestRouteVisit(t *testing.T) {
 									},
 								},
 							},
+							RequestHeadersToAdd: envoy.RouteHeaders(),
 						}},
 					}},
 				},
@@ -1558,6 +1580,7 @@ func TestRouteVisit(t *testing.T) {
 									},
 								},
 							},
+							RequestHeadersToAdd: envoy.RouteHeaders(),
 						}},
 					}},
 				},
@@ -1642,6 +1665,7 @@ func TestRouteVisit(t *testing.T) {
 									},
 								},
 							},
+							RequestHeadersToAdd: envoy.RouteHeaders(),
 						}},
 					}},
 				},
@@ -1720,7 +1744,6 @@ func routecluster(cluster string) *route.Route_Route {
 			ClusterSpecifier: &route.RouteAction_Cluster{
 				Cluster: cluster,
 			},
-			RequestHeadersToAdd: headers(appendHeader("x-request-start", "t=%START_TIME(%s.%3f)%")),
 		},
 	}
 
@@ -1762,22 +1785,7 @@ func weightedClusters(first, second *route.WeightedCluster_ClusterWeight, rest .
 
 func weightedCluster(name string, weight int) *route.WeightedCluster_ClusterWeight {
 	return &route.WeightedCluster_ClusterWeight{
-		Name:                name,
-		Weight:              u32(weight),
-		RequestHeadersToAdd: headers(appendHeader("x-request-start", "t=%START_TIME(%s.%3f)%")),
-	}
-}
-
-func headers(first *core.HeaderValueOption, rest ...*core.HeaderValueOption) []*core.HeaderValueOption {
-	return append([]*core.HeaderValueOption{first}, rest...)
-}
-
-func appendHeader(key, value string) *core.HeaderValueOption {
-	return &core.HeaderValueOption{
-		Header: &core.HeaderValue{
-			Key:   key,
-			Value: value,
-		},
-		Append: bv(true),
+		Name:   name,
+		Weight: u32(weight),
 	}
 }

--- a/internal/e2e/e2e.go
+++ b/internal/e2e/e2e.go
@@ -208,4 +208,3 @@ func fileAccessLog(path string) *accesslog.FileAccessLog {
 }
 
 func u32(val int) *types.UInt32Value { return &types.UInt32Value{Value: uint32(val)} }
-func bv(val bool) *types.BoolValue   { return &types.BoolValue{Value: val} }

--- a/internal/e2e/rds_test.go
+++ b/internal/e2e/rds_test.go
@@ -21,7 +21,6 @@ import (
 	"time"
 
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2"
-	"github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
 	"github.com/gogo/protobuf/types"
 	ingressroutev1 "github.com/heptio/contour/apis/contour/v1beta1"
@@ -107,8 +106,9 @@ func TestEditIngress(t *testing.T) {
 					Name:    "*",
 					Domains: []string{"*"},
 					Routes: []route.Route{{
-						Match:  envoy.PrefixMatch("/"),
-						Action: routecluster("default/kuard/80/da39a3ee5e"),
+						Match:               envoy.PrefixMatch("/"),
+						Action:              routecluster("default/kuard/80/da39a3ee5e"),
+						RequestHeadersToAdd: envoy.RouteHeaders(),
 					}},
 				}},
 			}),
@@ -150,8 +150,9 @@ func TestEditIngress(t *testing.T) {
 					Name:    "*",
 					Domains: []string{"*"},
 					Routes: []route.Route{{
-						Match:  envoy.PrefixMatch("/testing"),
-						Action: routecluster("default/kuard/80/da39a3ee5e"),
+						Match:               envoy.PrefixMatch("/testing"),
+						Action:              routecluster("default/kuard/80/da39a3ee5e"),
+						RequestHeadersToAdd: envoy.RouteHeaders(),
 					}},
 				}},
 			}),
@@ -229,8 +230,9 @@ func TestIngressPathRouteWithoutHost(t *testing.T) {
 					Name:    "*",
 					Domains: []string{"*"},
 					Routes: []route.Route{{
-						Match:  envoy.PrefixMatch("/hello"),
-						Action: routecluster("default/hello/80/da39a3ee5e"),
+						Match:               envoy.PrefixMatch("/hello"),
+						Action:              routecluster("default/hello/80/da39a3ee5e"),
+						RequestHeadersToAdd: envoy.RouteHeaders(),
 					}},
 				}},
 			}),
@@ -309,8 +311,9 @@ func TestEditIngressInPlace(t *testing.T) {
 					Name:    "hello.example.com",
 					Domains: []string{"hello.example.com", "hello.example.com:80"},
 					Routes: []route.Route{{
-						Match:  envoy.PrefixMatch("/"),
-						Action: routecluster("default/wowie/80/da39a3ee5e"),
+						Match:               envoy.PrefixMatch("/"),
+						Action:              routecluster("default/wowie/80/da39a3ee5e"),
+						RequestHeadersToAdd: envoy.RouteHeaders(),
 					}},
 				}},
 			}),
@@ -358,11 +361,13 @@ func TestEditIngressInPlace(t *testing.T) {
 					Name:    "hello.example.com",
 					Domains: []string{"hello.example.com", "hello.example.com:80"},
 					Routes: []route.Route{{
-						Match:  envoy.PrefixMatch("/whoop"),
-						Action: routecluster("default/kerpow/9000/da39a3ee5e"),
+						Match:               envoy.PrefixMatch("/whoop"),
+						Action:              routecluster("default/kerpow/9000/da39a3ee5e"),
+						RequestHeadersToAdd: envoy.RouteHeaders(),
 					}, {
-						Match:  envoy.PrefixMatch("/"),
-						Action: routecluster("default/wowie/80/da39a3ee5e"),
+						Match:               envoy.PrefixMatch("/"),
+						Action:              routecluster("default/wowie/80/da39a3ee5e"),
+						RequestHeadersToAdd: envoy.RouteHeaders(),
 					}},
 				}},
 			}),
@@ -498,11 +503,13 @@ func TestEditIngressInPlace(t *testing.T) {
 					Name:    "hello.example.com",
 					Domains: []string{"hello.example.com", "hello.example.com:443"},
 					Routes: []route.Route{{
-						Match:  envoy.PrefixMatch("/whoop"),
-						Action: routecluster("default/kerpow/9000/da39a3ee5e"),
+						Match:               envoy.PrefixMatch("/whoop"),
+						Action:              routecluster("default/kerpow/9000/da39a3ee5e"),
+						RequestHeadersToAdd: envoy.RouteHeaders(),
 					}, {
-						Match:  envoy.PrefixMatch("/"),
-						Action: routecluster("default/wowie/80/da39a3ee5e"),
+						Match:               envoy.PrefixMatch("/"),
+						Action:              routecluster("default/wowie/80/da39a3ee5e"),
+						RequestHeadersToAdd: envoy.RouteHeaders(),
 					}},
 				}}}),
 		},
@@ -548,8 +555,9 @@ func TestRequestTimeout(t *testing.T) {
 		Name:    "*",
 		Domains: []string{"*"},
 		Routes: []route.Route{{
-			Match:  envoy.PrefixMatch("/"), // match all
-			Action: routecluster("default/backend/80/da39a3ee5e"),
+			Match:               envoy.PrefixMatch("/"), // match all
+			Action:              routecluster("default/backend/80/da39a3ee5e"),
+			RequestHeadersToAdd: envoy.RouteHeaders(),
 		}},
 	}}, nil)
 
@@ -569,8 +577,9 @@ func TestRequestTimeout(t *testing.T) {
 		Name:    "*",
 		Domains: []string{"*"},
 		Routes: []route.Route{{
-			Match:  envoy.PrefixMatch("/"), // match all
-			Action: clustertimeout("default/backend/80/da39a3ee5e", durationInfinite),
+			Match:               envoy.PrefixMatch("/"), // match all
+			Action:              clustertimeout("default/backend/80/da39a3ee5e", durationInfinite),
+			RequestHeadersToAdd: envoy.RouteHeaders(),
 		}},
 	}}, nil)
 
@@ -590,8 +599,9 @@ func TestRequestTimeout(t *testing.T) {
 		Name:    "*",
 		Domains: []string{"*"},
 		Routes: []route.Route{{
-			Match:  envoy.PrefixMatch("/"), // match all
-			Action: clustertimeout("default/backend/80/da39a3ee5e", duration10Minutes),
+			Match:               envoy.PrefixMatch("/"), // match all
+			Action:              clustertimeout("default/backend/80/da39a3ee5e", duration10Minutes),
+			RequestHeadersToAdd: envoy.RouteHeaders(),
 		}},
 	}}, nil)
 
@@ -611,8 +621,9 @@ func TestRequestTimeout(t *testing.T) {
 		Name:    "*",
 		Domains: []string{"*"},
 		Routes: []route.Route{{
-			Match:  envoy.PrefixMatch("/"), // match all
-			Action: clustertimeout("default/backend/80/da39a3ee5e", durationInfinite),
+			Match:               envoy.PrefixMatch("/"), // match all
+			Action:              clustertimeout("default/backend/80/da39a3ee5e", durationInfinite),
+			RequestHeadersToAdd: envoy.RouteHeaders(),
 		}},
 	}}, nil)
 }
@@ -722,8 +733,9 @@ func TestSSLRedirectOverlay(t *testing.T) {
 		Name:    "example.com",
 		Domains: []string{"example.com", "example.com:80"},
 		Routes: []route.Route{{
-			Match:  envoy.PrefixMatch("/.well-known/acme-challenge/gVJl5NWL2owUqZekjHkt_bo3OHYC2XNDURRRgLI5JTk"),
-			Action: routecluster("nginx-ingress/challenge-service/8009/da39a3ee5e"),
+			Match:               envoy.PrefixMatch("/.well-known/acme-challenge/gVJl5NWL2owUqZekjHkt_bo3OHYC2XNDURRRgLI5JTk"),
+			Action:              routecluster("nginx-ingress/challenge-service/8009/da39a3ee5e"),
+			RequestHeadersToAdd: envoy.RouteHeaders(),
 		}, {
 			Match:  envoy.PrefixMatch("/"), // match all
 			Action: envoy.UpgradeHTTPS(),
@@ -732,11 +744,13 @@ func TestSSLRedirectOverlay(t *testing.T) {
 		Name:    "example.com",
 		Domains: []string{"example.com", "example.com:443"},
 		Routes: []route.Route{{
-			Match:  envoy.PrefixMatch("/.well-known/acme-challenge/gVJl5NWL2owUqZekjHkt_bo3OHYC2XNDURRRgLI5JTk"),
-			Action: routecluster("nginx-ingress/challenge-service/8009/da39a3ee5e"),
+			Match:               envoy.PrefixMatch("/.well-known/acme-challenge/gVJl5NWL2owUqZekjHkt_bo3OHYC2XNDURRRgLI5JTk"),
+			Action:              routecluster("nginx-ingress/challenge-service/8009/da39a3ee5e"),
+			RequestHeadersToAdd: envoy.RouteHeaders(),
 		}, {
-			Match:  envoy.PrefixMatch("/"), // match all
-			Action: routecluster("default/app-service/8080/da39a3ee5e"),
+			Match:               envoy.PrefixMatch("/"), // match all
+			Action:              routecluster("default/app-service/8080/da39a3ee5e"),
+			RequestHeadersToAdd: envoy.RouteHeaders(),
 		}},
 	}})
 }
@@ -795,8 +809,9 @@ func TestIssue257(t *testing.T) {
 		Name:    "*",
 		Domains: []string{"*"},
 		Routes: []route.Route{{
-			Match:  envoy.PrefixMatch("/"), // match all
-			Action: routecluster("default/kuard/80/da39a3ee5e"),
+			Match:               envoy.PrefixMatch("/"), // match all
+			Action:              routecluster("default/kuard/80/da39a3ee5e"),
+			RequestHeadersToAdd: envoy.RouteHeaders(),
 		}},
 	}}, nil)
 
@@ -848,8 +863,9 @@ func TestIssue257(t *testing.T) {
 		Name:    "kuard.db.gd-ms.com",
 		Domains: []string{"kuard.db.gd-ms.com", "kuard.db.gd-ms.com:80"},
 		Routes: []route.Route{{
-			Match:  envoy.PrefixMatch("/"), // match all
-			Action: routecluster("default/kuard/80/da39a3ee5e"),
+			Match:               envoy.PrefixMatch("/"), // match all
+			Action:              routecluster("default/kuard/80/da39a3ee5e"),
+			RequestHeadersToAdd: envoy.RouteHeaders(),
 		}},
 	}}, nil)
 }
@@ -964,8 +980,9 @@ func TestRDSFilter(t *testing.T) {
 					Name:    "example.com",
 					Domains: []string{"example.com", "example.com:80"},
 					Routes: []route.Route{{
-						Match:  envoy.PrefixMatch("/.well-known/acme-challenge/gVJl5NWL2owUqZekjHkt_bo3OHYC2XNDURRRgLI5JTk"),
-						Action: routecluster("nginx-ingress/challenge-service/8009/da39a3ee5e"),
+						Match:               envoy.PrefixMatch("/.well-known/acme-challenge/gVJl5NWL2owUqZekjHkt_bo3OHYC2XNDURRRgLI5JTk"),
+						Action:              routecluster("nginx-ingress/challenge-service/8009/da39a3ee5e"),
+						RequestHeadersToAdd: envoy.RouteHeaders(),
 					}, {
 						Match:  envoy.PrefixMatch("/"), // match all
 						Action: envoy.UpgradeHTTPS(),
@@ -986,11 +1003,13 @@ func TestRDSFilter(t *testing.T) {
 					Name:    "example.com",
 					Domains: []string{"example.com", "example.com:443"},
 					Routes: []route.Route{{
-						Match:  envoy.PrefixMatch("/.well-known/acme-challenge/gVJl5NWL2owUqZekjHkt_bo3OHYC2XNDURRRgLI5JTk"),
-						Action: routecluster("nginx-ingress/challenge-service/8009/da39a3ee5e"),
+						Match:               envoy.PrefixMatch("/.well-known/acme-challenge/gVJl5NWL2owUqZekjHkt_bo3OHYC2XNDURRRgLI5JTk"),
+						Action:              routecluster("nginx-ingress/challenge-service/8009/da39a3ee5e"),
+						RequestHeadersToAdd: envoy.RouteHeaders(),
 					}, {
-						Match:  envoy.PrefixMatch("/"), // match all
-						Action: routecluster("default/app-service/8080/da39a3ee5e"),
+						Match:               envoy.PrefixMatch("/"), // match all
+						Action:              routecluster("default/app-service/8080/da39a3ee5e"),
+						RequestHeadersToAdd: envoy.RouteHeaders(),
 					}},
 				}},
 			}),
@@ -1048,8 +1067,9 @@ func TestWebsocketIngress(t *testing.T) {
 		Name:    "websocket.hello.world",
 		Domains: []string{"websocket.hello.world", "websocket.hello.world:80"},
 		Routes: []route.Route{{
-			Match:  envoy.PrefixMatch("/"), // match all
-			Action: websocketroute("default/ws/80/da39a3ee5e"),
+			Match:               envoy.PrefixMatch("/"), // match all
+			Action:              websocketroute("default/ws/80/da39a3ee5e"),
+			RequestHeadersToAdd: envoy.RouteHeaders(),
 		}},
 	}}, nil)
 }
@@ -1107,14 +1127,17 @@ func TestWebsocketIngressRoute(t *testing.T) {
 		Name:    "websocket.hello.world",
 		Domains: []string{"websocket.hello.world", "websocket.hello.world:80"},
 		Routes: []route.Route{{
-			Match:  envoy.PrefixMatch("/ws-2"),
-			Action: websocketroute("default/ws/80/da39a3ee5e"),
+			Match:               envoy.PrefixMatch("/ws-2"),
+			Action:              websocketroute("default/ws/80/da39a3ee5e"),
+			RequestHeadersToAdd: envoy.RouteHeaders(),
 		}, {
-			Match:  envoy.PrefixMatch("/ws-1"),
-			Action: websocketroute("default/ws/80/da39a3ee5e"),
+			Match:               envoy.PrefixMatch("/ws-1"),
+			Action:              websocketroute("default/ws/80/da39a3ee5e"),
+			RequestHeadersToAdd: envoy.RouteHeaders(),
 		}, {
-			Match:  envoy.PrefixMatch("/"), // match all
-			Action: routecluster("default/ws/80/da39a3ee5e"),
+			Match:               envoy.PrefixMatch("/"), // match all
+			Action:              routecluster("default/ws/80/da39a3ee5e"),
+			RequestHeadersToAdd: envoy.RouteHeaders(),
 		}},
 	}}, nil)
 }
@@ -1171,14 +1194,17 @@ func TestPrefixRewriteIngressRoute(t *testing.T) {
 		Name:    "prefixrewrite.hello.world",
 		Domains: []string{"prefixrewrite.hello.world", "prefixrewrite.hello.world:80"},
 		Routes: []route.Route{{
-			Match:  envoy.PrefixMatch("/ws-2"),
-			Action: prefixrewriteroute("default/ws/80/da39a3ee5e"),
+			Match:               envoy.PrefixMatch("/ws-2"),
+			Action:              prefixrewriteroute("default/ws/80/da39a3ee5e"),
+			RequestHeadersToAdd: envoy.RouteHeaders(),
 		}, {
-			Match:  envoy.PrefixMatch("/ws-1"),
-			Action: prefixrewriteroute("default/ws/80/da39a3ee5e"),
+			Match:               envoy.PrefixMatch("/ws-1"),
+			Action:              prefixrewriteroute("default/ws/80/da39a3ee5e"),
+			RequestHeadersToAdd: envoy.RouteHeaders(),
 		}, {
-			Match:  envoy.PrefixMatch("/"), // match all
-			Action: routecluster("default/ws/80/da39a3ee5e"),
+			Match:               envoy.PrefixMatch("/"), // match all
+			Action:              routecluster("default/ws/80/da39a3ee5e"),
+			RequestHeadersToAdd: envoy.RouteHeaders(),
 		}},
 	}}, nil)
 }
@@ -1272,18 +1298,21 @@ func TestDefaultBackendDoesNotOverwriteNamedHost(t *testing.T) {
 					Name:    "*",
 					Domains: []string{"*"},
 					Routes: []route.Route{{
-						Match:  envoy.PrefixMatch("/kuard"),
-						Action: routecluster("default/kuard/8080/da39a3ee5e"),
+						Match:               envoy.PrefixMatch("/kuard"),
+						Action:              routecluster("default/kuard/8080/da39a3ee5e"),
+						RequestHeadersToAdd: envoy.RouteHeaders(),
 					}, {
-						Match:  envoy.PrefixMatch("/"),
-						Action: routecluster("default/kuard/80/da39a3ee5e"),
+						Match:               envoy.PrefixMatch("/"),
+						Action:              routecluster("default/kuard/80/da39a3ee5e"),
+						RequestHeadersToAdd: envoy.RouteHeaders(),
 					}},
 				}, {
 					Name:    "test-gui",
 					Domains: []string{"test-gui", "test-gui:80"},
 					Routes: []route.Route{{
-						Match:  envoy.PrefixMatch("/"),
-						Action: routecluster("default/test-gui/80/da39a3ee5e"),
+						Match:               envoy.PrefixMatch("/"),
+						Action:              routecluster("default/test-gui/80/da39a3ee5e"),
+						RequestHeadersToAdd: envoy.RouteHeaders(),
 					}},
 				}},
 			}),
@@ -1346,8 +1375,9 @@ func TestRDSIngressRouteInsideRootNamespaces(t *testing.T) {
 					Name:    "example.com",
 					Domains: []string{"example.com", "example.com:80"},
 					Routes: []route.Route{{
-						Match:  envoy.PrefixMatch("/"),
-						Action: routecluster("roots/kuard/8080/da39a3ee5e"),
+						Match:               envoy.PrefixMatch("/"),
+						Action:              routecluster("roots/kuard/8080/da39a3ee5e"),
+						RequestHeadersToAdd: envoy.RouteHeaders(),
 					}},
 				}},
 			}),
@@ -1462,8 +1492,9 @@ func TestRDSIngressRouteClassAnnotation(t *testing.T) {
 		Name:    "www.example.com",
 		Domains: []string{"www.example.com", "www.example.com:80"},
 		Routes: []route.Route{{
-			Match:  envoy.PrefixMatch("/"),
-			Action: routecluster("default/kuard/8080/da39a3ee5e"),
+			Match:               envoy.PrefixMatch("/"),
+			Action:              routecluster("default/kuard/8080/da39a3ee5e"),
+			RequestHeadersToAdd: envoy.RouteHeaders(),
 		}},
 	}}, nil)
 
@@ -1547,8 +1578,9 @@ func TestRDSIngressRouteClassAnnotation(t *testing.T) {
 		Name:    "www.example.com",
 		Domains: []string{"www.example.com", "www.example.com:80"},
 		Routes: []route.Route{{
-			Match:  envoy.PrefixMatch("/"),
-			Action: routecluster("default/kuard/8080/da39a3ee5e"),
+			Match:               envoy.PrefixMatch("/"),
+			Action:              routecluster("default/kuard/8080/da39a3ee5e"),
+			RequestHeadersToAdd: envoy.RouteHeaders(),
 		}},
 	}}, nil)
 
@@ -1581,8 +1613,9 @@ func TestRDSIngressRouteClassAnnotation(t *testing.T) {
 		Name:    "www.example.com",
 		Domains: []string{"www.example.com", "www.example.com:80"},
 		Routes: []route.Route{{
-			Match:  envoy.PrefixMatch("/"),
-			Action: routecluster("default/kuard/8080/da39a3ee5e"),
+			Match:               envoy.PrefixMatch("/"),
+			Action:              routecluster("default/kuard/8080/da39a3ee5e"),
+			RequestHeadersToAdd: envoy.RouteHeaders(),
 		}},
 	}}, nil)
 
@@ -1630,8 +1663,9 @@ func TestRDSIngressClassAnnotation(t *testing.T) {
 		Name:    "*",
 		Domains: []string{"*"},
 		Routes: []route.Route{{
-			Match:  envoy.PrefixMatch("/"),
-			Action: routecluster("default/kuard/8080/da39a3ee5e"),
+			Match:               envoy.PrefixMatch("/"),
+			Action:              routecluster("default/kuard/8080/da39a3ee5e"),
+			RequestHeadersToAdd: envoy.RouteHeaders(),
 		}},
 	}}, nil)
 
@@ -1691,8 +1725,9 @@ func TestRDSIngressClassAnnotation(t *testing.T) {
 		Name:    "*",
 		Domains: []string{"*"},
 		Routes: []route.Route{{
-			Match:  envoy.PrefixMatch("/"),
-			Action: routecluster("default/kuard/8080/da39a3ee5e"),
+			Match:               envoy.PrefixMatch("/"),
+			Action:              routecluster("default/kuard/8080/da39a3ee5e"),
+			RequestHeadersToAdd: envoy.RouteHeaders(),
 		}},
 	}}, nil)
 
@@ -1716,8 +1751,9 @@ func TestRDSIngressClassAnnotation(t *testing.T) {
 		Name:    "*",
 		Domains: []string{"*"},
 		Routes: []route.Route{{
-			Match:  envoy.PrefixMatch("/"),
-			Action: routecluster("default/kuard/8080/da39a3ee5e"),
+			Match:               envoy.PrefixMatch("/"),
+			Action:              routecluster("default/kuard/8080/da39a3ee5e"),
+			RequestHeadersToAdd: envoy.RouteHeaders(),
 		}},
 	}}, nil)
 
@@ -1849,8 +1885,9 @@ func TestRDSIngressSpecMissingHTTPKey(t *testing.T) {
 		Name:    "test2.test.com",
 		Domains: []string{"test2.test.com", "test2.test.com:80"},
 		Routes: []route.Route{{
-			Match:  envoy.PrefixMatch("/"), // match all
-			Action: routecluster("default/network-test/9001/da39a3ee5e"),
+			Match:               envoy.PrefixMatch("/"), // match all
+			Action:              routecluster("default/network-test/9001/da39a3ee5e"),
+			RequestHeadersToAdd: envoy.RouteHeaders(),
 		}},
 	}}, nil)
 }
@@ -1896,8 +1933,9 @@ func TestRouteWithAServiceWeight(t *testing.T) {
 		Name:    "test2.test.com",
 		Domains: []string{"test2.test.com", "test2.test.com:80"},
 		Routes: []route.Route{{
-			Match:  envoy.PrefixMatch("/a"), // match all
-			Action: routecluster("default/kuard/80/da39a3ee5e"),
+			Match:               envoy.PrefixMatch("/a"), // match all
+			Action:              routecluster("default/kuard/80/da39a3ee5e"),
+			RequestHeadersToAdd: envoy.RouteHeaders(),
 		}},
 	}}, nil)
 
@@ -1933,6 +1971,7 @@ func TestRouteWithAServiceWeight(t *testing.T) {
 				weightedcluster{"default/kuard/80/da39a3ee5e", 60},
 				weightedcluster{"default/kuard/80/da39a3ee5e", 90},
 			),
+			RequestHeadersToAdd: envoy.RouteHeaders(),
 		}},
 	}}, nil)
 }
@@ -2009,8 +2048,9 @@ func TestRouteWithTLS(t *testing.T) {
 					Name:    "test2.test.com",
 					Domains: []string{"test2.test.com", "test2.test.com:443"},
 					Routes: []route.Route{{
-						Match:  envoy.PrefixMatch("/a"),
-						Action: routecluster("default/kuard/80/da39a3ee5e"),
+						Match:               envoy.PrefixMatch("/a"),
+						Action:              routecluster("default/kuard/80/da39a3ee5e"),
+						RequestHeadersToAdd: envoy.RouteHeaders(),
 					}},
 				}}}),
 		},
@@ -2106,8 +2146,9 @@ func TestRouteWithTLS_InsecurePaths(t *testing.T) {
 							Match:  envoy.PrefixMatch("/secure"),
 							Action: envoy.UpgradeHTTPS(),
 						}, {
-							Match:  envoy.PrefixMatch("/insecure"),
-							Action: routecluster("default/kuard/80/da39a3ee5e"),
+							Match:               envoy.PrefixMatch("/insecure"),
+							Action:              routecluster("default/kuard/80/da39a3ee5e"),
+							RequestHeadersToAdd: envoy.RouteHeaders(),
 						},
 					},
 				}}}),
@@ -2118,11 +2159,13 @@ func TestRouteWithTLS_InsecurePaths(t *testing.T) {
 					Domains: []string{"test2.test.com", "test2.test.com:443"},
 					Routes: []route.Route{
 						{
-							Match:  envoy.PrefixMatch("/secure"),
-							Action: routecluster("default/svc2/80/da39a3ee5e"),
+							Match:               envoy.PrefixMatch("/secure"),
+							Action:              routecluster("default/svc2/80/da39a3ee5e"),
+							RequestHeadersToAdd: envoy.RouteHeaders(),
 						}, {
-							Match:  envoy.PrefixMatch("/insecure"),
-							Action: routecluster("default/kuard/80/da39a3ee5e"),
+							Match:               envoy.PrefixMatch("/insecure"),
+							Action:              routecluster("default/kuard/80/da39a3ee5e"),
+							RequestHeadersToAdd: envoy.RouteHeaders(),
 						},
 					},
 				}}}),
@@ -2170,8 +2213,9 @@ func TestRouteRetryAnnotations(t *testing.T) {
 		Name:    "*",
 		Domains: []string{"*"},
 		Routes: []route.Route{{
-			Match:  envoy.PrefixMatch("/"), // match all
-			Action: routeretry("default/backend/80/da39a3ee5e", "50x,gateway-error", 7, 120*time.Millisecond),
+			Match:               envoy.PrefixMatch("/"), // match all
+			Action:              routeretry("default/backend/80/da39a3ee5e", "50x,gateway-error", 7, 120*time.Millisecond),
+			RequestHeadersToAdd: envoy.RouteHeaders(),
 		}},
 	}}, nil)
 }
@@ -2222,8 +2266,9 @@ func TestRouteRetryIngressRoute(t *testing.T) {
 		Name:    "test2.test.com",
 		Domains: []string{"test2.test.com", "test2.test.com:80"},
 		Routes: []route.Route{{
-			Match:  envoy.PrefixMatch("/"), // match all
-			Action: routeretry("default/backend/80/da39a3ee5e", "50x", 7, 120*time.Millisecond),
+			Match:               envoy.PrefixMatch("/"), // match all
+			Action:              routeretry("default/backend/80/da39a3ee5e", "50x", 7, 120*time.Millisecond),
+			RequestHeadersToAdd: envoy.RouteHeaders(),
 		}},
 	}}, nil)
 }
@@ -2275,8 +2320,9 @@ func TestRouteTimeoutPolicyIngressRoute(t *testing.T) {
 		Name:    "test2.test.com",
 		Domains: []string{"test2.test.com", "test2.test.com:80"},
 		Routes: []route.Route{{
-			Match:  envoy.PrefixMatch("/"), // match all
-			Action: routecluster("default/backend/80/da39a3ee5e"),
+			Match:               envoy.PrefixMatch("/"), // match all
+			Action:              routecluster("default/backend/80/da39a3ee5e"),
+			RequestHeadersToAdd: envoy.RouteHeaders(),
 		}},
 	}}, nil)
 
@@ -2305,8 +2351,9 @@ func TestRouteTimeoutPolicyIngressRoute(t *testing.T) {
 		Name:    "test2.test.com",
 		Domains: []string{"test2.test.com", "test2.test.com:80"},
 		Routes: []route.Route{{
-			Match:  envoy.PrefixMatch("/"), // match all
-			Action: clustertimeout("default/backend/80/da39a3ee5e", durationInfinite),
+			Match:               envoy.PrefixMatch("/"), // match all
+			Action:              clustertimeout("default/backend/80/da39a3ee5e", durationInfinite),
+			RequestHeadersToAdd: envoy.RouteHeaders(),
 		}},
 	}}, nil)
 	// i3 corrects i2 to use a proper duration
@@ -2334,8 +2381,9 @@ func TestRouteTimeoutPolicyIngressRoute(t *testing.T) {
 		Name:    "test2.test.com",
 		Domains: []string{"test2.test.com", "test2.test.com:80"},
 		Routes: []route.Route{{
-			Match:  envoy.PrefixMatch("/"), // match all
-			Action: clustertimeout("default/backend/80/da39a3ee5e", duration10Minutes),
+			Match:               envoy.PrefixMatch("/"), // match all
+			Action:              clustertimeout("default/backend/80/da39a3ee5e", duration10Minutes),
+			RequestHeadersToAdd: envoy.RouteHeaders(),
 		}},
 	}}, nil)
 	// i4 updates i3 to explicitly request infinite timeout
@@ -2363,8 +2411,9 @@ func TestRouteTimeoutPolicyIngressRoute(t *testing.T) {
 		Name:    "test2.test.com",
 		Domains: []string{"test2.test.com", "test2.test.com:80"},
 		Routes: []route.Route{{
-			Match:  envoy.PrefixMatch("/"), // match all
-			Action: clustertimeout("default/backend/80/da39a3ee5e", durationInfinite),
+			Match:               envoy.PrefixMatch("/"), // match all
+			Action:              clustertimeout("default/backend/80/da39a3ee5e", durationInfinite),
+			RequestHeadersToAdd: envoy.RouteHeaders(),
 		}},
 	}}, nil)
 }
@@ -2435,8 +2484,9 @@ func TestLoadBalancingStrategies(t *testing.T) {
 		Domains: []string{"test2.test.com", "test2.test.com:80"},
 		Routes: []route.Route{
 			{
-				Match:  envoy.PrefixMatch("/a"),
-				Action: routeweightedcluster(wc...),
+				Match:               envoy.PrefixMatch("/a"),
+				Action:              routeweightedcluster(wc...),
+				RequestHeadersToAdd: envoy.RouteHeaders(),
 			},
 		},
 	}}
@@ -2518,8 +2568,9 @@ func TestBuilderExternalPort(t *testing.T) {
 					Name:    "kuard.io",
 					Domains: []string{"kuard.io", fmt.Sprintf("kuard.io:%d", insecurePort)},
 					Routes: []route.Route{{
-						Match:  envoy.PrefixMatch("/"),
-						Action: routecluster("default/kuard/80/da39a3ee5e"),
+						Match:               envoy.PrefixMatch("/"),
+						Action:              routecluster("default/kuard/80/da39a3ee5e"),
+						RequestHeadersToAdd: envoy.RouteHeaders(),
 					}},
 				}},
 			}),
@@ -2529,8 +2580,9 @@ func TestBuilderExternalPort(t *testing.T) {
 					Name:    "kuard.io",
 					Domains: []string{"kuard.io", fmt.Sprintf("kuard.io:%d", securePort)},
 					Routes: []route.Route{{
-						Match:  envoy.PrefixMatch("/"),
-						Action: routecluster("default/kuard/80/da39a3ee5e"),
+						Match:               envoy.PrefixMatch("/"),
+						Action:              routecluster("default/kuard/80/da39a3ee5e"),
+						RequestHeadersToAdd: envoy.RouteHeaders(),
 					}},
 				}},
 			}),
@@ -2581,13 +2633,6 @@ func routecluster(cluster string) *route.Route_Route {
 			ClusterSpecifier: &route.RouteAction_Cluster{
 				Cluster: cluster,
 			},
-			RequestHeadersToAdd: []*core.HeaderValueOption{{
-				Header: &core.HeaderValue{
-					Key:   "x-request-start",
-					Value: "t=%START_TIME(%s.%3f)%",
-				},
-				Append: bv(true),
-			}},
 		},
 	}
 }
@@ -2610,13 +2655,6 @@ func weightedclusters(clusters []weightedcluster) *route.WeightedCluster {
 		wc.Clusters = append(wc.Clusters, &route.WeightedCluster_ClusterWeight{
 			Name:   c.name,
 			Weight: u32(c.weight),
-			RequestHeadersToAdd: []*core.HeaderValueOption{{
-				Header: &core.HeaderValue{
-					Key:   "x-request-start",
-					Value: "t=%START_TIME(%s.%3f)%",
-				},
-				Append: bv(true),
-			}},
 		})
 	}
 	wc.TotalWeight = u32(total)

--- a/internal/envoy/route_test.go
+++ b/internal/envoy/route_test.go
@@ -63,7 +63,6 @@ func TestRouteRoute(t *testing.T) {
 					ClusterSpecifier: &route.RouteAction_Cluster{
 						Cluster: "default/kuard/8080/da39a3ee5e",
 					},
-					RequestHeadersToAdd: headers(appendHeader("x-request-start", "t=%START_TIME(%s.%3f)%")),
 				},
 			},
 		},
@@ -79,9 +78,6 @@ func TestRouteRoute(t *testing.T) {
 					ClusterSpecifier: &route.RouteAction_Cluster{
 						Cluster: "default/kuard/8080/da39a3ee5e",
 					},
-					RequestHeadersToAdd: headers(
-						appendHeader("x-request-start", "t=%START_TIME(%s.%3f)%"),
-					),
 					UpgradeConfigs: []*route.RouteAction_UpgradeConfig{{
 						UpgradeType: "websocket",
 					}},
@@ -111,13 +107,11 @@ func TestRouteRoute(t *testing.T) {
 					ClusterSpecifier: &route.RouteAction_WeightedClusters{
 						WeightedClusters: &route.WeightedCluster{
 							Clusters: []*route.WeightedCluster_ClusterWeight{{
-								Name:                "default/kuard/8080/da39a3ee5e",
-								Weight:              u32(0),
-								RequestHeadersToAdd: headers(appendHeader("x-request-start", "t=%START_TIME(%s.%3f)%")),
+								Name:   "default/kuard/8080/da39a3ee5e",
+								Weight: u32(0),
 							}, {
-								Name:                "default/kuard/8080/da39a3ee5e",
-								Weight:              u32(90),
-								RequestHeadersToAdd: headers(appendHeader("x-request-start", "t=%START_TIME(%s.%3f)%")),
+								Name:   "default/kuard/8080/da39a3ee5e",
+								Weight: u32(90),
 							}},
 							TotalWeight: u32(90),
 						},
@@ -149,13 +143,11 @@ func TestRouteRoute(t *testing.T) {
 					ClusterSpecifier: &route.RouteAction_WeightedClusters{
 						WeightedClusters: &route.WeightedCluster{
 							Clusters: []*route.WeightedCluster_ClusterWeight{{
-								Name:                "default/kuard/8080/da39a3ee5e",
-								Weight:              u32(0),
-								RequestHeadersToAdd: headers(appendHeader("x-request-start", "t=%START_TIME(%s.%3f)%")),
+								Name:   "default/kuard/8080/da39a3ee5e",
+								Weight: u32(0),
 							}, {
-								Name:                "default/kuard/8080/da39a3ee5e",
-								Weight:              u32(90),
-								RequestHeadersToAdd: headers(appendHeader("x-request-start", "t=%START_TIME(%s.%3f)%")),
+								Name:   "default/kuard/8080/da39a3ee5e",
+								Weight: u32(90),
 							}},
 							TotalWeight: u32(90),
 						},
@@ -179,7 +171,6 @@ func TestRouteRoute(t *testing.T) {
 					ClusterSpecifier: &route.RouteAction_Cluster{
 						Cluster: "default/kuard/8080/da39a3ee5e",
 					},
-					RequestHeadersToAdd: headers(appendHeader("x-request-start", "t=%START_TIME(%s.%3f)%")),
 				},
 			},
 		},
@@ -198,9 +189,6 @@ func TestRouteRoute(t *testing.T) {
 					ClusterSpecifier: &route.RouteAction_Cluster{
 						Cluster: "default/kuard/8080/da39a3ee5e",
 					},
-					RequestHeadersToAdd: headers(
-						appendHeader("x-request-start", "t=%START_TIME(%s.%3f)%"),
-					),
 					RetryPolicy: &route.RetryPolicy{
 						RetryOn:       "503",
 						NumRetries:    u32(6),
@@ -222,9 +210,6 @@ func TestRouteRoute(t *testing.T) {
 					ClusterSpecifier: &route.RouteAction_Cluster{
 						Cluster: "default/kuard/8080/da39a3ee5e",
 					},
-					RequestHeadersToAdd: headers(
-						appendHeader("x-request-start", "t=%START_TIME(%s.%3f)%"),
-					),
 					Timeout: duration(90 * time.Second),
 				},
 			},
@@ -242,9 +227,6 @@ func TestRouteRoute(t *testing.T) {
 					ClusterSpecifier: &route.RouteAction_Cluster{
 						Cluster: "default/kuard/8080/da39a3ee5e",
 					},
-					RequestHeadersToAdd: headers(
-						appendHeader("x-request-start", "t=%START_TIME(%s.%3f)%"),
-					),
 					Timeout: duration(0),
 				},
 			},
@@ -286,13 +268,11 @@ func TestWeightedClusters(t *testing.T) {
 			}},
 			want: &route.WeightedCluster{
 				Clusters: []*route.WeightedCluster_ClusterWeight{{
-					Name:                "default/kuard/8080/da39a3ee5e",
-					Weight:              u32(1),
-					RequestHeadersToAdd: headers(appendHeader("x-request-start", "t=%START_TIME(%s.%3f)%")),
+					Name:   "default/kuard/8080/da39a3ee5e",
+					Weight: u32(1),
 				}, {
-					Name:                "default/nginx/8080/da39a3ee5e",
-					Weight:              u32(1),
-					RequestHeadersToAdd: headers(appendHeader("x-request-start", "t=%START_TIME(%s.%3f)%")),
+					Name:   "default/nginx/8080/da39a3ee5e",
+					Weight: u32(1),
 				}},
 				TotalWeight: u32(2),
 			},
@@ -319,13 +299,11 @@ func TestWeightedClusters(t *testing.T) {
 			}},
 			want: &route.WeightedCluster{
 				Clusters: []*route.WeightedCluster_ClusterWeight{{
-					Name:                "default/kuard/8080/da39a3ee5e",
-					Weight:              u32(80),
-					RequestHeadersToAdd: headers(appendHeader("x-request-start", "t=%START_TIME(%s.%3f)%")),
+					Name:   "default/kuard/8080/da39a3ee5e",
+					Weight: u32(80),
 				}, {
-					Name:                "default/nginx/8080/da39a3ee5e",
-					Weight:              u32(20),
-					RequestHeadersToAdd: headers(appendHeader("x-request-start", "t=%START_TIME(%s.%3f)%")),
+					Name:   "default/nginx/8080/da39a3ee5e",
+					Weight: u32(20),
 				}},
 				TotalWeight: u32(100),
 			},
@@ -360,17 +338,14 @@ func TestWeightedClusters(t *testing.T) {
 			}},
 			want: &route.WeightedCluster{
 				Clusters: []*route.WeightedCluster_ClusterWeight{{
-					Name:                "default/kuard/8080/da39a3ee5e",
-					Weight:              u32(80),
-					RequestHeadersToAdd: headers(appendHeader("x-request-start", "t=%START_TIME(%s.%3f)%")),
+					Name:   "default/kuard/8080/da39a3ee5e",
+					Weight: u32(80),
 				}, {
-					Name:                "default/nginx/8080/da39a3ee5e",
-					Weight:              u32(20),
-					RequestHeadersToAdd: headers(appendHeader("x-request-start", "t=%START_TIME(%s.%3f)%")),
+					Name:   "default/nginx/8080/da39a3ee5e",
+					Weight: u32(20),
 				}, {
-					Name:                "default/notraffic/8080/da39a3ee5e",
-					Weight:              u32(0),
-					RequestHeadersToAdd: headers(appendHeader("x-request-start", "t=%START_TIME(%s.%3f)%")),
+					Name:   "default/notraffic/8080/da39a3ee5e",
+					Weight: u32(0),
 				}},
 				TotalWeight: u32(100),
 			},


### PR DESCRIPTION
The newer version of go-control-plane has some fields removed like
RouteAction.RequestHeadersToAdd[] which were deprecated in v0.6.9.
Due to this, the existing implementation which added headers at the
weightedCluster and RouteAction layer was changed. Headers are now
added at the route layer as per discussion with @stevesloka.

Signed-off-by: Rohan Vora <vorar@vmware.com>

#Fixes: #999