### PR TITLE
internal/grpc: derive grpc resource types from go-control-plane

### DIFF
--- a/cmd/contour/cli.go
+++ b/cmd/contour/cli.go
@@ -22,16 +22,6 @@ import (
 	"google.golang.org/grpc"
 )
 
-const (
-	googleApis   = "type.googleapis.com/"
-	typePrefix   = googleApis + "envoy.api.v2."
-	endpointType = typePrefix + "ClusterLoadAssignment"
-	clusterType  = typePrefix + "Cluster"
-	routeType    = typePrefix + "RouteConfiguration"
-	listenerType = typePrefix + "Listener"
-	secretType   = typePrefix + "auth.Secret"
-)
-
 type Client struct {
 	ContourAddr string
 }

--- a/cmd/contour/contour.go
+++ b/cmd/contour/contour.go
@@ -23,6 +23,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/envoyproxy/go-control-plane/pkg/cache"
 	clientset "github.com/heptio/contour/apis/generated/clientset/versioned"
 	contourinformers "github.com/heptio/contour/apis/generated/informers/externalversions"
 	"github.com/heptio/contour/internal/contour"
@@ -148,19 +149,19 @@ func main() {
 		writeBootstrapConfig(&config, *path)
 	case cds.FullCommand():
 		stream := client.ClusterStream()
-		watchstream(stream, clusterType, resources)
+		watchstream(stream, cache.ClusterType, resources)
 	case eds.FullCommand():
 		stream := client.EndpointStream()
-		watchstream(stream, endpointType, resources)
+		watchstream(stream, cache.EndpointType, resources)
 	case lds.FullCommand():
 		stream := client.ListenerStream()
-		watchstream(stream, listenerType, resources)
+		watchstream(stream, cache.ListenerType, resources)
 	case rds.FullCommand():
 		stream := client.RouteStream()
-		watchstream(stream, routeType, resources)
+		watchstream(stream, cache.RouteType, resources)
 	case sds.FullCommand():
 		stream := client.RouteStream()
-		watchstream(stream, secretType, resources)
+		watchstream(stream, cache.SecretType, resources)
 	case serve.FullCommand():
 		log.Infof("args: %v", args)
 		var g workgroup.Group

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,6 @@ require (
 	github.com/imdario/mergo v0.3.7 // indirect
 	github.com/json-iterator/go v1.1.5 // indirect
 	github.com/kisielk/errcheck v1.2.0
-	github.com/lyft/protoc-gen-validate v0.0.12 // indirect
 	github.com/mdempsky/unconvert v0.0.0-20190325185700-2f5dc3378ed3
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742 // indirect
@@ -37,7 +36,6 @@ require (
 	golang.org/x/oauth2 v0.0.0-20190402181905-9f3314589c9a // indirect
 	golang.org/x/sys v0.0.0-20190405154228-4b34438f7a67 // indirect
 	golang.org/x/tools v0.0.0-20190328211700-ab21143f2384 // indirect
-	gonum.org/v1/netlib v0.0.0-20190331212654-76723241ea4e // indirect
 	google.golang.org/grpc v1.19.1
 	gopkg.in/alecthomas/kingpin.v2 v2.2.6
 	gopkg.in/inf.v0 v0.9.1 // indirect

--- a/internal/grpc/resources.go
+++ b/internal/grpc/resources.go
@@ -18,19 +18,17 @@ import (
 
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2/auth"
+	"github.com/envoyproxy/go-control-plane/pkg/cache"
 
 	"github.com/gogo/protobuf/proto"
 )
 
-// Resource types in xDS v2.
 const (
-	googleApis   = "type.googleapis.com/"
-	typePrefix   = googleApis + "envoy.api.v2."
-	endpointType = typePrefix + "ClusterLoadAssignment"
-	clusterType  = typePrefix + "Cluster"
-	routeType    = typePrefix + "RouteConfiguration"
-	listenerType = typePrefix + "Listener"
-	secretType   = typePrefix + "auth.Secret"
+	endpointType = cache.EndpointType
+	clusterType  = cache.ClusterType
+	routeType    = cache.RouteType
+	listenerType = cache.ListenerType
+	secretType   = cache.SecretType
 )
 
 // cache represents a source of proto.Message valus that can be registered


### PR DESCRIPTION
Rather than derive the resource type names from first principle,
reference the values provided by go-control-plane. If they change, we
get that for free, if they are removed, we will now notice.

Also, tidy the go.mod file from some unnecessary deps that crept in.

Updates #273 

Signed-off-by: Dave Cheney <dave@cheney.net>