### PR TITLE
internal/envoy: move StatsListener generation to helper

### DIFF
--- a/internal/contour/listener.go
+++ b/internal/contour/listener.go
@@ -16,14 +16,8 @@ package contour
 import (
 	"sync"
 
-	"github.com/gogo/protobuf/types"
-
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2/listener"
-	"github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
-	health_check "github.com/envoyproxy/go-control-plane/envoy/config/filter/http/health_check/v2"
-	http "github.com/envoyproxy/go-control-plane/envoy/config/filter/network/http_connection_manager/v2"
-	"github.com/envoyproxy/go-control-plane/pkg/util"
 	"github.com/gogo/protobuf/proto"
 	"github.com/heptio/contour/internal/dag"
 	"github.com/heptio/contour/internal/envoy"
@@ -139,60 +133,7 @@ type ListenerCache struct {
 func NewListenerCache(address string, port int) ListenerCache {
 	return ListenerCache{
 		staticValues: map[string]*v2.Listener{
-			"stats-health": {
-				Name:    "stats-health",
-				Address: *envoy.SocketAddress(address, port),
-				FilterChains: []listener.FilterChain{{
-					Filters: []listener.Filter{{
-						Name: util.HTTPConnectionManager,
-						ConfigType: &listener.Filter_TypedConfig{
-							TypedConfig: any(&http.HttpConnectionManager{
-								// TODO(dfc) should the stats listener expose stats? is that likely to collapse the multiverse?
-								StatPrefix: "stats",
-								RouteSpecifier: &http.HttpConnectionManager_RouteConfig{
-									RouteConfig: &v2.RouteConfiguration{
-										VirtualHosts: []route.VirtualHost{{
-											Name:    "backend",
-											Domains: []string{"*"},
-											Routes: []route.Route{{
-												Match: route.RouteMatch{
-													PathSpecifier: &route.RouteMatch_Prefix{
-														Prefix: "/stats",
-													},
-												},
-												Action: &route.Route_Route{
-													Route: &route.RouteAction{
-														ClusterSpecifier: &route.RouteAction_Cluster{
-															Cluster: "service-stats",
-														},
-													},
-												},
-											}},
-										}},
-									},
-								},
-								HttpFilters: []*http.HttpFilter{{
-									Name: util.HealthCheck,
-									ConfigType: &http.HttpFilter_TypedConfig{
-										TypedConfig: any(&health_check.HealthCheck{
-											PassThroughMode: &types.BoolValue{Value: false},
-											Headers: []*route.HeaderMatcher{{
-												Name: ":path",
-												HeaderMatchSpecifier: &route.HeaderMatcher_ExactMatch{
-													ExactMatch: "/healthz",
-												},
-											}},
-										}),
-									},
-								}, {
-									Name: util.Router,
-								}},
-								NormalizePath: &types.BoolValue{Value: true},
-							}),
-						},
-					}},
-				}},
-			},
+			"stats-health": envoy.StatsListener("stats-health", address, port),
 		},
 	}
 }
@@ -341,12 +282,4 @@ func (v *listenerVisitor) visit(vertex dag.Vertex) {
 		// recurse
 		vertex.Visit(v.visit)
 	}
-}
-
-func any(pb proto.Message) *types.Any {
-	any, err := types.MarshalAny(pb)
-	if err != nil {
-		panic(err.Error())
-	}
-	return any
 }

--- a/internal/contour/listener.go
+++ b/internal/contour/listener.go
@@ -131,9 +131,10 @@ type ListenerCache struct {
 
 // NewListenerCache returns an instance of a ListenerCache
 func NewListenerCache(address string, port int) ListenerCache {
+	stats := envoy.StatsListener(address, port)
 	return ListenerCache{
 		staticValues: map[string]*v2.Listener{
-			"stats-health": envoy.StatsListener("stats-health", address, port),
+			stats.Name: stats,
 		},
 	}
 }

--- a/internal/e2e/lds_test.go
+++ b/internal/e2e/lds_test.go
@@ -1463,5 +1463,5 @@ func tcpproxy(t *testing.T, statPrefix, cluster string) listener.Filter {
 }
 
 func staticListener() *v2.Listener {
-	return envoy.StatsListener("stats-health", statsAddress, statsPort)
+	return envoy.StatsListener(statsAddress, statsPort)
 }

--- a/internal/e2e/lds_test.go
+++ b/internal/e2e/lds_test.go
@@ -47,7 +47,7 @@ func TestNonTLSListener(t *testing.T) {
 	assertEqual(t, &v2.DiscoveryResponse{
 		VersionInfo: "0",
 		Resources: []types.Any{
-			any(t, staticListener(t)),
+			any(t, staticListener()),
 		},
 		TypeUrl: listenerType,
 		Nonce:   "0",
@@ -74,7 +74,7 @@ func TestNonTLSListener(t *testing.T) {
 				Address:      *envoy.SocketAddress("0.0.0.0", 8080),
 				FilterChains: filterchain(envoy.HTTPConnectionManager("ingress_http", "/dev/stdout")),
 			}),
-			any(t, staticListener(t)),
+			any(t, staticListener()),
 		},
 		TypeUrl: listenerType,
 		Nonce:   "1",
@@ -99,7 +99,7 @@ func TestNonTLSListener(t *testing.T) {
 	assertEqual(t, &v2.DiscoveryResponse{
 		VersionInfo: "2",
 		Resources: []types.Any{
-			any(t, staticListener(t)),
+			any(t, staticListener()),
 		},
 		TypeUrl: listenerType,
 		Nonce:   "2",
@@ -130,7 +130,7 @@ func TestNonTLSListener(t *testing.T) {
 				Address:      *envoy.SocketAddress("0.0.0.0", 8080),
 				FilterChains: filterchain(envoy.HTTPConnectionManager("ingress_http", "/dev/stdout")),
 			}),
-			any(t, staticListener(t)),
+			any(t, staticListener()),
 		},
 		TypeUrl: listenerType,
 		Nonce:   "3",
@@ -175,7 +175,7 @@ func TestTLSListener(t *testing.T) {
 	assertEqual(t, &v2.DiscoveryResponse{
 		VersionInfo: "1",
 		Resources: []types.Any{
-			any(t, staticListener(t)),
+			any(t, staticListener()),
 		},
 		TypeUrl: listenerType,
 		Nonce:   "1",
@@ -199,7 +199,7 @@ func TestTLSListener(t *testing.T) {
 				},
 				FilterChains: filterchaintls("kuard.example.com", s1, envoy.HTTPConnectionManager("ingress_https", "/dev/stdout"), "h2", "http/1.1"),
 			}),
-			any(t, staticListener(t)),
+			any(t, staticListener()),
 		},
 		TypeUrl: listenerType,
 		Nonce:   "2",
@@ -236,7 +236,7 @@ func TestTLSListener(t *testing.T) {
 				},
 				FilterChains: filterchaintls("kuard.example.com", s1, envoy.HTTPConnectionManager("ingress_https", "/dev/stdout"), "h2", "http/1.1"),
 			}),
-			any(t, staticListener(t)),
+			any(t, staticListener()),
 		},
 		TypeUrl: listenerType,
 		Nonce:   "3",
@@ -247,7 +247,7 @@ func TestTLSListener(t *testing.T) {
 	assertEqual(t, &v2.DiscoveryResponse{
 		VersionInfo: "4",
 		Resources: []types.Any{
-			any(t, staticListener(t)),
+			any(t, staticListener()),
 		},
 		TypeUrl: listenerType,
 		Nonce:   "4",
@@ -325,7 +325,7 @@ func TestIngressRouteTLSListener(t *testing.T) {
 	assertEqual(t, &v2.DiscoveryResponse{
 		VersionInfo: "1",
 		Resources: []types.Any{
-			any(t, staticListener(t)),
+			any(t, staticListener()),
 		},
 		TypeUrl: listenerType,
 		Nonce:   "1",
@@ -353,7 +353,7 @@ func TestIngressRouteTLSListener(t *testing.T) {
 				FilterChains: filterchain(envoy.HTTPConnectionManager("ingress_http", "/dev/stdout")),
 			}),
 			any(t, l1),
-			any(t, staticListener(t)),
+			any(t, staticListener()),
 		},
 		TypeUrl: listenerType,
 		Nonce:   "2",
@@ -369,7 +369,7 @@ func TestIngressRouteTLSListener(t *testing.T) {
 				Address:      *envoy.SocketAddress("0.0.0.0", 8080),
 				FilterChains: filterchain(envoy.HTTPConnectionManager("ingress_http", "/dev/stdout")),
 			}),
-			any(t, staticListener(t)),
+			any(t, staticListener()),
 		},
 		TypeUrl: listenerType,
 		Nonce:   "3",
@@ -400,7 +400,7 @@ func TestIngressRouteTLSListener(t *testing.T) {
 				FilterChains: filterchain(envoy.HTTPConnectionManager("ingress_http", "/dev/stdout")),
 			}),
 			any(t, l2),
-			any(t, staticListener(t)),
+			any(t, staticListener()),
 		},
 		TypeUrl: listenerType,
 		Nonce:   "6",
@@ -454,7 +454,7 @@ func TestLDSFilter(t *testing.T) {
 				},
 				FilterChains: filterchaintls("kuard.example.com", s1, envoy.HTTPConnectionManager("ingress_https", "/dev/stdout"), "h2", "http/1.1"),
 			}),
