### PR TITLE
internal/dag: respect force-ssl-redirect over allow-http annotation

### DIFF
--- a/docs/annotations.md
+++ b/docs/annotations.md
@@ -16,6 +16,7 @@ However, Contour still supports a number of annotations on the Ingress resources
  - `ingress.kubernetes.io/force-ssl-redirect`: Requires TLS/SSL for the Ingress to Envoy by setting the [Envoy virtual host option require_tls](https://www.envoyproxy.io/docs/envoy/latest/api-v2/api/v2/route/route.proto.html#envoy-api-field-route-virtualhost-require-tls)
  - `kubernetes.io/ingress.allow-http`: Instructs Contour to not create an Envoy HTTP route for the virtual host. The Ingress exists only for HTTPS requests. Specify `"false"` for Envoy to mark the endpoint as HTTPS only. All other values are ignored.
 
+The `ingress.kubernetes.io/force-ssl-redirect` annotation takes precedence over `kubernetes.io/ingress.allow-http`. If they are set to `"true"` and `"false"` respectively, Contour *will* create an Envoy HTTP route for the Virtual host, and set the `require_tls` virtual host option.
 
 ## Contour specific Ingress annotations
 

--- a/internal/dag/builder.go
+++ b/internal/dag/builder.go
@@ -472,7 +472,7 @@ func (b *builder) computeIngresses() {
 				}
 
 				// should we create port 80 routes for this ingress
-				if httpAllowed(ing) {
+				if tlsRequired(ing) || httpAllowed(ing) {
 					b.lookupVirtualHost(host).addRoute(r)
 				}
 


### PR DESCRIPTION
Fixes #1023

The behaviour when these two annotations are both specified is somewhat
surprising: `allow-http: false` meant that no routes were not registered
for port 80, even if `force-ssl-redirect: true` was set - leading to a
404 where a 3xx with an upgrade to `https` was expected.

With this commit, we prioritize respecting `force-ssl-redirect`: if this
annotation is specified and set to `true`, we always register a port 80
route for the ingress, even if `allow-http: false`, so that the forced
upgrade can take effect.

Signed-off-by: Cera Davies <ceralena.davies@gmail.com>