### PR TITLE
internal/grpc: move TypeURL into internal/contour

### DIFF
--- a/cmd/contour/contour.go
+++ b/cmd/contour/contour.go
@@ -218,22 +218,12 @@ func main() {
 				return err
 			}
 
-			// Resource types in xDS v2.
-			const (
-				googleApis   = "type.googleapis.com/"
-				typePrefix   = googleApis + "envoy.api.v2."
-				endpointType = typePrefix + "ClusterLoadAssignment"
-				clusterType  = typePrefix + "Cluster"
-				routeType    = typePrefix + "RouteConfiguration"
-				listenerType = typePrefix + "Listener"
-				secretType   = typePrefix + "auth.Secret"
-			)
-			s := grpc.NewAPI(log, map[string]grpc.Cache{
-				clusterType:  &ch.ClusterCache,
-				routeType:    &ch.RouteCache,
-				listenerType: &ch.ListenerCache,
-				endpointType: et,
-				secretType:   &ch.SecretCache,
+			s := grpc.NewAPI(log, map[string]grpc.Resource{
+				ch.ClusterCache.TypeURL():  &ch.ClusterCache,
+				ch.RouteCache.TypeURL():    &ch.RouteCache,
+				ch.ListenerCache.TypeURL(): &ch.ListenerCache,
+				et.TypeURL():               et,
+				ch.SecretCache.TypeURL():   &ch.SecretCache,
 			})
 			log.Println("started")
 			defer log.Println("stopped")

--- a/internal/contour/cluster.go
+++ b/internal/contour/cluster.go
@@ -82,6 +82,8 @@ func (c *ClusterCache) Values(filter func(string) bool) []proto.Message {
 	return values
 }
 
+func (*ClusterCache) TypeURL() string { return clusterType }
+
 type clusterVisitor struct {
 	clusters map[string]*v2.Cluster
 }

--- a/internal/contour/endpointstranslator.go
+++ b/internal/contour/endpointstranslator.go
@@ -67,6 +67,8 @@ func (e *EndpointsTranslator) OnDelete(obj interface{}) {
 	}
 }
 
+func (*EndpointsTranslator) TypeURL() string { return endpointType }
+
 func (e *EndpointsTranslator) addEndpoints(ep *v1.Endpoints) {
 	e.recomputeClusterLoadAssignment(nil, ep)
 }

--- a/internal/contour/listener.go
+++ b/internal/contour/listener.go
@@ -195,6 +195,8 @@ func (c *ListenerCache) Values(filter func(string) bool) []proto.Message {
 	return values
 }
 
+func (*ListenerCache) TypeURL() string { return listenerType }
+
 type listenerVisitor struct {
 	*ListenerVisitorConfig
 

--- a/internal/contour/route.go
+++ b/internal/contour/route.go
@@ -85,6 +85,8 @@ func (c *RouteCache) Values(filter func(string) bool) []proto.Message {
 	return values
 }
 
+func (*RouteCache) TypeURL() string { return routeType }
+
 type routeVisitor struct {
 	routes map[string]*v2.RouteConfiguration
 }

--- a/internal/contour/secret.go
+++ b/internal/contour/secret.go
@@ -82,6 +82,8 @@ func (c *SecretCache) Values(filter func(string) bool) []proto.Message {
 	return values
 }
 
+func (*SecretCache) TypeURL() string { return secretType }
+
 type secretVisitor struct {
 	secrets map[string]*auth.Secret
 }

--- a/internal/contour/xds.go
+++ b/internal/contour/xds.go
@@ -1,0 +1,27 @@
+// Copyright © 2019 Heptio
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package contour
+
+import _cache "github.com/envoyproxy/go-control-plane/pkg/cache"
+
+// TODO(dfc) these are repeated here because this package declares a type
+// called cache. Rather than renaming the import across five other files
+// we do so here to make things simpler. Ideally this wouldn't be necessary.
+const (
+	endpointType = _cache.EndpointType
+	clusterType  = _cache.ClusterType
+	routeType    = _cache.RouteType
+	listenerType = _cache.ListenerType
+	secretType   = _cache.SecretType
+)

--- a/internal/e2e/e2e.go
+++ b/internal/e2e/e2e.go
@@ -92,11 +92,11 @@ func setup(t *testing.T, opts ...func(*contour.ResourceEventHandler)) (cache.Res
 	discard := logrus.New()
 	discard.Out = new(discardWriter)
 	// Resource types in xDS v2.
-	srv := cgrpc.NewAPI(discard, map[string]cgrpc.Cache{
-		clusterType:  &ch.ClusterCache,
-		routeType:    &ch.RouteCache,
-		listenerType: &ch.ListenerCache,
-		endpointType: et,
+	srv := cgrpc.NewAPI(discard, map[string]cgrpc.Resource{
+		ch.ClusterCache.TypeURL():  &ch.ClusterCache,
+		ch.RouteCache.TypeURL():    &ch.RouteCache,
+		ch.ListenerCache.TypeURL(): &ch.ListenerCache,
+		et.TypeURL():               et,
 	})
 
 	done := make(chan error, 1)

--- a/internal/grpc/resources.go
+++ b/internal/grpc/resources.go
@@ -22,11 +22,11 @@ import (
 	"github.com/gogo/protobuf/proto"
 )
 
-// cache represents a source of proto.Message valus that can be registered
+// Resource represents a source of proto.Messages that can be registered
 // for interest.
-type Cache interface {
+type Resource interface {
 	// Values returns a slice of proto.Message implementations that match
-	// the provided filter.
+	// the filter function.
 	Values(func(string) bool) []proto.Message
 
 	// Register registers ch to receive a value when Notify is called.
@@ -38,12 +38,12 @@ type Cache interface {
 
 // CDS implements the CDS v2 gRPC API.
 type CDS struct {
-	Cache
+	Resource
 }
 
 // Values returns a sorted list of Clusters.
 func (c *CDS) Values(filter func(string) bool) []proto.Message {
-	v := c.Cache.Values(filter)
+	v := c.Resource.Values(filter)
 	sort.Stable(clusterByName(v))
 	return v
 }
@@ -56,12 +56,12 @@ func (c clusterByName) Less(i, j int) bool { return c[i].(*v2.Cluster).Name < c[
 
 // EDS implements the EDS v2 gRPC API.
 type EDS struct {
-	Cache
+	Resource
 }
 
 // Values returns a sorted list of ClusterLoadAssignments.
 func (e *EDS) Values(filter func(string) bool) []proto.Message {
-	v := e.Cache.Values(filter)
+	v := e.Resource.Values(filter)
 	sort.Stable(clusterLoadAssignmentsByName(v))
 	return v
 }
@@ -76,12 +76,12 @@ func (c clusterLoadAssignmentsByName) Less(i, j int) bool {
 
 // LDS implements the LDS v2 gRPC API.
 type LDS struct {
-	Cache
+	Resource
 }
 
 // Values returns a sorted list of Listeners.
 func (l *LDS) Values(filter func(string) bool) []proto.Message {
-	v := l.Cache.Values(filter)
+	v := l.Resource.Values(filter)
 	sort.Stable(listenersByName(v))
 	return v
 }
@@ -96,12 +96,12 @@ func (l listenersByName) Less(i, j int) bool {
 
 // RDS implements the RDS v2 gRPC API.
 type RDS struct {
-	Cache
+	Resource
 }
 
 // Values returns a sorted list of RouteConfigurations.
 func (r *RDS) Values(filter func(string) bool) []proto.Message {
-	v := r.Cache.Values(filter)
+	v := r.Resource.Values(filter)
 	sort.Stable(routeConfigurationsByName(v))
 	return v
 }
@@ -114,14 +114,14 @@ func (r routeConfigurationsByName) Less(i, j int) bool {
 	return r[i].(*v2.RouteConfiguration).Name < r[j].(*v2.RouteConfiguration).Name
 }
 
-// SDS implements the RDS v2 gRPC API.
+// SDS implements the SDS v2 gRPC API.
 type SDS struct {
-	Cache
+	Resource
 }
 
 // Values returns a sorted list of RouteConfigurations.
 func (s *SDS) Values(filter func(string) bool) []proto.Message {
-	v := s.Cache.Values(filter)
+	v := s.Resource.Values(filter)
 	sort.Stable(secretsByName(v))
 	return v
 }

--- a/internal/grpc/resources.go
+++ b/internal/grpc/resources.go
@@ -18,17 +18,8 @@ import (
 
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2/auth"
-	"github.com/envoyproxy/go-control-plane/pkg/cache"
 
 	"github.com/gogo/protobuf/proto"
-)
-
-const (
-	endpointType = cache.EndpointType
-	clusterType  = cache.ClusterType
-	routeType    = cache.RouteType
-	listenerType = cache.ListenerType
-	secretType   = cache.SecretType
 )
 
 // cache represents a source of proto.Message valus that can be registered
@@ -40,6 +31,9 @@ type Cache interface {
 
 	// Register registers ch to receive a value when Notify is called.
 	Register(chan int, int)
+
+	// TypeURL returns the typeURL of messages returned from Values.
+	TypeURL() string
 }
 
 // CDS implements the CDS v2 gRPC API.
@@ -53,8 +47,6 @@ func (c *CDS) Values(filter func(string) bool) []proto.Message {
 	sort.Stable(clusterByName(v))
 	return v
 }
-
-func (c *CDS) TypeURL() string { return clusterType }
 
 type clusterByName []proto.Message
 
@@ -73,8 +65,6 @@ func (e *EDS) Values(filter func(string) bool) []proto.Message {
 	sort.Stable(clusterLoadAssignmentsByName(v))
 	return v
 }
-
-func (e *EDS) TypeURL() string { return endpointType }
 
 type clusterLoadAssignmentsByName []proto.Message
 
@@ -96,8 +86,6 @@ func (l *LDS) Values(filter func(string) bool) []proto.Message {
 	return v
 }
 
-func (l *LDS) TypeURL() string { return listenerType }
-
 type listenersByName []proto.Message
 
 func (l listenersByName) Len() int      { return len(l) }
@@ -118,8 +106,6 @@ func (r *RDS) Values(filter func(string) bool) []proto.Message {
 	return v
 }
 
-func (r *RDS) TypeURL() string { return routeType }
-
 type routeConfigurationsByName []proto.Message
 
 func (r routeConfigurationsByName) Len() int      { return len(r) }
@@ -139,8 +125,6 @@ func (s *SDS) Values(filter func(string) bool) []proto.Message {
 	sort.Stable(secretsByName(v))
 	return v
 }
-
-func (s *SDS) TypeURL() string { return secretType }
 
 type secretsByName []proto.Message
 

--- a/internal/grpc/server.go
+++ b/internal/grpc/server.go
@@ -22,6 +22,7 @@ import (
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v2"
 	loadstats "github.com/envoyproxy/go-control-plane/envoy/service/load_stats/v2"
+	"github.com/envoyproxy/go-control-plane/pkg/cache"
 	"github.com/sirupsen/logrus"
 )
 
@@ -46,20 +47,20 @@ func NewAPI(log logrus.FieldLogger, cacheMap map[string]Cache) *grpc.Server {
 		xdsHandler{
 			FieldLogger: log,
 			resources: map[string]resource{
-				clusterType: &CDS{
-					Cache: cacheMap[clusterType],
+				cache.ClusterType: &CDS{
+					Cache: cacheMap[cache.ClusterType],
 				},
-				endpointType: &EDS{
-					Cache: cacheMap[endpointType],
+				cache.EndpointType: &EDS{
+					Cache: cacheMap[cache.EndpointType],
 				},
-				listenerType: &LDS{
-					Cache: cacheMap[listenerType],
+				cache.ListenerType: &LDS{
+					Cache: cacheMap[cache.ListenerType],
 				},
-				routeType: &RDS{
-					Cache: cacheMap[routeType],
+				cache.RouteType: &RDS{
+					Cache: cacheMap[cache.RouteType],
 				},
-				secretType: &SDS{
-					Cache: cacheMap[secretType],
+				cache.SecretType: &SDS{
+					Cache: cacheMap[cache.SecretType],
 				},
 			},
 		},
@@ -81,9 +82,6 @@ type grpcServer struct {
 // A resource provides resources formatted as []types.Any.
 type resource interface {
 	Cache
-
-	// TypeURL returns the typeURL of messages returned from Values.
-	TypeURL() string
 }
 
 func (s *grpcServer) FetchClusters(_ context.Context, req *v2.DiscoveryRequest) (*v2.DiscoveryResponse, error) {

--- a/internal/grpc/server.go
+++ b/internal/grpc/server.go
@@ -32,7 +32,7 @@ const (
 )
 
 // NewAPI returns a *grpc.Server which responds to the Envoy v2 xDS gRPC API.
-func NewAPI(log logrus.FieldLogger, cacheMap map[string]Cache) *grpc.Server {
+func NewAPI(log logrus.FieldLogger, resources map[string]Resource) *grpc.Server {
 	opts := []grpc.ServerOption{
 		// By default the Go grpc library defaults to a value of ~100 streams per
 		// connection. This number is likely derived from the HTTP/2 spec:
@@ -46,21 +46,21 @@ func NewAPI(log logrus.FieldLogger, cacheMap map[string]Cache) *grpc.Server {
 	s := &grpcServer{
 		xdsHandler{
 			FieldLogger: log,
-			resources: map[string]Cache{
+			resources: map[string]Resource{
 				cache.ClusterType: &CDS{
-					Cache: cacheMap[cache.ClusterType],
+					Resource: resources[cache.ClusterType],
 				},
 				cache.EndpointType: &EDS{
-					Cache: cacheMap[cache.EndpointType],
+					Resource: resources[cache.EndpointType],
 				},
 				cache.ListenerType: &LDS{
-					Cache: cacheMap[cache.ListenerType],
+					Resource: resources[cache.ListenerType],
 				},
 				cache.RouteType: &RDS{
-					Cache: cacheMap[cache.RouteType],
+					Resource: resources[cache.RouteType],
 				},
 				cache.SecretType: &SDS{
-					Cache: cacheMap[cache.SecretType],
+					Resource: resources[cache.SecretType],
 				},
 			},
 		},

--- a/internal/grpc/server.go
+++ b/internal/grpc/server.go
@@ -46,7 +46,7 @@ func NewAPI(log logrus.FieldLogger, cacheMap map[string]Cache) *grpc.Server {
 	s := &grpcServer{
 		xdsHandler{
 			FieldLogger: log,
-			resources: map[string]resource{
+			resources: map[string]Cache{
 				cache.ClusterType: &CDS{
 					Cache: cacheMap[cache.ClusterType],
 				},
@@ -77,11 +77,6 @@ func NewAPI(log logrus.FieldLogger, cacheMap map[string]Cache) *grpc.Server {
 // grpcServer implements the LDS, RDS, CDS, and EDS, gRPC endpoints.
 type grpcServer struct {
 	xdsHandler
-}
-
-// A resource provides resources formatted as []types.Any.
-type resource interface {
-	Cache
 }
 
 func (s *grpcServer) FetchClusters(_ context.Context, req *v2.DiscoveryRequest) (*v2.DiscoveryResponse, error) {

--- a/internal/grpc/server_test.go
+++ b/internal/grpc/server_test.go
@@ -199,7 +199,7 @@ func TestGRPC(t *testing.T) {
 				Metrics:     ch.Metrics,
 				FieldLogger: log,
 			}
-			srv := NewAPI(log, map[string]Cache{
+			srv := NewAPI(log, map[string]Resource{
 				ch.ClusterCache.TypeURL():  &ch.ClusterCache,
 				ch.RouteCache.TypeURL():    &ch.RouteCache,
 				ch.ListenerCache.TypeURL(): &ch.ListenerCache,

--- a/internal/grpc/server_test.go
+++ b/internal/grpc/server_test.go
@@ -21,6 +21,8 @@ import (
 	"time"
 
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2"
+	discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v2"
+	"github.com/envoyproxy/go-control-plane/pkg/cache"
 	"github.com/heptio/contour/internal/contour"
 	"github.com/heptio/contour/internal/metrics"
 	"github.com/prometheus/client_golang/prometheus"
@@ -63,9 +65,9 @@ func TestGRPC(t *testing.T) {
 			defer cancel()
 			stream, err := sds.StreamClusters(ctx)
 			check(t, err)
-			sendreq(t, stream, clusterType) // send initial notification
-			checkrecv(t, stream)            // check we receive one notification
-			checktimeout(t, stream)         // check that the second receive times out
+			sendreq(t, stream, cache.ClusterType) // send initial notification
+			checkrecv(t, stream)                  // check we receive one notification
+			checktimeout(t, stream)               // check that the second receive times out
 		},
 		"StreamEndpoints": func(t *testing.T, cc *grpc.ClientConn) {
 			et.OnAdd(&v1.Endpoints{
@@ -90,9 +92,9 @@ func TestGRPC(t *testing.T) {
 			defer cancel()
 			stream, err := eds.StreamEndpoints(ctx)
 			check(t, err)
-			sendreq(t, stream, endpointType) // send initial notification
-			checkrecv(t, stream)             // check we receive one notification
-			checktimeout(t, stream)          // check that the second receive times out
+			sendreq(t, stream, cache.EndpointType) // send initial notification
+			checkrecv(t, stream)                   // check we receive one notification
+			checktimeout(t, stream)                // check that the second receive times out
 		},
 		"StreamListeners": func(t *testing.T, cc *grpc.ClientConn) {
 			// add an ingress, which will create a non tls listener
@@ -123,9 +125,9 @@ func TestGRPC(t *testing.T) {
 			defer cancel()
 			stream, err := lds.StreamListeners(ctx)
 			check(t, err)
-			sendreq(t, stream, listenerType) // send initial notification
-			checkrecv(t, stream)             // check we receive one notification
-			checktimeout(t, stream)          // check that the second receive times out
+			sendreq(t, stream, cache.ListenerType) // send initial notification
+			checkrecv(t, stream)                   // check we receive one notification
+			checktimeout(t, stream)                // check that the second receive times out
 		},
 		"StreamRoutes": func(t *testing.T, cc *grpc.ClientConn) {
 			reh.OnAdd(&v1beta1.Ingress{
@@ -155,9 +157,30 @@ func TestGRPC(t *testing.T) {
 			defer cancel()
 			stream, err := rds.StreamRoutes(ctx)
 			check(t, err)
-			sendreq(t, stream, routeType) // send initial notification
-			checkrecv(t, stream)          // check we receive one notification
-			checktimeout(t, stream)       // check that the second receive times out
+			sendreq(t, stream, cache.RouteType) // send initial notification
+			checkrecv(t, stream)                // check we receive one notification
+			checktimeout(t, stream)             // check that the second receive times out
+		},
+		"StreamSecrets": func(t *testing.T, cc *grpc.ClientConn) {
+			reh.OnAdd(&v1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "secret",
+					Namespace: "default",
+				},
+				Data: map[string][]byte{
+					v1.TLSCertKey:       []byte("certificate"),
+					v1.TLSPrivateKeyKey: []byte("key"),
+				},
+			})
+
+			sds := discovery.NewSecretDiscoveryServiceClient(cc)
+			ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+			defer cancel()
+			stream, err := sds.StreamSecrets(ctx)
+			check(t, err)
+			sendreq(t, stream, cache.SecretType) // send initial notification
+			checkrecv(t, stream)                 // check we receive one notification
+			checktimeout(t, stream)              // check that the second receive times out
 		},
 	}
 
@@ -177,10 +200,11 @@ func TestGRPC(t *testing.T) {
 				FieldLogger: log,
 			}
 			srv := NewAPI(log, map[string]Cache{
-				clusterType:  &ch.ClusterCache,
-				routeType:    &ch.RouteCache,
-				listenerType: &ch.ListenerCache,
-				endpointType: et,
+				ch.ClusterCache.TypeURL():  &ch.ClusterCache,
+				ch.RouteCache.TypeURL():    &ch.RouteCache,
+				ch.ListenerCache.TypeURL(): &ch.ListenerCache,
+				ch.SecretCache.TypeURL():   &ch.SecretCache,
+				et.TypeURL():               et,
 			})
 			l, err := net.Listen("tcp", "127.0.0.1:0")
 			check(t, err)

--- a/internal/grpc/xds.go
+++ b/internal/grpc/xds.go
@@ -29,7 +29,7 @@ import (
 type xdsHandler struct {
 	logrus.FieldLogger
 	connections counter
-	resources   map[string]resource // registered resource types
+	resources   map[string]Cache // registered resource types
 }
 
 type grpcStream interface {
@@ -122,7 +122,7 @@ func (xh *xdsHandler) stream(st grpcStream) (err error) {
 
 // toAny converts the contents of a resourcer's Values to the
 // respective slice of types.Any.
-func toAny(res resource, filter func(string) bool) ([]types.Any, error) {
+func toAny(res Cache, filter func(string) bool) ([]types.Any, error) {
 	v := res.Values(filter)
 	resources := make([]types.Any, len(v))
 	for i := range v {

--- a/internal/grpc/xds.go
+++ b/internal/grpc/xds.go
@@ -29,7 +29,7 @@ import (
 type xdsHandler struct {
 	logrus.FieldLogger
 	connections counter
-	resources   map[string]Cache // registered resource types
+	resources   map[string]Resource // registered resource types
 }
 
 type grpcStream interface {
@@ -122,7 +122,7 @@ func (xh *xdsHandler) stream(st grpcStream) (err error) {
 
 // toAny converts the contents of a resourcer's Values to the
 // respective slice of types.Any.
-func toAny(res Cache, filter func(string) bool) ([]types.Any, error) {
+func toAny(res Resource, filter func(string) bool) ([]types.Any, error) {
 	v := res.Values(filter)
 	resources := make([]types.Any, len(v))
 	for i := range v {

--- a/internal/grpc/xds_test.go
+++ b/internal/grpc/xds_test.go
@@ -59,7 +59,7 @@ func TestXDSHandlerStream(t *testing.T) {
 		"failed to convert values to any": {
 			xh: xdsHandler{
 				FieldLogger: log,
-				resources: map[string]resource{
+				resources: map[string]Cache{
 					"com.heptio.potato": &mockResource{
 						register: func(ch chan int, i int) {
 							ch <- i + 1
@@ -83,7 +83,7 @@ func TestXDSHandlerStream(t *testing.T) {
 		"failed to send": {
 			xh: xdsHandler{
 				FieldLogger: log,
-				resources: map[string]resource{
+				resources: map[string]Cache{
 					"com.heptio.potato": &mockResource{
 						register: func(ch chan int, i int) {
 							ch <- i + 1
@@ -111,7 +111,7 @@ func TestXDSHandlerStream(t *testing.T) {
 		"context canceled": {
 			xh: xdsHandler{
 				FieldLogger: log,
-				resources: map[string]resource{
+				resources: map[string]Cache{
 					"com.heptio.potato": &mockResource{
 						register: func(ch chan int, i int) {
 							// do nothing

--- a/internal/grpc/xds_test.go
+++ b/internal/grpc/xds_test.go
@@ -59,7 +59,7 @@ func TestXDSHandlerStream(t *testing.T) {
 		"failed to convert values to any": {
 			xh: xdsHandler{
 				FieldLogger: log,
-				resources: map[string]Cache{
+				resources: map[string]Resource{
 					"com.heptio.potato": &mockResource{
 						register: func(ch chan int, i int) {
 							ch <- i + 1
@@ -83,7 +83,7 @@ func TestXDSHandlerStream(t *testing.T) {
 		"failed to send": {
 			xh: xdsHandler{
 				FieldLogger: log,
-				resources: map[string]Cache{
+				resources: map[string]Resource{
 					"com.heptio.potato": &mockResource{
 						register: func(ch chan int, i int) {
 							ch <- i + 1
@@ -111,7 +111,7 @@ func TestXDSHandlerStream(t *testing.T) {
 		"context canceled": {
 			xh: xdsHandler{
 				FieldLogger: log,
-				resources: map[string]Cache{
+				resources: map[string]Resource{
 					"com.heptio.potato": &mockResource{
 						register: func(ch chan int, i int) {
 							// do nothing


### PR DESCRIPTION
Updates #1091

To convert a proto.Message to a proto.Any you need to know its declared
type (not Go type, protobuf type). Previously this was handled by the
CDS/EDS/RDS/etc types in internal/grpc, but this isn't very useful as
those types are tightly coupled to the values that are sourced from
internal/contour. Thus splitting the type that declares TypeURL and the
type that provides proto.Messages of those types permits things to be
constructed inconsistently. With this change the thing that provides
proto.Message values, via the Values() method, also provides a TypeURL
method to describe the type of the things provided by Values.

Also, add missing StreamSecret test case.

Signed-off-by: Dave Cheney <dave@cheney.net>