### PR TITLE
Remove extra annotation from sample deployment

### DIFF
--- a/deployment/ds-hostnet-split/03-envoy.yaml
+++ b/deployment/ds-hostnet-split/03-envoy.yaml
@@ -20,7 +20,6 @@ spec:
         prometheus.io/port: "8002"
         prometheus.io/statsdport: "9102"
         prometheus.io/path: "/stats/prometheus"
-        steve: "sloka"
       labels:
         app: envoy
     spec:


### PR DESCRIPTION
Removes an unnecessary annotation (`steve: "sloka"`) from the example `ds-hostnet-split` deployment. The change was added in https://github.com/heptio/contour/pull/1034

Signed-off-by: Robert Syvarth <robert.syvarth@gmail.com>