### PR TITLE
internal/dag: Fix secret lookup

### DIFF
--- a/internal/dag/builder.go
+++ b/internal/dag/builder.go
@@ -206,6 +206,9 @@ func (b *builder) lookupSecret(m meta) *Secret {
 	if !ok {
 		return nil
 	}
+	if !validSecret(sec) {
+		return nil
+	}
 	s := &Secret{
 		Object: sec,
 	}
@@ -624,6 +627,11 @@ func (b *builder) rootAllowed(ir *ingressroutev1.IngressRoute) bool {
 		}
 	}
 	return false
+}
+
+// validSecret returns true if the Secret contains certificate and private key material.
+func validSecret(s *v1.Secret) bool {
+	return len(s.Data[v1.TLSCertKey]) > 0 && len(s.Data[v1.TLSPrivateKeyKey]) > 0
 }
 
 func (b *builder) processRoutes(ir *ingressroutev1.IngressRoute, prefixMatch string, visited []*ingressroutev1.IngressRoute, host string, enforceTLS bool) {

--- a/internal/dag/builder_test.go
+++ b/internal/dag/builder_test.go
@@ -1266,6 +1266,15 @@ func TestDAGInsert(t *testing.T) {
 		Data: secretdata("certificate", "key"),
 	}
 
+	// Invalid cert in the secret
+	sec2 := &v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "secret",
+			Namespace: "default",
+		},
+		Data: secretdata("", ""),
+	}
+
 	tests := map[string]struct {
 		*Builder
 		objs []interface{}
@@ -1506,6 +1515,34 @@ func TestDAGInsert(t *testing.T) {
 					Port: 443,
 					VirtualHosts: virtualhosts(
 						securevirtualhost("kuard.example.com", sec1, route("/")),
+					),
+				},
+			),
+		},
+		"insert invalid secret then ingress w/o tls": {
+			objs: []interface{}{
+				sec2,
+				i1,
+			},
+			want: listeners(
+				&Listener{
+					Port: 80,
+					VirtualHosts: virtualhosts(
+						virtualhost("*", route("/")),
+					),
+				},
+			),
+		},
+		"insert invalid secret then ingress w/ tls": {
+			objs: []interface{}{
+				sec2,
+				i3,
+			},
+			want: listeners(
+				&Listener{
+					Port: 80,
+					VirtualHosts: virtualhosts(
+						virtualhost("kuard.example.com", route("/")),
 					),
 				},
 			),


### PR DESCRIPTION
Fixes secret lookup in Dag builder. It returns nil if certificate or
private key is empty/null in the kubernetes secret.

Fixes: #1051
Signed-off-by: Rohan Vora <vorar@vmware.com>