### PR TITLE
internal/dag: Missing retry count implies 1 retry

### DIFF
--- a/internal/dag/builder.go
+++ b/internal/dag/builder.go
@@ -657,7 +657,7 @@ func (b *builder) processRoutes(ir *ingressroutev1.IngressRoute, prefixMatch str
 				HTTPSUpgrade:  routeEnforceTLS(enforceTLS, route.PermitInsecure),
 				PrefixRewrite: route.PrefixRewrite,
 				TimeoutPolicy: timeoutPolicyIngressRoute(route.TimeoutPolicy),
-				RetryPolicy:   retryPolicy(retryPolicyIngressRoute(route.RetryPolicy)),
+				RetryPolicy:   retryPolicyIngressRoute(route.RetryPolicy),
 			}
 			for _, service := range route.Services {
 				if service.Port < 1 || service.Port > 65535 {
@@ -820,15 +820,6 @@ type Status struct {
 	Status      string
 	Description string
 	Vhost       string
-}
-
-func retryPolicyIngressRoute(rp *ingressroutev1.RetryPolicy) (retryOn string, retryCount int, perTryTimeout time.Duration) {
-	if rp != nil {
-		perTryTimeout, _ = time.ParseDuration(rp.PerTryTimeout)
-		retryCount = rp.NumRetries
-		retryOn = "5xx"
-	}
-	return
 }
 
 func timeoutPolicyIngressRoute(tp *ingressroutev1.TimeoutPolicy) *TimeoutPolicy {

--- a/internal/dag/policy.go
+++ b/internal/dag/policy.go
@@ -1,0 +1,39 @@
+// Copyright © 2019 Heptio
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dag
+
+import (
+	"time"
+
+	"github.com/heptio/contour/apis/contour/v1beta1"
+)
+
+func retryPolicyIngressRoute(rp *v1beta1.RetryPolicy) *RetryPolicy {
+	if rp == nil {
+		return nil
+	}
+	perTryTimeout, _ := time.ParseDuration(rp.PerTryTimeout)
+	return &RetryPolicy{
+		RetryOn:       "5xx",
+		NumRetries:    max(1, rp.NumRetries),
+		PerTryTimeout: perTryTimeout,
+	}
+}
+
+func max(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}

--- a/internal/dag/policy_test.go
+++ b/internal/dag/policy_test.go
@@ -1,0 +1,79 @@
+// Copyright © 2019 Heptio
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dag
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/heptio/contour/apis/contour/v1beta1"
+)
+
+func TestRetryPolicyIngressRoute(t *testing.T) {
+	tests := map[string]struct {
+		rp   *v1beta1.RetryPolicy
+		want *RetryPolicy
+	}{
+		"nil retry policy": {
+			rp:   nil,
+			want: nil,
+		},
+		"empty policy": {
+			rp: &v1beta1.RetryPolicy{},
+			want: &RetryPolicy{
+				RetryOn:    "5xx",
+				NumRetries: 1,
+			},
+		},
+		"explicitly zero retries": {
+			rp: &v1beta1.RetryPolicy{
+				NumRetries: 0, // zero value for NumRetries
+			},
+			want: &RetryPolicy{
+				RetryOn:    "5xx",
+				NumRetries: 1,
+			},
+		},
+		"no retry count, per try timeout": {
+			rp: &v1beta1.RetryPolicy{
+				PerTryTimeout: "10s",
+			},
+			want: &RetryPolicy{
+				RetryOn:       "5xx",
+				NumRetries:    1,
+				PerTryTimeout: 10 * time.Second,
+			},
+		},
+		"explicit 0s timeout": {
+			rp: &v1beta1.RetryPolicy{
+				PerTryTimeout: "0s",
+			},
+			want: &RetryPolicy{
+				RetryOn:       "5xx",
+				NumRetries:    1,
+				PerTryTimeout: 0 * time.Second,
+			},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := retryPolicyIngressRoute(tc.rp)
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Fatal(diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Updates #1019

The retry policy documentation (#1042) states that a `retryPolicy:`
stanza with no fields implies a retry count of 1 -- if you don't want to
retry, don't add a `retryPolicy:` key.

This PR addresses this issue, and breaks out the retryPolicy logic into
a new file with associated tests to isolate this buisiness logic.

Signed-off-by: Dave Cheney <dave@cheney.net>