### PR TITLE
internal/envoy: Support services type externalName

### DIFF
--- a/deployment/example-workload/ingressroute/07-externalname/root.ingressroute.yaml
+++ b/deployment/example-workload/ingressroute/07-externalname/root.ingressroute.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: contour.heptio.com/v1beta1
+kind: IngressRoute
+metadata: 
+  name: external-name
+spec:
+  virtualhost:
+    fqdn: bar.com
+  routes: 
+    - match: /
+      services: 
+        - name: externaldns
+          port: 80

--- a/deployment/example-workload/ingressroute/07-externalname/service.yaml
+++ b/deployment/example-workload/ingressroute/07-externalname/service.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    run: externaldns
+  name: externaldns
+  namespace: default
+spec:
+  externalName: foo-basic.bar.com
+  ports:
+  - name: http
+    port: 80
+    protocol: TCP
+    targetPort: 80
+  type: ExternalName

--- a/docs/ingressroute.md
+++ b/docs/ingressroute.md
@@ -693,6 +693,33 @@ spec:
           port: 80
 ```
 
+#### ExternalName
+
+IngressRoute supports routing traffic to service types `ExternalName`.
+Contour looks at the `spec.externalName` field of the service and configures the route to use that DNS name instead of utilizing EDS.
+
+There's nothing specific in the `IngressRoute` object that needs configured other than referencing a service of type `ExternalName`.
+
+NOTE: The ports are required to be specified.
+
+```
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    run: externaldns
+  name: externaldns
+  namespace: default
+spec:
+  externalName: foo-basic.bar.com
+  ports:
+  - name: http
+    port: 80
+    protocol: TCP
+    targetPort: 80
+  type: ExternalName
+```
+
 ## IngressRoute Delegation
 
 A key feature of the IngressRoute specification is route delegation which follows the working model of DNS:

--- a/internal/dag/builder.go
+++ b/internal/dag/builder.go
@@ -170,11 +170,19 @@ func (b *builder) addHTTPService(svc *v1.Service, port *v1.ServicePort, strategy
 			MaxRequests:        parseAnnotation(svc.Annotations, annotationMaxRequests),
 			MaxRetries:         parseAnnotation(svc.Annotations, annotationMaxRetries),
 			HealthCheck:        hc,
+			ExternalName:       externalName(svc),
 		},
 		Protocol: protocol,
 	}
 	b.services[s.toMeta()] = s
 	return s
+}
+
+func externalName(svc *v1.Service) string {
+	if svc.Spec.Type != v1.ServiceTypeExternalName {
+		return ""
+	}
+	return svc.Spec.ExternalName
 }
 
 func (b *builder) addTCPService(svc *v1.Service, port *v1.ServicePort, strategy string, hc *ingressroutev1.HealthCheck) *TCPService {

--- a/internal/dag/dag.go
+++ b/internal/dag/dag.go
@@ -242,6 +242,9 @@ type TCPService struct {
 	MaxRetries int
 
 	HealthCheck *ingressroutev1.HealthCheck
+
+	// ExternalName is an optional field referencing a dns entry for Service type "ExternalName"
+	ExternalName string
 }
 
 type servicemeta struct {

--- a/internal/e2e/rds_test.go
+++ b/internal/e2e/rds_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/envoyproxy/go-control-plane/envoy/api/v2"
+	v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
 	"github.com/gogo/protobuf/types"
 	ingressroutev1 "github.com/heptio/contour/apis/contour/v1beta1"
@@ -29,7 +29,7 @@ import (
 	"github.com/heptio/contour/internal/envoy"
 	"github.com/heptio/contour/internal/k8s"
 	"google.golang.org/grpc"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/api/extensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -2788,6 +2788,20 @@ func service(ns, name string, ports ...v1.ServicePort) *v1.Service {
 		},
 		Spec: v1.ServiceSpec{
 			Ports: ports,
+		},
+	}
+}
+
+func externalnameservice(ns, name, externalname string, ports ...v1.ServicePort) *v1.Service {
+	return &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: ns,
+		},
+		Spec: v1.ServiceSpec{
+			Ports:        ports,
+			ExternalName: externalname,
+			Type:         v1.ServiceTypeExternalName,
 		},
 	}
 }

--- a/internal/envoy/route.go
+++ b/internal/envoy/route.go
@@ -14,9 +14,10 @@ package envoy
 
 import (
 	"fmt"
-	"github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 	"sort"
 	"time"
+
+	"github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
 	"github.com/gogo/protobuf/types"


### PR DESCRIPTION
Fixes #334 by allowing routes to proxy traffic to DNS names specified in the service.spec.externalName field of a service. When defined, this skips EDS and specifies the dns endpoint directly on the cluster.

Signed-off-by: Steve Sloka <slokas@vmware.com>