### PR TITLE
internal/dag: unify timeout and retry policy logic

### DIFF
--- a/internal/dag/annotations.go
+++ b/internal/dag/annotations.go
@@ -17,7 +17,6 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/gogo/protobuf/types"
 	"k8s.io/api/extensions/v1beta1"
@@ -38,14 +37,6 @@ const (
 	annotationNumRetries         = "contour.heptio.com/num-retries"
 	annotationPerTryTimeout      = "contour.heptio.com/per-try-timeout"
 )
-
-// parseAnnotationTimeout parses the annotations map for the supplied key as a timeout.
-// If the value is present, but malformed, the timeout value is valid, and represents
-// infinite timeout.
-func parseAnnotationTimeout(annotations map[string]string, key string) time.Duration {
-	timeout := annotations[key]
-	return parseTimeout(timeout)
-}
 
 // parseAnnotation parses the annotation map for the supplied key.
 // If the value is not present, or malformed, then zero is returned.

--- a/internal/dag/policy.go
+++ b/internal/dag/policy.go
@@ -19,7 +19,7 @@ import (
 	"github.com/heptio/contour/apis/contour/v1beta1"
 )
 
-func retryPolicyIngressRoute(rp *v1beta1.RetryPolicy) *RetryPolicy {
+func retryPolicy(rp *v1beta1.RetryPolicy) *RetryPolicy {
 	if rp == nil {
 		return nil
 	}
@@ -31,7 +31,7 @@ func retryPolicyIngressRoute(rp *v1beta1.RetryPolicy) *RetryPolicy {
 	}
 }
 
-func timeoutPolicyIngressRoute(tp *v1beta1.TimeoutPolicy) *TimeoutPolicy {
+func timeoutPolicy(tp *v1beta1.TimeoutPolicy) *TimeoutPolicy {
 	if tp == nil {
 		return nil
 	}

--- a/internal/dag/policy_test.go
+++ b/internal/dag/policy_test.go
@@ -70,7 +70,7 @@ func TestRetryPolicyIngressRoute(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			got := retryPolicyIngressRoute(tc.rp)
+			got := retryPolicy(tc.rp)
 			if diff := cmp.Diff(tc.want, got); diff != "" {
 				t.Fatal(diff)
 			}
@@ -125,7 +125,7 @@ func TestTimeoutPolicyIngressRoute(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			got := timeoutPolicyIngressRoute(tc.tp)
+			got := timeoutPolicy(tc.tp)
 			if diff := cmp.Diff(tc.want, got); diff != "" {
 				t.Fatal(diff)
 			}


### PR DESCRIPTION
Updates #1019

Rename timeoutPolicyIngressRoute and friend to timeoutPolicy as they
represent the current best practice logic for handling timeout/retries.

The older annotation based logic is handled differently because if the
differences in not found vs no set logic with respect to retry-on and
timeout parsing.

There are some TODO's that highlight the inconsistencies in the logic,
its not clear if its worth taking a compatability break to change that
logic now. There is good code coverage in this area that ensures we
won't regress the logic so maybe just leaving well enough alone is good
enough.

Signed-off-by: Dave Cheney <dave@cheney.net>