### PR TITLE
internal/envoy: remove remaining use of struct config

### DIFF
--- a/internal/envoy/listener.go
+++ b/internal/envoy/listener.go
@@ -32,9 +32,6 @@ import (
 func TLSInspector() listener.ListenerFilter {
 	return listener.ListenerFilter{
 		Name: util.TlsInspector,
-		ConfigType: &listener.ListenerFilter_Config{
-			Config: new(types.Struct),
-		},
 	}
 }
 
@@ -42,9 +39,6 @@ func TLSInspector() listener.ListenerFilter {
 func ProxyProtocol() listener.ListenerFilter {
 	return listener.ListenerFilter{
 		Name: util.ProxyProtocol,
-		ConfigType: &listener.ListenerFilter_Config{
-			Config: new(types.Struct),
-		},
 	}
 }
 


### PR DESCRIPTION
Fixes #876

Tested locally on my GKE installation. It looks like Envoy's requirement
to have empty configuration structures has been relaxed with the switch
to typed config.

Signed-off-by: Dave Cheney <dave@cheney.net>