-			any(t, staticListener(t)),
+			any(t, staticListener()),
 		},
 		TypeUrl: listenerType,
 		Nonce:   "2",
@@ -469,7 +469,7 @@ func TestLDSFilter(t *testing.T) {
 				Address:      *envoy.SocketAddress("0.0.0.0", 8080),
 				FilterChains: filterchain(envoy.HTTPConnectionManager("ingress_http", "/dev/stdout")),
 			}),
-			any(t, staticListener(t)),
+			any(t, staticListener()),
 		},
 		TypeUrl: listenerType,
 		Nonce:   "2",
@@ -479,7 +479,7 @@ func TestLDSFilter(t *testing.T) {
 	assertEqual(t, &v2.DiscoveryResponse{
 		VersionInfo: "2",
 		Resources: []types.Any{
-			any(t, staticListener(t)),
+			any(t, staticListener()),
 		},
 		TypeUrl: listenerType,
 		Nonce:   "2",
@@ -494,7 +494,7 @@ func TestLDSStreamEmpty(t *testing.T) {
 	assertEqual(t, &v2.DiscoveryResponse{
 		VersionInfo: "0",
 		Resources: []types.Any{
-			any(t, staticListener(t)),
+			any(t, staticListener()),
 		},
 		TypeUrl: listenerType, Nonce: "0",
 	}, streamLDS(t, cc, "HTTP"))
@@ -547,7 +547,7 @@ func TestLDSTLSMinimumProtocolVersion(t *testing.T) {
 				},
 				FilterChains: filterchaintls("kuard.example.com", s1, envoy.HTTPConnectionManager("ingress_https", "/dev/stdout"), "h2", "http/1.1"),
 			}),
-			any(t, staticListener(t)),
+			any(t, staticListener()),
 		},
 		TypeUrl: listenerType,
 		Nonce:   "3",
@@ -588,7 +588,7 @@ func TestLDSTLSMinimumProtocolVersion(t *testing.T) {
 		VersionInfo: "4",
 		Resources: []types.Any{
 			any(t, l1),
-			any(t, staticListener(t)),
+			any(t, staticListener()),
 		},
 		TypeUrl: listenerType,
 		Nonce:   "4",
@@ -606,7 +606,7 @@ func TestLDSIngressHTTPUseProxyProtocol(t *testing.T) {
 	assertEqual(t, &v2.DiscoveryResponse{
 		VersionInfo: "0",
 		Resources: []types.Any{
-			any(t, staticListener(t)),
+			any(t, staticListener()),
 		},
 		TypeUrl: listenerType,
 		Nonce:   "0",
@@ -637,7 +637,7 @@ func TestLDSIngressHTTPUseProxyProtocol(t *testing.T) {
 				},
 				FilterChains: filterchain(envoy.HTTPConnectionManager("ingress_http", "/dev/stdout")),
 			}),
-			any(t, staticListener(t)),
+			any(t, staticListener()),
 		},
 		TypeUrl: listenerType,
 		Nonce:   "1",
@@ -684,7 +684,7 @@ func TestLDSIngressHTTPSUseProxyProtocol(t *testing.T) {
 	assertEqual(t, &v2.DiscoveryResponse{
 		VersionInfo: "1",
 		Resources: []types.Any{
-			any(t, staticListener(t)),
+			any(t, staticListener()),
 		},
 		TypeUrl: listenerType,
 		Nonce:   "1",
@@ -715,7 +715,7 @@ func TestLDSIngressHTTPSUseProxyProtocol(t *testing.T) {
 				FilterChains: filterchain(envoy.HTTPConnectionManager("ingress_http", "/dev/stdout")),
 			}),
 			any(t, ingress_https),
-			any(t, staticListener(t)),
+			any(t, staticListener()),
 		},
 		TypeUrl: listenerType,
 		Nonce:   "2",
@@ -765,7 +765,7 @@ func TestLDSCustomAddressAndPort(t *testing.T) {
 	assertEqual(t, &v2.DiscoveryResponse{
 		VersionInfo: "1",
 		Resources: []types.Any{
-			any(t, staticListener(t)),
+			any(t, staticListener()),
 		},
 		TypeUrl: listenerType,
 		Nonce:   "1",
@@ -793,7 +793,7 @@ func TestLDSCustomAddressAndPort(t *testing.T) {
 		Resources: []types.Any{
 			any(t, ingress_http),
 			any(t, ingress_https),
-			any(t, staticListener(t)),
+			any(t, staticListener()),
 		},
 		TypeUrl: listenerType,
 		Nonce:   "2",
@@ -841,7 +841,7 @@ func TestLDSCustomAccessLogPaths(t *testing.T) {
 	assertEqual(t, &v2.DiscoveryResponse{
 		VersionInfo: "1",
 		Resources: []types.Any{
-			any(t, staticListener(t)),
+			any(t, staticListener()),
 		},
 		TypeUrl: listenerType,
 		Nonce:   "1",
@@ -867,7 +867,7 @@ func TestLDSCustomAccessLogPaths(t *testing.T) {
 		Resources: []types.Any{
 			any(t, ingress_http),
 			any(t, ingress_https),
-			any(t, staticListener(t)),
+			any(t, staticListener()),
 		},
 		TypeUrl: listenerType,
 		Nonce:   "2",
@@ -887,7 +887,7 @@ func TestLDSIngressRouteInsideRootNamespaces(t *testing.T) {
 	assertEqual(t, &v2.DiscoveryResponse{
 		VersionInfo: "0",
 		Resources: []types.Any{
-			any(t, staticListener(t)),
+			any(t, staticListener()),
 		},
 		TypeUrl: listenerType,
 		Nonce:   "0",
@@ -923,7 +923,7 @@ func TestLDSIngressRouteInsideRootNamespaces(t *testing.T) {
 				Address:      *envoy.SocketAddress("0.0.0.0", 8080),
 				FilterChains: filterchain(envoy.HTTPConnectionManager("ingress_http", "/dev/stdout")),
 			}),
-			any(t, staticListener(t)),
+			any(t, staticListener()),
 		},
 		TypeUrl: listenerType,
 		Nonce:   "1",
@@ -943,7 +943,7 @@ func TestLDSIngressRouteOutsideRootNamespaces(t *testing.T) {
 	assertEqual(t, &v2.DiscoveryResponse{
 		VersionInfo: "0",
 		Resources: []types.Any{
-			any(t, staticListener(t)),
+			any(t, staticListener()),
 		},
 		TypeUrl: listenerType,
 		Nonce:   "0",
@@ -974,7 +974,7 @@ func TestLDSIngressRouteOutsideRootNamespaces(t *testing.T) {
 	assertEqual(t, &v2.DiscoveryResponse{
 		VersionInfo: "1",
 		Resources: []types.Any{
-			any(t, staticListener(t)),
+			any(t, staticListener()),
 		},
 		TypeUrl: listenerType,
 		Nonce:   "1",
@@ -994,7 +994,7 @@ func TestIngressRouteHTTPS(t *testing.T) {
 	assertEqual(t, &v2.DiscoveryResponse{
 		VersionInfo: "0",
 		Resources: []types.Any{
-			any(t, staticListener(t)),
+			any(t, staticListener()),
 		},
 		TypeUrl: listenerType,
 		Nonce:   "0",
@@ -1060,7 +1060,7 @@ func TestIngressRouteHTTPS(t *testing.T) {
 		Resources: []types.Any{
 			any(t, ingressHTTP),
 			any(t, ingressHTTPS),
-			any(t, staticListener(t)),
+			any(t, staticListener()),
 		},
 		TypeUrl: listenerType,
 		Nonce:   "2",
@@ -1129,7 +1129,7 @@ func TestLDSIngressRouteTCPProxyTLSPassthrough(t *testing.T) {
 		VersionInfo: "2",
 		Resources: []types.Any{
 			any(t, ingressHTTPS),
-			any(t, staticListener(t)),
+			any(t, staticListener()),
 		},
 		TypeUrl: listenerType,
 		Nonce:   "2",
@@ -1201,7 +1201,7 @@ func TestLDSIngressRouteTCPForward(t *testing.T) {
 		VersionInfo: "3",
 		Resources: []types.Any{
 			any(t, ingressHTTPS),
-			any(t, staticListener(t)),
+			any(t, staticListener()),
 		},
 		TypeUrl: listenerType,
 		Nonce:   "3",
@@ -1217,7 +1217,7 @@ func TestIngressRouteTLSCertificateDelegation(t *testing.T) {
 	assertEqual(t, &v2.DiscoveryResponse{
 		VersionInfo: "0",
 		Resources: []types.Any{
-			any(t, staticListener(t)),
+			any(t, staticListener()),
 		},
 		TypeUrl: listenerType,
 		Nonce:   "0",
@@ -1271,7 +1271,7 @@ func TestIngressRouteTLSCertificateDelegation(t *testing.T) {
 		VersionInfo: "2",
 		Resources: []types.Any{
 			any(t, ingress_http),
-			any(t, staticListener(t)),
+			any(t, staticListener()),
 		},
 		TypeUrl: listenerType,
 		Nonce:   "2",
@@ -1308,7 +1308,7 @@ func TestIngressRouteTLSCertificateDelegation(t *testing.T) {
 		Resources: []types.Any{
 			any(t, ingress_http),
 			any(t, ingress_https),
-			any(t, staticListener(t)),
+			any(t, staticListener()),
 		},
 		TypeUrl: listenerType,
 		Nonce:   "3",
@@ -1336,7 +1336,7 @@ func TestIngressRouteTLSCertificateDelegation(t *testing.T) {
 		Resources: []types.Any{
 			any(t, ingress_http),
 			any(t, ingress_https),
-			any(t, staticListener(t)),
+			any(t, staticListener()),
 		},
 		TypeUrl: listenerType,
 		Nonce:   "4",
@@ -1363,7 +1363,7 @@ func TestIngressRouteTLSCertificateDelegation(t *testing.T) {
 		VersionInfo: "5",
 		Resources: []types.Any{
 			any(t, ingress_http),
-			any(t, staticListener(t)),
+			any(t, staticListener()),
 		},
 		TypeUrl: listenerType,
 		Nonce:   "5",
@@ -1390,7 +1390,7 @@ func TestIngressRouteTLSCertificateDelegation(t *testing.T) {
 		VersionInfo: "6",
 		Resources: []types.Any{
 			any(t, ingress_http),
-			any(t, staticListener(t)),
+			any(t, staticListener()),
 		},
 		TypeUrl: listenerType,
 		Nonce:   "6",
@@ -1462,6 +1462,6 @@ func tcpproxy(t *testing.T, statPrefix, cluster string) listener.Filter {
 	}
 }
 
-func staticListener(t *testing.T) *v2.Listener {
+func staticListener() *v2.Listener {
 	return envoy.StatsListener("stats-health", statsAddress, statsPort)
 }

--- a/internal/envoy/stats.go
+++ b/internal/envoy/stats.go
@@ -1,0 +1,82 @@
+// Copyright © 2019 Heptio
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package envoy
+
+import (
+	v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
+	"github.com/envoyproxy/go-control-plane/envoy/api/v2/listener"
+	"github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
+	health_check "github.com/envoyproxy/go-control-plane/envoy/config/filter/http/health_check/v2"
+	http "github.com/envoyproxy/go-control-plane/envoy/config/filter/network/http_connection_manager/v2"
+	"github.com/envoyproxy/go-control-plane/pkg/util"
+	"github.com/gogo/protobuf/types"
+)
+
+// StatsListener returns a *v2.Listener configured to serve prometheus
+// metrics on /stats.
+func StatsListener(name, address string, port int) *v2.Listener {
+	return &v2.Listener{
+		Name:    "stats-health",
+		Address: *SocketAddress(address, port),
+		FilterChains: []listener.FilterChain{{
+			Filters: []listener.Filter{{
+				Name: util.HTTPConnectionManager,
+				ConfigType: &listener.Filter_TypedConfig{
+					TypedConfig: any(&http.HttpConnectionManager{
+						StatPrefix: "stats",
+						RouteSpecifier: &http.HttpConnectionManager_RouteConfig{
+							RouteConfig: &v2.RouteConfiguration{
+								VirtualHosts: []route.VirtualHost{{
+									Name:    "backend",
+									Domains: []string{"*"},
+									Routes: []route.Route{{
+										Match: route.RouteMatch{
+											PathSpecifier: &route.RouteMatch_Prefix{
+												Prefix: "/stats",
+											},
+										},
+										Action: &route.Route_Route{
+											Route: &route.RouteAction{
+												ClusterSpecifier: &route.RouteAction_Cluster{
+													Cluster: "service-stats",
+												},
+											},
+										},
+									}},
+								}},
+							},
+						},
+						HttpFilters: []*http.HttpFilter{{
+							Name: util.HealthCheck,
+							ConfigType: &http.HttpFilter_TypedConfig{
+								TypedConfig: any(&health_check.HealthCheck{
+									PassThroughMode: &types.BoolValue{Value: false},
+									Headers: []*route.HeaderMatcher{{
+										Name: ":path",
+										HeaderMatchSpecifier: &route.HeaderMatcher_ExactMatch{
+											ExactMatch: "/healthz",
+										},
+									}},
+								}),
+							},
+						}, {
+							Name: util.Router,
+						}},
+						NormalizePath: &types.BoolValue{Value: true},
+					}),
+				},
+			}},
+		}},
+	}
+}

--- a/internal/envoy/stats.go
+++ b/internal/envoy/stats.go
@@ -25,7 +25,7 @@ import (
 
 // StatsListener returns a *v2.Listener configured to serve prometheus
 // metrics on /stats.
-func StatsListener(name, address string, port int) *v2.Listener {
+func StatsListener(address string, port int) *v2.Listener {
 	return &v2.Listener{
 		Name:    "stats-health",
 		Address: *SocketAddress(address, port),

--- a/internal/envoy/stats_test.go
+++ b/internal/envoy/stats_test.go
@@ -28,12 +28,11 @@ import (
 
 func TestStatsListener(t *testing.T) {
 	tests := map[string]struct {
-		name, address string
-		port          int
-		want          *v2.Listener
+		address string
+		port    int
+		want    *v2.Listener
 	}{
 		"stats-health": {
-			name:    "stats-health",
 			address: "127.0.0.127",
 			port:    8123,
 			want: &v2.Listener{
@@ -93,7 +92,7 @@ func TestStatsListener(t *testing.T) {
 	}
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			got := StatsListener(tc.name, tc.address, tc.port)
+			got := StatsListener(tc.address, tc.port)
 			if diff := cmp.Diff(tc.want, got); diff != "" {
 				t.Fatal(diff)
 			}

--- a/internal/envoy/stats_test.go
+++ b/internal/envoy/stats_test.go
@@ -1,0 +1,102 @@
+// Copyright © 2019 Heptio
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package envoy
+
+import (
+	"testing"
+
+	v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
+	"github.com/envoyproxy/go-control-plane/envoy/api/v2/listener"
+	"github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
+	health_check "github.com/envoyproxy/go-control-plane/envoy/config/filter/http/health_check/v2"
+	http "github.com/envoyproxy/go-control-plane/envoy/config/filter/network/http_connection_manager/v2"
+	"github.com/envoyproxy/go-control-plane/pkg/util"
+	"github.com/gogo/protobuf/types"
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestStatsListener(t *testing.T) {
+	tests := map[string]struct {
+		name, address string
+		port          int
+		want          *v2.Listener
+	}{
+		"stats-health": {
+			name:    "stats-health",
+			address: "127.0.0.127",
+			port:    8123,
+			want: &v2.Listener{
+				Name:    "stats-health",
+				Address: *SocketAddress("127.0.0.127", 8123),
+				FilterChains: []listener.FilterChain{{
+					Filters: []listener.Filter{{
+						Name: util.HTTPConnectionManager,
+						ConfigType: &listener.Filter_TypedConfig{
+							TypedConfig: any(&http.HttpConnectionManager{
+								StatPrefix: "stats",
+								RouteSpecifier: &http.HttpConnectionManager_RouteConfig{
+									RouteConfig: &v2.RouteConfiguration{
+										VirtualHosts: []route.VirtualHost{{
+											Name:    "backend",
+											Domains: []string{"*"},
+											Routes: []route.Route{{
+												Match: route.RouteMatch{
+													PathSpecifier: &route.RouteMatch_Prefix{
+														Prefix: "/stats",
+													},
+												},
+												Action: &route.Route_Route{
+													Route: &route.RouteAction{
+														ClusterSpecifier: &route.RouteAction_Cluster{
+															Cluster: "service-stats",
+														},
+													},
+												},
+											}},
+										}},
+									},
+								},
+								HttpFilters: []*http.HttpFilter{{
+									Name: util.HealthCheck,
+									ConfigType: &http.HttpFilter_TypedConfig{
+										TypedConfig: any(&health_check.HealthCheck{
+											PassThroughMode: &types.BoolValue{Value: false},
+											Headers: []*route.HeaderMatcher{{
+												Name: ":path",
+												HeaderMatchSpecifier: &route.HeaderMatcher_ExactMatch{
+													ExactMatch: "/healthz",
+												},
+											}},
+										}),
+									},
+								}, {
+									Name: util.Router,
+								}},
+								NormalizePath: &types.BoolValue{Value: true},
+							}),
+						},
+					}},
+				}},
+			},
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := StatsListener(tc.name, tc.address, tc.port)
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Fatal(diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Move the generation of the StatsListener to a helper inside
internal/envoy. This defines what the canonical definition of the stats
listener is, in one place, with a test. It also removes a lot of the
implementation plumbing from internal/contour and internal/e2e.

Signed-off-by: Dave Cheney <dave@cheney.net>