### PR TITLE
internal/envoy: convert TCPProxy to TypedConfig

### DIFF
--- a/internal/e2e/e2e.go
+++ b/internal/e2e/e2e.go
@@ -19,7 +19,6 @@ import (
 	"testing"
 
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2"
-	accesslog "github.com/envoyproxy/go-control-plane/envoy/config/accesslog/v2"
 	"github.com/gogo/protobuf/proto"
 	"github.com/gogo/protobuf/types"
 	"github.com/heptio/contour/apis/generated/clientset/versioned/fake"
@@ -193,17 +192,6 @@ func assertEqual(t *testing.T, want, got *v2.DiscoveryResponse) {
 			ExpandAny: true,
 		}
 		t.Fatalf("\nexpected:\n%v\ngot:\n%v", m.Text(want), m.Text(got))
-	}
-}
-
-// fileAccessLog is defined here to avoid the conflict between the package that defines the
-// accesslog.AccessLog interface, "github.com/envoyproxy/go-control-plane/envoy/config/filter/accesslog/v2"
-// and the package the defines the FileAccessLog implement,
-// "github.com/envoyproxy/go-control-plane/envoy/config/accesslog/v2"
-
-func fileAccessLog(path string) *accesslog.FileAccessLog {
-	return &accesslog.FileAccessLog{
-		Path: path,
 	}
 }
 

--- a/internal/envoy/accesslog_test.go
+++ b/internal/envoy/accesslog_test.go
@@ -1,0 +1,50 @@
+// Copyright © 2019 Heptio
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package envoy
+
+import (
+	"testing"
+
+	accesslog_v2 "github.com/envoyproxy/go-control-plane/envoy/config/accesslog/v2"
+	envoy_accesslog "github.com/envoyproxy/go-control-plane/envoy/config/filter/accesslog/v2"
+	"github.com/envoyproxy/go-control-plane/pkg/util"
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestFileAccessLog(t *testing.T) {
+	tests := map[string]struct {
+		path string
+		want []*envoy_accesslog.AccessLog
+	}{
+		"stdout": {
+			path: "/dev/stdout",
+			want: []*envoy_accesslog.AccessLog{{
+				Name: util.FileAccessLog,
+				ConfigType: &envoy_accesslog.AccessLog_TypedConfig{
+					TypedConfig: any(&accesslog_v2.FileAccessLog{
+						Path: "/dev/stdout",
+					}),
+				},
+			}},
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := FileAccessLog(tc.path)
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Fatal(diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Updates #876
Updates #499

Convert TCPProxy listener filter to a TypedConfig. This gives us
protection if Envoy changes the proto definition of the filter types in
the future. It also reduces the background churn of idempotent, but not
bit-for-bit identical messages between Contour and Envoy.

This has lots of pleasent follow on effects; sorting of TCP Proxy
members is less gross, and we remove all uses of the odeous
messageToStruct via JSON hack.

Also, add tests for FileAccessLog and HTTPConnectionManager. They're
simple, but by adding a test we can then be sure that we can use them in
other functions as we have a test to assert what they are returning --
and if we change it in the future.

Signed-off-by: Dave Cheney <dave@cheney.net>