### PR TITLE
internal/contour: Move static listener configuration out of bootstrap

### DIFF
--- a/internal/e2e/e2e.go
+++ b/internal/e2e/e2e.go
@@ -40,6 +40,8 @@ const (
 	clusterType  = typePrefix + "Cluster"
 	routeType    = typePrefix + "RouteConfiguration"
 	listenerType = typePrefix + "Listener"
+	statsAddress = "0.0.0.0"
+	statsPort    = 8002
 )
 
 type testWriter struct {
@@ -71,7 +73,8 @@ func setup(t *testing.T, opts ...func(*contour.ResourceEventHandler)) (cache.Res
 		IngressRouteStatus: &k8s.IngressRouteStatus{
 			Client: fake.NewSimpleClientset(),
 		},
-		Metrics: metrics.NewMetrics(r),
+		Metrics:       metrics.NewMetrics(r),
+		ListenerCache: contour.NewListenerCache(statsAddress, statsPort),
 	}
 
 	reh := contour.ResourceEventHandler{

--- a/internal/envoy/bootstrap.go
+++ b/internal/envoy/bootstrap.go
@@ -23,7 +23,6 @@ import (
 	clusterv2 "github.com/envoyproxy/go-control-plane/envoy/api/v2/cluster"
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2/endpoint"
-	"github.com/envoyproxy/go-control-plane/envoy/api/v2/listener"
 	bootstrap "github.com/envoyproxy/go-control-plane/envoy/config/bootstrap/v2"
 	metrics "github.com/envoyproxy/go-control-plane/envoy/config/metrics/v2"
 	"github.com/envoyproxy/go-control-plane/pkg/util"
@@ -38,59 +37,6 @@ func Bootstrap(c *BootstrapConfig) *bootstrap.Bootstrap {
 			CdsConfig: ConfigSource("contour"),
 		},
 		StaticResources: &bootstrap.Bootstrap_StaticResources{
-			Listeners: []api.Listener{{
-				Address: *SocketAddress(
-					stringOrDefault(c.StatsAddress, "0.0.0.0"),
-					intOrDefault(c.StatsPort, 8002),
-				),
-				FilterChains: []listener.FilterChain{{
-					Filters: []listener.Filter{{
-						Name: util.HTTPConnectionManager,
-						ConfigType: &listener.Filter_Config{
-							Config: &types.Struct{
-								Fields: map[string]*types.Value{
-									"codec_type":  sv("AUTO"),
-									"stat_prefix": sv("stats"),
-									"route_config": st(map[string]*types.Value{
-										"virtual_hosts": st(map[string]*types.Value{
-											"name":    sv("backend"),
-											"domains": lv(sv("*")),
-											"routes": lv(
-												st(map[string]*types.Value{
-													"match": st(map[string]*types.Value{
-														"prefix": sv("/stats"),
-													}),
-													"route": st(map[string]*types.Value{
-														"cluster": sv("service-stats"),
-													}),
-												}),
-											),
-										}),
-									}),
-									"http_filters": lv(
-										st(map[string]*types.Value{
-											"name": sv(util.HealthCheck),
-											"config": st(map[string]*types.Value{
-												"pass_through_mode": sv("false"), // not sure about this
-												"headers": lv(
-													st(map[string]*types.Value{
-														"name":        sv(":path"),
-														"exact_match": sv("/healthz"),
-													}),
-												),
-											}),
-										}),
-										st(map[string]*types.Value{
-											"name": sv(util.Router),
-										}),
-									),
-									"normalize_path": {Kind: &types.Value_BoolValue{BoolValue: true}},
-								},
-							},
-						},
-					}},
-				}},
-			}},
 			Clusters: []api.Cluster{{
 				Name:                 "contour",
 				AltStatName:          strings.Join([]string{c.Namespace, "contour", strconv.Itoa(intOrDefault(c.XDSGRPCPort, 8001))}, "_"),
@@ -191,14 +137,6 @@ type BootstrapConfig struct {
 	// AdminPort is the port that the administration server will listen on.
 	// Defaults to 9001.
 	AdminPort int
-
-	// StatsAddress is the address that the /stats path will listen on.
-	// Defaults to 0.0.0.0 and is only enabled if StatsdEnabled is true.
-	StatsAddress string
-
-	// StatsPort is the port that the /stats path will listen on.
-	// Defaults to 8002 and is only enabled if StatsdEnabled is true.
-	StatsPort int
 
 	// XDSAddress is the TCP address of the gRPC XDS management server.
 	// Defaults to 127.0.0.1.

--- a/internal/envoy/bootstrap_test.go
+++ b/internal/envoy/bootstrap_test.go
@@ -31,65 +31,6 @@ func TestBootstrap(t *testing.T) {
 			config: BootstrapConfig{Namespace: "testing-ns"},
 			want: `{
   "static_resources": {
-    "listeners": [
-      {
-        "address": {
-          "socket_address": {
-            "address": "0.0.0.0",
-            "port_value": 8002
-          }
-        },
-        "filter_chains": [
-          {
-            "filters": [
-              {
-                "name": "envoy.http_connection_manager",
-                "config": {
-                  "codec_type": "AUTO",
-                  "http_filters": [
-                    {
-                      "config": {
-                        "headers": [
-                          {
-                            "exact_match": "/healthz",
-                            "name": ":path"
-                          }
-                        ],
-                        "pass_through_mode": "false"
-                      },
-                      "name": "envoy.health_check"
-                    },
-                    {
-                      "name": "envoy.router"
-                    }
-                  ],
-                  "route_config": {
-                    "virtual_hosts": {
-                      "domains": [
-                        "*"
-                      ],
-                      "name": "backend",
-                      "routes": [
-                        {
-                          "match": {
-                            "prefix": "/stats"
-                          },
-                          "route": {
-                            "cluster": "service-stats"
-                          }
-                        }
-                      ]
-                    }
-                  },
-                  "stat_prefix": "stats",
-                  "normalize_path": true
-                }
-              }
-            ]
-          }
-        ]
-      }
-    ],
     "clusters": [
       {
         "name": "contour",
@@ -205,65 +146,6 @@ func TestBootstrap(t *testing.T) {
 			},
 			want: `{
   "static_resources": {
-    "listeners": [
-      {
-        "address": {
-          "socket_address": {
-            "address": "0.0.0.0",
-            "port_value": 8002
-          }
-        },
-        "filter_chains": [
-          {
-            "filters": [
-              {
-                "name": "envoy.http_connection_manager",
-                "config": {
-                  "codec_type": "AUTO",
-                  "http_filters": [
-                    {
-                      "config": {
-                        "headers": [
-                          {
-                            "exact_match": "/healthz",
-                            "name": ":path"
-                          }
-                        ],
-                        "pass_through_mode": "false"
-                      },
-                      "name": "envoy.health_check"
-                    },
-                    {
-                      "name": "envoy.router"
-                    }
-                  ],
-                  "route_config": {
-                    "virtual_hosts": {
-                      "domains": [
-                        "*"
-                      ],
-                      "name": "backend",
-                      "routes": [
-                        {
-                          "match": {
-                            "prefix": "/stats"
-                          },
-                          "route": {
-                            "cluster": "service-stats"
-                          }
-                        }
-                      ]
-                    }
-                  },
-                  "stat_prefix": "stats",
-                  "normalize_path": true
-                }
-              }
-            ]
-          }
-        ]
-      }
-    ],
     "clusters": [
       {
         "name": "contour",
@@ -395,65 +277,6 @@ func TestBootstrap(t *testing.T) {
 			},
 			want: `{
   "static_resources": {
-    "listeners": [
-      {
-        "address": {
-          "socket_address": {
-            "address": "0.0.0.0",
-            "port_value": 8002
-          }
-        },
-        "filter_chains": [
-          {
-            "filters": [
-              {
-                "name": "envoy.http_connection_manager",
-                "config": {
-                  "codec_type": "AUTO",
-                  "http_filters": [
-                    {
-                      "config": {
-                        "headers": [
-                          {
-                            "exact_match": "/healthz",
-                            "name": ":path"
-                          }
-                        ],
-                        "pass_through_mode": "false"
-                      },
-                      "name": "envoy.health_check"
-                    },
-                    {
-                      "name": "envoy.router"
-                    }
-                  ],
-                  "route_config": {
-                    "virtual_hosts": {
-                      "domains": [
-                        "*"
-                      ],
-                      "name": "backend",
-                      "routes": [
-                        {
-                          "match": {
-                            "prefix": "/stats"
-                          },
-                          "route": {
-                            "cluster": "service-stats"
-                          }
-                        }
-                      ]
-                    }
-                  },
-                  "stat_prefix": "stats",
-                  "normalize_path": true
-                }
-              }
-            ]
-          }
-        ]
-      }
-    ],
     "clusters": [
       {
         "name": "contour",
@@ -584,65 +407,6 @@ func TestBootstrap(t *testing.T) {
 			},
 			want: `{
   "static_resources": {
-    "listeners": [
-      {
-        "address": {
-          "socket_address": {
-            "address": "0.0.0.0",
-            "port_value": 8002
-          }
-        },
-        "filter_chains": [
-          {
-            "filters": [
-              {
-                "name": "envoy.http_connection_manager",
-                "config": {
-                  "codec_type": "AUTO",
-                  "http_filters": [
-                    {
-                      "config": {
-                        "headers": [
-                          {
-                            "exact_match": "/healthz",
-                            "name": ":path"
-                          }
-                        ],
-                        "pass_through_mode": "false"
-                      },
-                      "name": "envoy.health_check"
-                    },
-                    {
-                      "name": "envoy.router"
-                    }
-                  ],
-                  "route_config": {
-                    "virtual_hosts": {
-                      "domains": [
-                        "*"
-                      ],
-                      "name": "backend",
-                      "routes": [
-                        {
-                          "match": {
-                            "prefix": "/stats"
-                          },
-                          "route": {
-                            "cluster": "service-stats"
-                          }
-                        }
-                      ]
-                    }
-                  },
-                  "stat_prefix": "stats",
-                  "normalize_path": true
-                }
-              }
-            ]
-          }
-        ]
-      }
-    ],
     "clusters": [
       {
         "name": "contour",
@@ -758,65 +522,6 @@ func TestBootstrap(t *testing.T) {
 			},
 			want: `{
   "static_resources": {
-    "listeners": [
-      {
-        "address": {
-          "socket_address": {
-            "address": "0.0.0.0",
-            "port_value": 8002
-          }
-        },
-        "filter_chains": [
-          {
-            "filters": [
-              {
-                "name": "envoy.http_connection_manager",
-                "config": {
-                  "codec_type": "AUTO",
-                  "http_filters": [
-                    {
-                      "config": {
-                        "headers": [
-                          {
-                            "exact_match": "/healthz",
-                            "name": ":path"
-                          }
-                        ],
-                        "pass_through_mode": "false"
-                      },
-                      "name": "envoy.health_check"
-                    },
-                    {
-                      "name": "envoy.router"
-                    }
-                  ],
-                  "route_config": {
-                    "virtual_hosts": {
-                      "domains": [
-                        "*"
-                      ],
-                      "name": "backend",
-                      "routes": [
-                        {
-                          "match": {
-                            "prefix": "/stats"
-                          },
-                          "route": {
-                            "cluster": "service-stats"
-                          }
-                        }
-                      ]
-                    }
-                  },
-                  "stat_prefix": "stats",
-                  "normalize_path": true
-                }
-              }
-            ]
-          }
-        ]
-      }
-    ],
     "clusters": [
       {
         "name": "contour",
@@ -933,65 +638,6 @@ func TestBootstrap(t *testing.T) {
 			},
 			want: `{
   "static_resources": {
-    "listeners": [
-      {
-        "address": {
-          "socket_address": {
-            "address": "0.0.0.0",
-            "port_value": 8002
-          }
-        },
-        "filter_chains": [
-          {
-            "filters": [
-              {
-                "name": "envoy.http_connection_manager",
-                "config": {
-                  "codec_type": "AUTO",
-                  "http_filters": [
-                    {
-                      "config": {
-                        "headers": [
-                          {
-                            "exact_match": "/healthz",
-                            "name": ":path"
-                          }
-                        ],
-                        "pass_through_mode": "false"
-                      },
-                      "name": "envoy.health_check"
-                    },
-                    {
-                      "name": "envoy.router"
-                    }
-                  ],
-                  "route_config": {
-                    "virtual_hosts": {
-                      "domains": [
-                        "*"
-                      ],
-                      "name": "backend",
-                      "routes": [
-                        {
-                          "match": {
-                            "prefix": "/stats"
-                          },
-                          "route": {
-                            "cluster": "service-stats"
-                          }
-                        }
-                      ]
-                    }
-                  },
-                  "stat_prefix": "stats",
-                  "normalize_path": true
-                }
-              }
-            ]
-          }
-        ]
-      }
-    ],
     "clusters": [
       {
         "name": "contour",
@@ -1102,71 +748,10 @@ func TestBootstrap(t *testing.T) {
 		},
 		"--stats-address=8.8.8.8 --stats-port=9200": {
 			config: BootstrapConfig{
-				StatsAddress: "8.8.8.8",
-				StatsPort:    9200,
-				Namespace:    "testing-ns",
+				Namespace: "testing-ns",
 			},
 			want: `{
   "static_resources": {
-    "listeners": [
-      {
-        "address": {
-          "socket_address": {
-            "address": "8.8.8.8",
-            "port_value": 9200
-          }
-        },
-        "filter_chains": [
-          {
-            "filters": [
-              {
-                "name": "envoy.http_connection_manager",
-                "config": {
-                  "codec_type": "AUTO",
-                  "http_filters": [
-                    {
-                      "config": {
-                        "headers": [
-                          {
-                            "exact_match": "/healthz",
-                            "name": ":path"
-                          }
-                        ],
-                        "pass_through_mode": "false"
-                      },
-                      "name": "envoy.health_check"
-                    },
-                    {
-                      "name": "envoy.router"
-                    }
-                  ],
-                  "route_config": {
-                    "virtual_hosts": {
-                      "domains": [
-                        "*"
-                      ],
-                      "name": "backend",
-                      "routes": [
-                        {
-                          "match": {
-                            "prefix": "/stats"
-                          },
-                          "route": {
-                            "cluster": "service-stats"
-                          }
-                        }
-                      ]
-                    }
-                  },
-                  "stat_prefix": "stats",
-                  "normalize_path": true
-                }
-              }
-            ]
-          }
-        ]
-      }
-    ],
     "clusters": [
       {
         "name": "contour",

--- a/internal/envoy/listener.go
+++ b/internal/envoy/listener.go
@@ -197,10 +197,6 @@ func st(m map[string]*types.Value) *types.Value {
 	return &types.Value{Kind: &types.Value_StructValue{StructValue: &types.Struct{Fields: m}}}
 }
 
-func lv(v ...*types.Value) *types.Value {
-	return &types.Value{Kind: &types.Value_ListValue{ListValue: &types.ListValue{Values: v}}}
-}
-
 func any(pb proto.Message) *types.Any {
 	any, err := types.MarshalAny(pb)
 	if err != nil {


### PR DESCRIPTION
Fixes #376 by removing the static listener from the bootstrap config to contour/listeners. This doesn't change how Contour has worked in the past, just moves where it's configured from bootstrap to inside Contour's XDs server. 

Signed-off-by: Steve Sloka <slokas@vmware.com>