### PR TITLE
internal/envoy: listener idle timeouts

### DIFF
--- a/internal/envoy/listener.go
+++ b/internal/envoy/listener.go
@@ -103,6 +103,8 @@ func HTTPConnectionManager(routename, accessLogPath string) listener.Filter {
 					"access_log":         accesslog(accessLogPath),
 					"use_remote_address": {Kind: &types.Value_BoolValue{BoolValue: true}}, // TODO(jbeda) should this ever be false?
 					"normalize_path":     {Kind: &types.Value_BoolValue{BoolValue: true}},
+					"idle_timeout":       sv("60s"),
+					"request_timeout":    sv("15s"),
 				},
 			},
 		},


### PR DESCRIPTION
Hardcodes the listener idle_timeout to 60s.

Fixes #1054