### PR TITLE
internal/grpc: remove Fetch* support

### DIFF
--- a/internal/grpc/server.go
+++ b/internal/grpc/server.go
@@ -87,23 +87,23 @@ type resource interface {
 }
 
 func (s *grpcServer) FetchClusters(_ context.Context, req *v2.DiscoveryRequest) (*v2.DiscoveryResponse, error) {
-	return s.fetch(req)
+	return nil, status.Errorf(codes.Unimplemented, "FetchClusters unimplemented")
 }
 
 func (s *grpcServer) FetchEndpoints(_ context.Context, req *v2.DiscoveryRequest) (*v2.DiscoveryResponse, error) {
-	return s.fetch(req)
+	return nil, status.Errorf(codes.Unimplemented, "FetchEndpoints unimplemented")
 }
 
 func (s *grpcServer) FetchListeners(_ context.Context, req *v2.DiscoveryRequest) (*v2.DiscoveryResponse, error) {
-	return s.fetch(req)
+	return nil, status.Errorf(codes.Unimplemented, "FetchListeners unimplemented")
 }
 
 func (s *grpcServer) FetchRoutes(_ context.Context, req *v2.DiscoveryRequest) (*v2.DiscoveryResponse, error) {
-	return s.fetch(req)
+	return nil, status.Errorf(codes.Unimplemented, "FetchRoutes unimplemented")
 }
 
 func (s *grpcServer) FetchSecrets(_ context.Context, req *v2.DiscoveryRequest) (*v2.DiscoveryResponse, error) {
-	return s.fetch(req)
+	return nil, status.Errorf(codes.Unimplemented, "FetchSecrets unimplemented")
 }
 
 func (s *grpcServer) StreamClusters(srv v2.ClusterDiscoveryService_StreamClustersServer) error {

--- a/internal/grpc/server_test.go
+++ b/internal/grpc/server_test.go
@@ -159,46 +159,6 @@ func TestGRPC(t *testing.T) {
 			checkrecv(t, stream)          // check we receive one notification
 			checktimeout(t, stream)       // check that the second receive times out
 		},
-		"FetchClusters": func(t *testing.T, cc *grpc.ClientConn) {
-			sds := v2.NewClusterDiscoveryServiceClient(cc)
-			ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
-			defer cancel()
-			req := &v2.DiscoveryRequest{
-				TypeUrl: clusterType,
-			}
-			_, err := sds.FetchClusters(ctx, req)
-			check(t, err)
-		},
-		"FetchEndpoints": func(t *testing.T, cc *grpc.ClientConn) {
-			eds := v2.NewEndpointDiscoveryServiceClient(cc)
-			ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
-			defer cancel()
-			req := &v2.DiscoveryRequest{
-				TypeUrl: endpointType,
-			}
-			_, err := eds.FetchEndpoints(ctx, req)
-			check(t, err)
-		},
-		"FetchListeners": func(t *testing.T, cc *grpc.ClientConn) {
-			lds := v2.NewListenerDiscoveryServiceClient(cc)
-			ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
-			defer cancel()
-			req := &v2.DiscoveryRequest{
-				TypeUrl: listenerType,
-			}
-			_, err := lds.FetchListeners(ctx, req)
-			check(t, err)
-		},
-		"FetchRoutes": func(t *testing.T, cc *grpc.ClientConn) {
-			rds := v2.NewRouteDiscoveryServiceClient(cc)
-			ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
-			defer cancel()
-			req := &v2.DiscoveryRequest{
-				TypeUrl: routeType,
-			}
-			_, err := rds.FetchRoutes(ctx, req)
-			check(t, err)
-		},
 	}
 
 	log := logrus.New()

--- a/internal/grpc/xds.go
+++ b/internal/grpc/xds.go
@@ -32,22 +32,6 @@ type xdsHandler struct {
 	resources   map[string]resource // registered resource types
 }
 
-// fetch handles a single DiscoveryRequest.
-func (xh *xdsHandler) fetch(req *v2.DiscoveryRequest) (*v2.DiscoveryResponse, error) {
-	xh.WithField("connection", xh.connections.next()).WithField("version_info", req.VersionInfo).WithField("resource_names", req.ResourceNames).WithField("type_url", req.TypeUrl).WithField("response_nonce", req.ResponseNonce).WithField("error_detail", req.ErrorDetail).Info("fetch")
-	r, ok := xh.resources[req.TypeUrl]
-	if !ok {
-		return nil, fmt.Errorf("no resource registered for typeURL %q", req.TypeUrl)
-	}
-	resources, err := toAny(r, toFilter(req.ResourceNames))
-	return &v2.DiscoveryResponse{
-		VersionInfo: "0",
-		Resources:   resources,
-		TypeUrl:     r.TypeURL(),
-		Nonce:       "0",
-	}, err
-}
-
 type grpcStream interface {
 	Context() context.Context
 	Send(*v2.DiscoveryResponse) error

--- a/internal/grpc/xds_test.go
+++ b/internal/grpc/xds_test.go
@@ -26,46 +26,6 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-func TestXDSHandlerFetch(t *testing.T) {
-	log := logrus.New()
-	log.SetOutput(ioutil.Discard)
-	tests := map[string]struct {
-		xh   xdsHandler
-		req  *v2.DiscoveryRequest
-		want error
-	}{
-		"no registered typeURL": {
-			xh:   xdsHandler{FieldLogger: log},
-			req:  &v2.DiscoveryRequest{TypeUrl: "com.heptio.potato"},
-			want: fmt.Errorf("no resource registered for typeURL %q", "com.heptio.potato"),
-		},
-		"failed to convert values to any": {
-			xh: xdsHandler{
-				FieldLogger: log,
-				resources: map[string]resource{
-					"com.heptio.potato": &mockResource{
-						values: func(fn func(string) bool) []proto.Message {
-							return []proto.Message{nil}
-						},
-						typeurl: func() string { return "com.heptio.potato" },
-					},
-				},
-			},
-			req:  &v2.DiscoveryRequest{TypeUrl: "com.heptio.potato"},
-			want: fmt.Errorf("proto: Marshal called with nil"),
-		},
-	}
-
-	for name, tc := range tests {
-		t.Run(name, func(t *testing.T) {
-			_, got := tc.xh.fetch(tc.req)
-			if !equalError(tc.want, got) {
-				t.Fatalf("expected: %v, got: %v", tc.want, got)
-			}
-		})
-	}
-}
-
 func TestXDSHandlerStream(t *testing.T) {
 	log := logrus.New()
 	log.SetOutput(ioutil.Discard)


### PR DESCRIPTION
Fixes #1060
Updates #1091

Fetch is never used by Envoy, but supporting it (poorly) in Contour
complicates helpers and streaming code. Remove Fetch support to
facilitate rewriting the EDS streaming code to address #1091.

Signed-off-by: Dave Cheney <dave@cheney.net>