### PR TITLE
all: 50x -> 5xx

### DIFF
--- a/design/custom-request-timeout.md
+++ b/design/custom-request-timeout.md
@@ -61,9 +61,7 @@ spec:
               idle: 1s
           # retry for this route is independent of "/contour" retryPolicy.
           retryPolicy:
-          	count: "2"
-          	onStatusCodes:
-          	- 50x
+          	count: 2
 ```
 
 The naming conventions of the proposed YAML fields are inspired from [HTTP Timeouts](https://tools.ietf.org/id/draft-thomson-hybi-http-timeout-00.html#rfc.section.4).
@@ -209,7 +207,7 @@ We would use the following to map value from DAG's route to protobuf
 
 ### RetryPolicy for Route - Envoy
 - [Specifies the conditions under which retry takes place](https://www.envoyproxy.io/docs/envoy/latest/api-v2/api/v2/route/route.proto#route-retrypolicy-retry-on)
-- RetryOn is hard coded to ["50x"](https://www.envoyproxy.io/docs/envoy/latest/configuration/http_filters/router_filter#config-http-filters-router-x-envoy-retry-on)
+- RetryOn is hard coded to ["5xx"](https://www.envoyproxy.io/docs/envoy/latest/configuration/http_filters/router_filter#config-http-filters-router-x-envoy-retry-on)
 
         // for route
         RouteAction.RetryPolicy.RetryOn = "5xx"
@@ -222,12 +220,12 @@ We would use the following to map value from DAG's route to protobuf
 
         RouteAction.RetryPolicy.PerTryTimeout = Route.Retry.PerTryTimeout
 
-### Why only `50x` Status Codes?
+### Why only `5xx` Status Codes?
 
 `4xx` are user based errors and `5xx` are server based.
 Status codes of type `4xx` will continue to cause error unless the user corrects it.
 Whereas `5xx` errors on the server can occur due to a fault in the server side which may have been caused by unusual circumstances like network packet becoming corrupted while being transmitted or due to intermittent failure in the application that's unlikely to be repeated.
-The intent with this feature is to start small by supporting 50x status codes, and then adding more status codes on need basis.
+The intent with this feature is to start small by supporting 5xx status codes, and then adding more status codes on need basis.
 
 Citing the Retry Pattern described in [Azure Architecture - Retry Pattern](https://docs.microsoft.com/en-us/azure/architecture/patterns/retry), if the fault indicates that the failure isn't transient or is unlikely to be successful if repeated, the application should cancel the operation and report exception.
 If the specific fault reported is unusual or rare, it could be considered as an intermittent failure and the application could retry the failing request, which could probably be successful.
@@ -315,8 +313,6 @@ spec:
           port: 8080
       retryPolicy:
         maxRetries: "10"
-        onStatusCodes:
-          - "50x"
         perTryTimeout: 200ms
 ```
 

--- a/docs/ingressroute.md
+++ b/docs/ingressroute.md
@@ -429,14 +429,13 @@ spec:
 
 In this example, requests to `timeout.bar.com/` will have a request timeout policy of 1s. 
 This refers to the time that spans between the point at which complete client request has been processed by the proxy, and when the response from the server has been completely processed. 
-The Request Timeout error code returns with HTTP error code 504. 
 
 - `timeoutPolicy.request` This field can be any positive time period or "infinity". 
 The time period of **0s** will also be treated as infinity. 
 By default, Envoy has a 15 second timeout for a backend service to respond.
 More information can be found in [Envoy's documentation](https://www.envoyproxy.io/docs/envoy/latest/api-v2/api/v2/route/route.proto.html#envoy-api-field-route-routeaction-timeout).
 
-- `retryPolicy`: A retry will be attempted if the server returns a 50x error code, or if the server takes more than `retryPolicy.perTryTimeout` to process a request. 
+- `retryPolicy`: A retry will be attempted if the server returns an error code in the 5xx range, or if the server takes more than `retryPolicy.perTryTimeout` to process a request. 
     - `retryPolicy.count` specifies the maximum number of retries allowed. This parameter is optional and defaults to 1.
     - `retryPolicy.perTryTimeout` specifies the timeout per retry. If this field is greater than the request timeout, it is ignored. This parameter is optional. 
     If left unspecified, `timeoutPolicy.request` will be used. 

--- a/internal/contour/route_test.go
+++ b/internal/contour/route_test.go
@@ -1280,7 +1280,7 @@ func TestRouteVisit(t *testing.T) {
 						Name:      "kuard",
 						Namespace: "default",
 						Annotations: map[string]string{
-							"contour.heptio.com/retry-on": "50x,gateway-error",
+							"contour.heptio.com/retry-on": "5xx,gateway-error",
 						},
 					},
 					Spec: v1beta1.IngressSpec{
@@ -1312,7 +1312,7 @@ func TestRouteVisit(t *testing.T) {
 						Domains: []string{"*"},
 						Routes: []route.Route{{
 							Match:               envoy.PrefixMatch("/"),
-							Action:              routeretry("default/kuard/8080/da39a3ee5e", "50x,gateway-error", 0, 0),
+							Action:              routeretry("default/kuard/8080/da39a3ee5e", "5xx,gateway-error", 0, 0),
 							RequestHeadersToAdd: envoy.RouteHeaders(),
 						}},
 					}},
@@ -1329,7 +1329,7 @@ func TestRouteVisit(t *testing.T) {
 						Name:      "kuard",
 						Namespace: "default",
 						Annotations: map[string]string{
-							"contour.heptio.com/retry-on":    "50x,gateway-error",
+							"contour.heptio.com/retry-on":    "5xx,gateway-error",
 							"contour.heptio.com/num-retries": "7", // not five or six or eight, but seven.
 						},
 					},
@@ -1362,7 +1362,7 @@ func TestRouteVisit(t *testing.T) {
 						Domains: []string{"*"},
 						Routes: []route.Route{{
 							Match:               envoy.PrefixMatch("/"),
-							Action:              routeretry("default/kuard/8080/da39a3ee5e", "50x,gateway-error", 7, 0),
+							Action:              routeretry("default/kuard/8080/da39a3ee5e", "5xx,gateway-error", 7, 0),
 							RequestHeadersToAdd: envoy.RouteHeaders(),
 						}},
 					}},
