### PR TITLE
internal/dag: break out timeout policy handling

### DIFF
--- a/internal/dag/annotations.go
+++ b/internal/dag/annotations.go
@@ -37,12 +37,6 @@ const (
 	annotationRetryOn            = "contour.heptio.com/retry-on"
 	annotationNumRetries         = "contour.heptio.com/num-retries"
 	annotationPerTryTimeout      = "contour.heptio.com/per-try-timeout"
-
-	// By default envoy applies a 15 second timeout to all backend requests.
-	// The explicit value 0 turns off the timeout, implying "never time out"
-	// https://www.envoyproxy.io/docs/envoy/v1.5.0/api-v2/rds.proto#routeaction
-	infiniteTimeout = -1
-	noTimeout       = 0
 )
 
 // parseAnnotationTimeout parses the annotations map for the supplied key as a timeout.
@@ -51,28 +45,6 @@ const (
 func parseAnnotationTimeout(annotations map[string]string, key string) time.Duration {
 	timeout := annotations[key]
 	return parseTimeout(timeout)
-}
-
-func parseTimeout(timeout string) time.Duration {
-	// Error or unspecified is interpreted as no timeout specified, use envoy defaults
-	if timeout == "" {
-		return noTimeout
-	}
-	// Interpret "infinity" explicitly as an infinite timeout, which envoy config
-	// expects as a timeout of 0. This could be specified with the duration string
-	// "0s" but want to give an explicit out for operators.
-	if timeout == "infinity" {
-		return infiniteTimeout
-	}
-
-	d, err := time.ParseDuration(timeout)
-	if err != nil {
-		// TODO(cmalonty) plumb a logger in here so we can log this error.
-		// Assuming infinite duration is going to surprise people less for
-		// a not-parseable duration than a implicit 15 second one.
-		return infiniteTimeout
-	}
-	return d
 }
 
 // parseAnnotation parses the annotation map for the supplied key.

--- a/internal/dag/annotations_test.go
+++ b/internal/dag/annotations_test.go
@@ -18,49 +18,11 @@ import (
 	"math"
 	"reflect"
 	"testing"
-	"time"
 
 	"k8s.io/api/extensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
-
-func TestParseAnnotationTimeout(t *testing.T) {
-	tests := map[string]struct {
-		a    map[string]string
-		want time.Duration
-	}{
-		"nada": {
-			a:    nil,
-			want: 0,
-		},
-		"empty": {
-			a:    map[string]string{annotationRequestTimeout: ""}, // not even sure this is possible via the API
-			want: 0,
-		},
-		"infinity": {
-			a:    map[string]string{annotationRequestTimeout: "infinity"},
-			want: -1,
-		},
-		"10 seconds": {
-			a:    map[string]string{annotationRequestTimeout: "10s"},
-			want: 10 * time.Second,
-		},
-		"invalid": {
-			a:    map[string]string{annotationRequestTimeout: "10"}, // 10 what?
-			want: -1,
-		},
-	}
-
-	for name, tc := range tests {
-		t.Run(name, func(t *testing.T) {
-			got := parseAnnotationTimeout(tc.a, annotationRequestTimeout)
-			if got != tc.want {
-				t.Fatalf("parseAnnotationTimeout(%q): want: %v, got: %v", tc.a, tc.want, got)
-			}
-		})
-	}
-}
 
 func TestParseAnnotationUInt32(t *testing.T) {
 	tests := map[string]struct {

--- a/internal/dag/builder.go
+++ b/internal/dag/builder.go
@@ -821,11 +821,3 @@ type Status struct {
 	Description string
 	Vhost       string
 }
-
-func timeoutPolicyIngressRoute(tp *ingressroutev1.TimeoutPolicy) *TimeoutPolicy {
-	timeout := time.Duration(0)
-	if tp != nil {
-		timeout = parseTimeout(tp.Request)
-	}
-	return timeoutPolicy(timeout)
-}

--- a/internal/dag/policy.go
+++ b/internal/dag/policy.go
@@ -31,6 +31,41 @@ func retryPolicyIngressRoute(rp *v1beta1.RetryPolicy) *RetryPolicy {
 	}
 }
 
+func timeoutPolicyIngressRoute(tp *v1beta1.TimeoutPolicy) *TimeoutPolicy {
+	if tp == nil {
+		return nil
+	}
+	return &TimeoutPolicy{
+		Timeout: parseTimeout(tp.Request),
+	}
+}
+
+func parseTimeout(timeout string) time.Duration {
+	if timeout == "" {
+		// Blank is interpreted as no timeout specified, use envoy defaults
+		// By default envoy applies a 15 second timeout to all backend requests.
+		// The explicit value 0 turns off the timeout, implying "never time out"
+		// https://www.envoyproxy.io/docs/envoy/v1.5.0/api-v2/rds.proto#routeaction
+		return 0
+	}
+
+	// Interpret "infinity" explicitly as an infinite timeout, which envoy config
+	// expects as a timeout of 0. This could be specified with the duration string
+	// "0s" but want to give an explicit out for operators.
+	if timeout == "infinity" {
+		return -1
+	}
+
+	d, err := time.ParseDuration(timeout)
+	if err != nil {
+		// TODO(cmalonty) plumb a logger in here so we can log this error.
+		// Assuming infinite duration is going to surprise people less for
+		// a not-parseable duration than a implicit 15 second one.
+		return -1
+	}
+	return d
+}
+
 func max(a, b int) int {
 	if a > b {
 		return a


### PR DESCRIPTION
Updates #1019

Move timeout policy handling to policy.go and add unit tests.
Also move parseTimeout and tests into policy.go to capture the
unexpected invalid duration == infinity logic.

Signed-off-by: Dave Cheney <dave@cheney.net>