@@ -1379,7 +1379,7 @@ func TestRouteVisit(t *testing.T) {
 						Name:      "kuard",
 						Namespace: "default",
 						Annotations: map[string]string{
-							"contour.heptio.com/retry-on":        "50x,gateway-error",
+							"contour.heptio.com/retry-on":        "5xx,gateway-error",
 							"contour.heptio.com/per-try-timeout": "150ms",
 						},
 					},
@@ -1412,7 +1412,7 @@ func TestRouteVisit(t *testing.T) {
 						Domains: []string{"*"},
 						Routes: []route.Route{{
 							Match:               envoy.PrefixMatch("/"),
-							Action:              routeretry("default/kuard/8080/da39a3ee5e", "50x,gateway-error", 0, 150*time.Millisecond),
+							Action:              routeretry("default/kuard/8080/da39a3ee5e", "5xx,gateway-error", 0, 150*time.Millisecond),
 							RequestHeadersToAdd: envoy.RouteHeaders(),
 						}},
 					}},

--- a/internal/dag/builder.go
+++ b/internal/dag/builder.go
@@ -826,7 +826,7 @@ func retryPolicyIngressRoute(rp *ingressroutev1.RetryPolicy) (retryOn string, re
 	if rp != nil {
 		perTryTimeout, _ = time.ParseDuration(rp.PerTryTimeout)
 		retryCount = rp.NumRetries
-		retryOn = "50x"
+		retryOn = "5xx"
 	}
 	return
 }

--- a/internal/dag/builder_test.go
+++ b/internal/dag/builder_test.go
@@ -2256,7 +2256,7 @@ func TestDAGInsert(t *testing.T) {
 							Prefix:   "/",
 							Clusters: clustermap(s1),
 							RetryPolicy: &RetryPolicy{
-								RetryOn:       "50x",
+								RetryOn:       "5xx",
 								NumRetries:    6,
 								PerTryTimeout: 10 * time.Second,
 							},
@@ -2278,7 +2278,7 @@ func TestDAGInsert(t *testing.T) {
 							Prefix:   "/",
 							Clusters: clustermap(s1),
 							RetryPolicy: &RetryPolicy{
-								RetryOn:       "50x",
+								RetryOn:       "5xx",
 								NumRetries:    6,
 								PerTryTimeout: 0,
 							},

--- a/internal/e2e/rds_test.go
+++ b/internal/e2e/rds_test.go
@@ -2296,7 +2296,7 @@ func TestRouteRetryAnnotations(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "hello", Namespace: "default",
 			Annotations: map[string]string{
-				"contour.heptio.com/retry-on":        "50x,gateway-error",
+				"contour.heptio.com/retry-on":        "5xx,gateway-error",
 				"contour.heptio.com/num-retries":     "7",
 				"contour.heptio.com/per-try-timeout": "120ms",
 			},
@@ -2311,7 +2311,7 @@ func TestRouteRetryAnnotations(t *testing.T) {
 		Domains: []string{"*"},
 		Routes: []route.Route{{
 			Match:               envoy.PrefixMatch("/"), // match all
-			Action:              routeretry("default/backend/80/da39a3ee5e", "50x,gateway-error", 7, 120*time.Millisecond),
+			Action:              routeretry("default/backend/80/da39a3ee5e", "5xx,gateway-error", 7, 120*time.Millisecond),
 			RequestHeadersToAdd: envoy.RouteHeaders(),
 		}},
 	}}, nil)
@@ -2364,7 +2364,7 @@ func TestRouteRetryIngressRoute(t *testing.T) {
 		Domains: []string{"test2.test.com", "test2.test.com:80"},
 		Routes: []route.Route{{
 			Match:               envoy.PrefixMatch("/"), // match all
-			Action:              routeretry("default/backend/80/da39a3ee5e", "50x", 7, 120*time.Millisecond),
+			Action:              routeretry("default/backend/80/da39a3ee5e", "5xx", 7, 120*time.Millisecond),
 			RequestHeadersToAdd: envoy.RouteHeaders(),
 		}},
 	}}, nil)


### PR DESCRIPTION
Fixes #1062

Update all references to 50x to be 5xx. The former is not a valid retry
code.

Signed-off-by: Dave Cheney <dave@cheney.net>