### PR TITLE
internal/{grpc,contour}: EDS always returns a value

### DIFF
--- a/internal/contour/cluster.go
+++ b/internal/contour/cluster.go
@@ -88,13 +88,14 @@ func (c *ClusterCache) Query(names []string) []proto.Message {
 	defer c.mu.Unlock()
 	var values []proto.Message
 	for _, n := range names {
-		v, ok := c.values[n]
-		if !ok {
-			v = &v2.Cluster{
-				Name: n,
-			}
+		// if the cluster is not registered we cannot return
+		// a blank cluster because each cluster has a required
+		// discovery type; DNS, EDS, etc. We cannot determine the
+		// correct value for this property from the cluster's name
+		// provided by the query so we must not return a blank cluster.
+		if v, ok := c.values[n]; ok {
+			values = append(values, v)
 		}
-		values = append(values, v)
 	}
 	sort.Stable(clusterByName(values))
 	return values

--- a/internal/contour/contour_test.go
+++ b/internal/contour/contour_test.go
@@ -16,10 +16,9 @@ package contour
 import (
 	"testing"
 
-	"github.com/gogo/protobuf/proto"
 	"github.com/heptio/contour/internal/dag"
 	"github.com/sirupsen/logrus"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -36,12 +35,6 @@ type testWriter struct {
 func (t *testWriter) Write(buf []byte) (int, error) {
 	t.Logf("%s", buf)
 	return len(buf), nil
-}
-
-func contents(v interface {
-	Values(func(string) bool) []proto.Message
-}) []proto.Message {
-	return v.Values(func(string) bool { return true })
 }
 
 func endpoints(ns, name string, subsets ...v1.EndpointSubset) *v1.Endpoints {

--- a/internal/contour/endpointstranslator.go
+++ b/internal/contour/endpointstranslator.go
@@ -90,6 +90,7 @@ func (e *EndpointsTranslator) Query(names []string) []proto.Message {
 		}
 		values = append(values, v)
 	}
+	sort.Stable(clusterLoadAssignmentsByName(values))
 	return values
 }
 

--- a/internal/contour/endpointstranslator.go
+++ b/internal/contour/endpointstranslator.go
@@ -71,9 +71,25 @@ func (e *EndpointsTranslator) OnDelete(obj interface{}) {
 	}
 }
 
-func (e *EndpointsTranslator) Values(filter func(string) bool) []proto.Message {
-	values := e.clusterLoadAssignmentCache.Values(filter)
+func (e *EndpointsTranslator) Contents() []proto.Message {
+	values := e.clusterLoadAssignmentCache.Contents()
 	sort.Stable(clusterLoadAssignmentsByName(values))
+	return values
+}
+
+func (e *EndpointsTranslator) Query(names []string) []proto.Message {
+	e.clusterLoadAssignmentCache.mu.Lock()
+	defer e.clusterLoadAssignmentCache.mu.Unlock()
+	var values []proto.Message
+	for _, n := range names {
+		v, ok := e.entries[n]
+		if !ok {
+			v = &v2.ClusterLoadAssignment{
+				ClusterName: n,
+			}
+		}
+		values = append(values, v)
+	}
 	return values
 }
 
@@ -201,16 +217,14 @@ func (c *clusterLoadAssignmentCache) Remove(name string) {
 	delete(c.entries, name)
 }
 
-// Values returns a slice of the value stored in the cache.
-func (c *clusterLoadAssignmentCache) Values(filter func(string) bool) []proto.Message {
+// Contents returns a copy of the contents of the cache.
+func (c *clusterLoadAssignmentCache) Contents() []proto.Message {
 	c.mu.Lock()
-	values := make([]proto.Message, 0, len(c.entries))
-	for n, v := range c.entries {
-		if filter(n) {
-			values = append(values, v)
-		}
+	defer c.mu.Unlock()
+	var values []proto.Message
+	for _, v := range c.entries {
+		values = append(values, v)
 	}
-	c.mu.Unlock()
 	return values
 }
 

--- a/internal/contour/listener.go
+++ b/internal/contour/listener.go
@@ -180,20 +180,29 @@ func (c *ListenerCache) notify() {
 	c.waiters = c.waiters[:0]
 }
 
-// Values returns a slice of the value stored in the cache.
-func (c *ListenerCache) Values(filter func(string) bool) []proto.Message {
+// Contents returns a copy of the cache's contents.
+func (c *ListenerCache) Contents() []proto.Message {
+	return c.contents(func(string) bool { return true })
+}
+
+func (c *ListenerCache) Query(names []string) []proto.Message {
+	return c.contents(tofilter(names))
+}
+
+func (c *ListenerCache) contents(filter func(string) bool) []proto.Message {
 	c.mu.Lock()
-	values := make([]proto.Message, 0, len(c.values))
+	defer c.mu.Unlock()
+	var values []proto.Message
 	for _, v := range c.values {
 		if filter(v.Name) {
 			values = append(values, v)
 		}
 	}
 	for _, v := range c.staticValues {
-		values = append(values, v)
+		if filter(v.Name) {
+			values = append(values, v)
+		}
 	}
-
-	c.mu.Unlock()
 	sort.Stable(listenersByName(values))
 	return values
 }

--- a/internal/contour/listener.go
+++ b/internal/contour/listener.go
@@ -204,9 +204,12 @@ func (c *ListenerCache) Query(names []string) []proto.Message {
 		if !ok {
 			v, ok = c.staticValues[n]
 			if !ok {
-				v = &v2.Listener{
-					Name: n,
-				}
+				// if the listener is not registered in
+				// dynamic or static values then skip it
+				// as there is no way to return a blank
+				// listener because the listener address
+				// field is required.
+				continue
 			}
 		}
 		values = append(values, v)

--- a/internal/contour/listener.go
+++ b/internal/contour/listener.go
@@ -182,26 +182,34 @@ func (c *ListenerCache) notify() {
 
 // Contents returns a copy of the cache's contents.
 func (c *ListenerCache) Contents() []proto.Message {
-	return c.contents(func(string) bool { return true })
-}
-
-func (c *ListenerCache) Query(names []string) []proto.Message {
-	return c.contents(tofilter(names))
-}
-
-func (c *ListenerCache) contents(filter func(string) bool) []proto.Message {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	var values []proto.Message
 	for _, v := range c.values {
-		if filter(v.Name) {
-			values = append(values, v)
-		}
+		values = append(values, v)
 	}
 	for _, v := range c.staticValues {
-		if filter(v.Name) {
-			values = append(values, v)
+		values = append(values, v)
+	}
+	sort.Stable(listenersByName(values))
+	return values
+}
+
+func (c *ListenerCache) Query(names []string) []proto.Message {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	var values []proto.Message
+	for _, n := range names {
+		v, ok := c.values[n]
+		if !ok {
+			v, ok = c.staticValues[n]
+			if !ok {
+				v = &v2.Listener{
+					Name: n,
+				}
+			}
 		}
+		values = append(values, v)
 	}
 	sort.Stable(listenersByName(values))
 	return values

--- a/internal/contour/route.go
+++ b/internal/contour/route.go
@@ -92,6 +92,11 @@ func (c *RouteCache) Query(names []string) []proto.Message {
 	for _, n := range names {
 		v, ok := c.values[n]
 		if !ok {
+			// if there is no route registered with the cache
+			// we return a blank route configuration. This is
+			// not the same as returning nil, we're choosing to
+			// say "the configuration you asked for _does exists_,
+			// but it contains no useful information.
 			v = &v2.RouteConfiguration{
 				Name: n,
 			}

--- a/internal/contour/route.go
+++ b/internal/contour/route.go
@@ -73,16 +73,24 @@ func (c *RouteCache) notify() {
 	c.waiters = c.waiters[:0]
 }
 
-// Values returns a slice of the value stored in the cache.
-func (c *RouteCache) Values(filter func(string) bool) []proto.Message {
+// Contents returns a copy of the cache's contents.
+func (c *RouteCache) Contents() []proto.Message {
+	return c.contents(func(string) bool { return true })
+}
+
+func (c *RouteCache) Query(names []string) []proto.Message {
+	return c.contents(tofilter(names))
+}
+
+func (c *RouteCache) contents(filter func(string) bool) []proto.Message {
 	c.mu.Lock()
-	values := make([]proto.Message, 0, len(c.values))
+	defer c.mu.Unlock()
+	var values []proto.Message
 	for _, v := range c.values {
 		if filter(v.Name) {
 			values = append(values, v)
 		}
 	}
-	c.mu.Unlock()
 	sort.Stable(routeConfigurationsByName(values))
 	return values
 }

--- a/internal/contour/secret.go
+++ b/internal/contour/secret.go
@@ -88,13 +88,12 @@ func (c *SecretCache) Query(names []string) []proto.Message {
 	defer c.mu.Unlock()
 	var values []proto.Message
 	for _, n := range names {
-		v, ok := c.values[n]
-		if !ok {
-			v = &auth.Secret{
-				Name: n,
-			}
+		// we can only return secrets where their value is
+		// known. if the secret is not registered in the cache
+		// we return nothing.
+		if v, ok := c.values[n]; ok {
+			values = append(values, v)
 		}
-		values = append(values, v)
 	}
 	sort.Stable(secretsByName(values))
 	return values

--- a/internal/contour/secret_test.go
+++ b/internal/contour/secret_test.go
@@ -6,14 +6,93 @@ import (
 
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2/auth"
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
+	"github.com/gogo/protobuf/proto"
+	"github.com/google/go-cmp/cmp"
 	ingressroutev1 "github.com/heptio/contour/apis/contour/v1beta1"
 	"github.com/heptio/contour/internal/metrics"
 	"github.com/prometheus/client_golang/prometheus"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/api/extensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
+
+func TestSecretContents(t *testing.T) {
+	tests := map[string]struct {
+		contents map[string]*auth.Secret
+		want     []proto.Message
+	}{
+		"empty": {
+			contents: nil,
+			want:     nil,
+		},
+		"simple": {
+			contents: secretmap(
+				secret("default/secret/cd1b506996", "cert", "key"),
+			),
+			want: []proto.Message{
+				secret("default/secret/cd1b506996", "cert", "key"),
+			},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			var sc SecretCache
+			sc.Update(tc.contents)
+			got := sc.Contents()
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Fatal(diff)
+			}
+		})
+	}
+}
+
+func TestSecretQuery(t *testing.T) {
+	tests := map[string]struct {
+		contents map[string]*auth.Secret
+		query    []string
+		want     []proto.Message
+	}{
+		"exact match": {
+			contents: secretmap(
+				secret("default/secret/cd1b506996", "cert", "key"),
+			),
+			query: []string{"default/secret/cd1b506996"},
+			want: []proto.Message{
+				secret("default/secret/cd1b506996", "cert", "key"),
+			},
+		},
+		"partial match": {
+			contents: secretmap(
+				secret("default/secret-a/ff2a9f58ca", "cert-a", "key-a"),
+				secret("default/secret-b/0a068be4ba", "cert-b", "key-b"),
+			),
+			query: []string{"default/secret/cd1b506996", "default/secret-b/0a068be4ba"},
+			want: []proto.Message{
+				secret("default/secret-b/0a068be4ba", "cert-b", "key-b"),
+			},
+		},
+		"no match": {
+			contents: secretmap(
+				secret("default/secret/cd1b506996", "cert", "key"),
+			),
+			query: []string{"default/secret-b/0a068be4ba"},
+			want:  nil,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			var sc SecretCache
+			sc.Update(tc.contents)
+			got := sc.Query(tc.query)
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Fatal(diff)
+			}
+		})
+	}
+}
 
 func TestSecretVisit(t *testing.T) {
 	tests := map[string]struct {
@@ -69,23 +148,9 @@ func TestSecretVisit(t *testing.T) {
 					Data: secretdata("cert", "key"),
 				},
 			},
-			want: secretmap(&auth.Secret{
-				Name: "default/secret/cd1b506996",
-				Type: &auth.Secret_TlsCertificate{
-					TlsCertificate: &auth.TlsCertificate{
-						PrivateKey: &core.DataSource{
-							Specifier: &core.DataSource_InlineBytes{
-								InlineBytes: []byte("key"),
-							},
-						},
-						CertificateChain: &core.DataSource{
-							Specifier: &core.DataSource_InlineBytes{
-								InlineBytes: []byte("cert"),
-							},
-						},
-					},
-				},
-			}),
+			want: secretmap(
+				secret("default/secret/cd1b506996", "cert", "key"),
+			),
 		},
 		"multiple ingresses with shared secret": {
 			objs: []interface{}{
@@ -129,23 +194,9 @@ func TestSecretVisit(t *testing.T) {
 					Data: secretdata("cert", "key"),
 				},
 			},
-			want: secretmap(&auth.Secret{
-				Name: "default/secret/cd1b506996",
-				Type: &auth.Secret_TlsCertificate{
-					TlsCertificate: &auth.TlsCertificate{
-						PrivateKey: &core.DataSource{
-							Specifier: &core.DataSource_InlineBytes{
-								InlineBytes: []byte("key"),
-							},
-						},
-						CertificateChain: &core.DataSource{
-							Specifier: &core.DataSource_InlineBytes{
-								InlineBytes: []byte("cert"),
-							},
-						},
-					},
-				},
-			}),
+			want: secretmap(
+				secret("default/secret/cd1b506996", "cert", "key"),
+			),
 		},
 		"multiple ingresses with different secrets": {
 			objs: []interface{}{
@@ -196,39 +247,10 @@ func TestSecretVisit(t *testing.T) {
 					Data: secretdata("cert-b", "key-b"),
 				},
 			},
-			want: secretmap(&auth.Secret{
-				Name: "default/secret-a/ff2a9f58ca",
-				Type: &auth.Secret_TlsCertificate{
-					TlsCertificate: &auth.TlsCertificate{
-						PrivateKey: &core.DataSource{
-							Specifier: &core.DataSource_InlineBytes{
-								InlineBytes: []byte("key-a"),
-							},
-						},
-						CertificateChain: &core.DataSource{
-							Specifier: &core.DataSource_InlineBytes{
-								InlineBytes: []byte("cert-a"),
-							},
-						},
-					},
-				},
-			}, &auth.Secret{
-				Name: "default/secret-b/0a068be4ba",
-				Type: &auth.Secret_TlsCertificate{
-					TlsCertificate: &auth.TlsCertificate{
-						PrivateKey: &core.DataSource{
-							Specifier: &core.DataSource_InlineBytes{
-								InlineBytes: []byte("key-b"),
-							},
-						},
-						CertificateChain: &core.DataSource{
-							Specifier: &core.DataSource_InlineBytes{
-								InlineBytes: []byte("cert-b"),
-							},
-						},
-					},
-				},
-			}),
+			want: secretmap(
+				secret("default/secret-a/ff2a9f58ca", "cert-a", "key-a"),
+				secret("default/secret-b/0a068be4ba", "cert-b", "key-b"),
+			),
 		},
 		"simple ingressroute with secret": {
 			objs: []interface{}{
@@ -264,23 +286,9 @@ func TestSecretVisit(t *testing.T) {
 					Data: secretdata("cert", "key"),
 				},
 			},
-			want: secretmap(&auth.Secret{
-				Name: "default/secret/cd1b506996",
-				Type: &auth.Secret_TlsCertificate{
-					TlsCertificate: &auth.TlsCertificate{
-						PrivateKey: &core.DataSource{
-							Specifier: &core.DataSource_InlineBytes{
-								InlineBytes: []byte("key"),
-							},
-						},
-						CertificateChain: &core.DataSource{
-							Specifier: &core.DataSource_InlineBytes{
-								InlineBytes: []byte("cert"),
-							},
-						},
-					},
-				},
-			}),
+			want: secretmap(
+				secret("default/secret/cd1b506996", "cert", "key"),
+			),
 		},
 		"multiple ingressroutes with shared secret": {
 			objs: []interface{}{
@@ -340,23 +348,9 @@ func TestSecretVisit(t *testing.T) {
 					Data: secretdata("cert", "key"),
 				},
 			},
-			want: secretmap(&auth.Secret{
-				Name: "default/secret/cd1b506996",
-				Type: &auth.Secret_TlsCertificate{
-					TlsCertificate: &auth.TlsCertificate{
-						PrivateKey: &core.DataSource{
-							Specifier: &core.DataSource_InlineBytes{
-								InlineBytes: []byte("key"),
-							},
-						},
-						CertificateChain: &core.DataSource{
-							Specifier: &core.DataSource_InlineBytes{
-								InlineBytes: []byte("cert"),
-							},
-						},
-					},
-				},
-			}),
+			want: secretmap(
+				secret("default/secret/cd1b506996", "cert", "key"),
+			),
 		},
 		"multiple ingressroutes with different secret": {
 			objs: []interface{}{
@@ -423,39 +417,10 @@ func TestSecretVisit(t *testing.T) {
 					Data: secretdata("cert-b", "key-b"),
 				},
 			},
-			want: secretmap(&auth.Secret{
-				Name: "default/secret-a/ff2a9f58ca",
-				Type: &auth.Secret_TlsCertificate{
-					TlsCertificate: &auth.TlsCertificate{
-						PrivateKey: &core.DataSource{
-							Specifier: &core.DataSource_InlineBytes{
-								InlineBytes: []byte("key-a"),
-							},
-						},
-						CertificateChain: &core.DataSource{
-							Specifier: &core.DataSource_InlineBytes{
-								InlineBytes: []byte("cert-a"),
-							},
-						},
-					},
-				},
-			}, &auth.Secret{
-				Name: "default/secret-b/0a068be4ba",
-				Type: &auth.Secret_TlsCertificate{
-					TlsCertificate: &auth.TlsCertificate{
-						PrivateKey: &core.DataSource{
-							Specifier: &core.DataSource_InlineBytes{
-								InlineBytes: []byte("key-b"),
-							},
-						},
-						CertificateChain: &core.DataSource{
-							Specifier: &core.DataSource_InlineBytes{
-								InlineBytes: []byte("cert-b"),
-							},
-						},
-					},
-				},
-			}),
+			want: secretmap(
+				secret("default/secret-a/ff2a9f58ca", "cert-a", "key-a"),
+				secret("default/secret-b/0a068be4ba", "cert-b", "key-b"),
+			),
 		},
 	}
 
@@ -484,4 +449,24 @@ func secretmap(secrets ...*auth.Secret) map[string]*auth.Secret {
 		m[s.Name] = s
 	}
 	return m
+}
+
+func secret(name, cert, key string) *auth.Secret {
+	return &auth.Secret{
+		Name: name,
+		Type: &auth.Secret_TlsCertificate{
+			TlsCertificate: &auth.TlsCertificate{
+				PrivateKey: &core.DataSource{
+					Specifier: &core.DataSource_InlineBytes{
+						InlineBytes: []byte(key),
+					},
+				},
+				CertificateChain: &core.DataSource{
+					Specifier: &core.DataSource_InlineBytes{
+						InlineBytes: []byte(cert),
+					},
+				},
+			},
+		},
+	}
 }

--- a/internal/contour/secret_test.go
+++ b/internal/contour/secret_test.go
@@ -17,7 +17,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
-func TestSecretContents(t *testing.T) {
+func TestSecretCacheContents(t *testing.T) {
 	tests := map[string]struct {
 		contents map[string]*auth.Secret
 		want     []proto.Message
@@ -48,7 +48,7 @@ func TestSecretContents(t *testing.T) {
 	}
 }
 
-func TestSecretQuery(t *testing.T) {
+func TestSecretCacheQuery(t *testing.T) {
 	tests := map[string]struct {
 		contents map[string]*auth.Secret
 		query    []string

--- a/internal/e2e/cds_test.go
+++ b/internal/e2e/cds_test.go
@@ -467,12 +467,7 @@ func TestCDSResourceFiltering(t *testing.T) {
 	assertEqual(t, &v2.DiscoveryResponse{
 		VersionInfo: "3",
 		TypeUrl:     clusterType,
-		Resources: []types.Any{
-			any(t, &v2.Cluster{
-				Name: "default/httpbin/9000",
-			}),
-		},
-		Nonce: "3",
+		Nonce:       "3",
 	}, streamCDS(t, cc, "default/httpbin/9000"))
 }
 

--- a/internal/e2e/cds_test.go
+++ b/internal/e2e/cds_test.go
@@ -463,12 +463,16 @@ func TestCDSResourceFiltering(t *testing.T) {
 		Nonce:   "3",
 	}, streamCDS(t, cc, "default/kuard/80/da39a3ee5e"))
 
-	// assert a non matching filter returns no results
-	// note: streamCDS would stall at this point.
+	// assert a non matching filter returns a response with no entries.
 	assertEqual(t, &v2.DiscoveryResponse{
 		VersionInfo: "3",
 		TypeUrl:     clusterType,
-		Nonce:       "3",
+		Resources: []types.Any{
+			any(t, &v2.Cluster{
+				Name: "default/httpbin/9000",
+			}),
+		},
+		Nonce: "3",
 	}, streamCDS(t, cc, "default/httpbin/9000"))
 }
 

--- a/internal/e2e/eds_test.go
+++ b/internal/e2e/eds_test.go
@@ -214,7 +214,13 @@ func TestEndpointFilter(t *testing.T) {
 	assertEqual(t, &v2.DiscoveryResponse{
 		VersionInfo: "1",
 		TypeUrl:     endpointType,
-		Nonce:       "1",
+		Resources: []types.Any{
+			any(t, clusterloadassignment(
+				"default/kuard/bar",
+			)),
+		},
+
+		Nonce: "1",
 	}, streamEDS(t, cc, "default/kuard/bar"))
 
 }
@@ -285,6 +291,9 @@ func addresses(ips ...string) []v1.EndpointAddress {
 }
 
 func clusterloadassignment(name string, lbendpoints ...endpoint.LbEndpoint) *v2.ClusterLoadAssignment {
+	if len(lbendpoints) == 0 {
+		return &v2.ClusterLoadAssignment{ClusterName: name}
+	}
 	return &v2.ClusterLoadAssignment{
 		ClusterName: name,
 		Endpoints: []endpoint.LocalityLbEndpoints{{

--- a/internal/e2e/lds_test.go
+++ b/internal/e2e/lds_test.go
@@ -477,13 +477,8 @@ func TestLDSFilter(t *testing.T) {
 	// fetch something non existent.
 	assertEqual(t, &v2.DiscoveryResponse{
 		VersionInfo: "2",
-		Resources: []types.Any{
-			any(t, &v2.Listener{
-				Name: "HTTP",
-			}),
-		},
-		TypeUrl: listenerType,
-		Nonce:   "2",
+		TypeUrl:     listenerType,
+		Nonce:       "2",
 	}, streamLDS(t, cc, "HTTP"))
 }
 
@@ -494,12 +489,8 @@ func TestLDSStreamEmpty(t *testing.T) {
 	// assert that streaming LDS with no ingresses does not stall.
 	assertEqual(t, &v2.DiscoveryResponse{
 		VersionInfo: "0",
-		Resources: []types.Any{
-			any(t, &v2.Listener{
-				Name: "HTTP",
-			}),
-		},
-		TypeUrl: listenerType, Nonce: "0",
+		TypeUrl:     listenerType,
+		Nonce:       "0",
 	}, streamLDS(t, cc, "HTTP"))
 }
 

--- a/internal/e2e/lds_test.go
+++ b/internal/e2e/lds_test.go
@@ -455,7 +455,6 @@ func TestLDSFilter(t *testing.T) {
 				},
 				FilterChains: filterchaintls("kuard.example.com", s1, envoy.HTTPConnectionManager("ingress_https", "/dev/stdout"), "h2", "http/1.1"),
 			}),
-			any(t, staticListener()),
 		},
 		TypeUrl: listenerType,
 		Nonce:   "2",
@@ -470,7 +469,6 @@ func TestLDSFilter(t *testing.T) {
 				Address:      *envoy.SocketAddress("0.0.0.0", 8080),
 				FilterChains: filterchain(envoy.HTTPConnectionManager("ingress_http", "/dev/stdout")),
 			}),
-			any(t, staticListener()),
 		},
 		TypeUrl: listenerType,
 		Nonce:   "2",
@@ -479,8 +477,8 @@ func TestLDSFilter(t *testing.T) {
 	// fetch something non existent.
 	assertEqual(t, &v2.DiscoveryResponse{
 		VersionInfo: "2",
-		Resources: []types.Any{
-			any(t, staticListener()),
+		Resources:   []types.Any{
+			// any(t, staticListener()),
 		},
 		TypeUrl: listenerType,
 		Nonce:   "2",
@@ -494,8 +492,8 @@ func TestLDSStreamEmpty(t *testing.T) {
 	// assert that streaming LDS with no ingresses does not stall.
 	assertEqual(t, &v2.DiscoveryResponse{
 		VersionInfo: "0",
-		Resources: []types.Any{
-			any(t, staticListener()),
+		Resources:   []types.Any{
+			// any(t, staticListener()),
 		},
 		TypeUrl: listenerType, Nonce: "0",
 	}, streamLDS(t, cc, "HTTP"))
@@ -548,7 +546,6 @@ func TestLDSTLSMinimumProtocolVersion(t *testing.T) {
 				},
 				FilterChains: filterchaintls("kuard.example.com", s1, envoy.HTTPConnectionManager("ingress_https", "/dev/stdout"), "h2", "http/1.1"),
 			}),
-			any(t, staticListener()),
 		},
 		TypeUrl: listenerType,
 		Nonce:   "3",
@@ -589,7 +586,6 @@ func TestLDSTLSMinimumProtocolVersion(t *testing.T) {
 		VersionInfo: "4",
 		Resources: []types.Any{
 			any(t, l1),
-			any(t, staticListener()),
 		},
 		TypeUrl: listenerType,
 		Nonce:   "4",

--- a/internal/e2e/lds_test.go
+++ b/internal/e2e/lds_test.go
@@ -477,8 +477,10 @@ func TestLDSFilter(t *testing.T) {
 	// fetch something non existent.
 	assertEqual(t, &v2.DiscoveryResponse{
 		VersionInfo: "2",
-		Resources:   []types.Any{
-			// any(t, staticListener()),
+		Resources: []types.Any{
+			any(t, &v2.Listener{
+				Name: "HTTP",
+			}),
 		},
 		TypeUrl: listenerType,
 		Nonce:   "2",
@@ -492,8 +494,10 @@ func TestLDSStreamEmpty(t *testing.T) {
 	// assert that streaming LDS with no ingresses does not stall.
 	assertEqual(t, &v2.DiscoveryResponse{
 		VersionInfo: "0",
-		Resources:   []types.Any{
-			// any(t, staticListener()),
+		Resources: []types.Any{
+			any(t, &v2.Listener{
+				Name: "HTTP",
+			}),
 		},
 		TypeUrl: listenerType, Nonce: "0",
 	}, streamLDS(t, cc, "HTTP"))

--- a/internal/grpc/xds.go
+++ b/internal/grpc/xds.go
@@ -28,9 +28,11 @@ import (
 // Resource represents a source of proto.Messages that can be registered
 // for interest.
 type Resource interface {
-	// Values returns a slice of proto.Message implementations that match
-	// the filter function.
-	Values(func(string) bool) []proto.Message
+	// Contents returns the contents of this resource.
+	Contents() []proto.Message
+
+	// Query returns an entry for each resource name supplied.
+	Query(names []string) []proto.Message
 
 	// Register registers ch to receive a value when Notify is called.
 	Register(chan int, int)
@@ -107,17 +109,25 @@ func (xh *xdsHandler) stream(st grpcStream) (err error) {
 				// TODO(dfc) the thing that has changed may not be in the scope of the filter
 				// so we're going to be sending an update that is a no-op. See #426
 
-				// generate a filter from the request, then call toAny which
-				// will get r's (our resource) filter values, then convert them
-				// to the types.Any from required by gRPC.
-				resources, err := toAny(r, toFilter(req.ResourceNames))
+				var resources []proto.Message
+				switch len(req.ResourceNames) {
+				case 0:
+					// no resource hints supplied, return the full
+					// contents of the resource
+					resources = r.Contents()
+				default:
+					// resource hints supplied, return exactly those
+					resources = r.Query(req.ResourceNames)
+				}
+
+				any, err := toAny(r.TypeURL(), resources)
 				if err != nil {
 					return err
 				}
 
 				resp := &v2.DiscoveryResponse{
 					VersionInfo: strconv.Itoa(last),
-					Resources:   resources,
+					Resources:   any,
 					TypeUrl:     r.TypeURL(),
 					Nonce:       strconv.Itoa(last),
 				}
@@ -136,31 +146,16 @@ func (xh *xdsHandler) stream(st grpcStream) (err error) {
 
 // toAny converts the contents of a resourcer's Values to the
 // respective slice of types.Any.
-func toAny(res Resource, filter func(string) bool) ([]types.Any, error) {
-	v := res.Values(filter)
-	resources := make([]types.Any, len(v))
-	for i := range v {
-		value, err := proto.Marshal(v[i])
+func toAny(typeURL string, values []proto.Message) ([]types.Any, error) {
+	var resources []types.Any
+	for _, value := range values {
+		v, err := proto.Marshal(value)
 		if err != nil {
 			return nil, err
 		}
-		resources[i] = types.Any{TypeUrl: res.TypeURL(), Value: value}
+		resources = append(resources, types.Any{TypeUrl: typeURL, Value: v})
 	}
 	return resources, nil
-}
-
-// toFilter converts a slice of strings into a filter function.
-// If the slice is empty, then a filter function that matches everything
-// is returned.
-func toFilter(names []string) func(string) bool {
-	if len(names) == 0 {
-		return func(string) bool { return true }
-	}
-	m := make(map[string]bool)
-	for _, n := range names {
-		m[n] = true
-	}
-	return func(name string) bool { return m[name] }
 }
 
 // counter holds an atomically incrementing counter.


### PR DESCRIPTION
Fixes #1091 
Updates #420
Updates #439 

Problems with Contour not returning a value to Envoy when asked specifically have occurred several times in the past. When they have occurred, because I didn't understand the underlying issue, they were fixed in a piecemeal fashion. This PR addresses the root cause of the issue and hopefully we'll never have to talk about this again.

## What caused the issue?

Envoy can ask Contour two different questions; the first is "please tell me the contents of the xDS table", the second is "please tell me the contents of these specific named xDS entries". The former is performed when a [xDS Discovery Request](https://www.envoyproxy.io/docs/envoy/latest/api-v2/api/v2/discovery.proto#envoy-api-msg-discoveryrequest) supplies no `resource_name` hints. The latter uses `resource_name` hints to say "I want to know about _these specific_ resources".

Naively one might think that the second case is a subset of the first, send me what you know about these specific resources is the union of the contents of the xDS cache and the names supplied. The first case is even simpler, it's the union of the cache with itself. However it's not so simple.

The first question, "tell me everything you have it the cache" is simple; everything in the cache is turned into grpc and sent over the wire to Envoy. The non intersecting set of things which are not in the cache are not sent to Envoy because that makes _NO SENSE_. However in the second case, _for some resource types_, Envoy will ask for a resource by name and will not be happy if the resource is not provided. This was the cause of #439, and #1091. 

In the latter case a Service had been scaled to zero. The service was present in the api server so a valid ingress document pointed to it. Thus Contour created a Cluster record and sent that to Envoy, which in turn asked EDS for the members of the cluster we just told it existed. However, because the service was scaled to zero, the endpoint object was blank, there were no valid endpoints, so nothing was entered into the EDS cache on Contour's side. Here's where things get really upsetting.

xDS does not provide any way for a server to reject a request. Well, you can close the connection, but that's not going to help, Envoy will just reconnect and ask again, and all the while, it will be blocked on startup. So, when Envoy asks for an EDS record _we must provide it_, even if we don't have any information about it. This is actually a more general problem than EDS, but EDS is more susceptible to this problem because of the background described in https://github.com/heptio/contour/issues/1091#issuecomment-493873654.

## How does this PR fix the issue?

This PR does two things. First, it recognises that the two questions Envoy are different--the DiscoveryRequest with resource_name hint is not a subset of _tell me everything in the cache_--this this PR removes the `Values(...string)` method on `grpc.Resource` and replaces it with `Contents()` and `Query([]string)`. The former clearly returns the contents of the cache, the latter takes a set of resources to query.

Secondly, on a per resource basis, the `Query` implementation will return blank results for records it does not hold in its cache _when safe to do so_. It turns out that for CDS, LDS, and SDS, there is no safe way to construct a blank record, so we cannot provide one to Envoy if it asks for one. For EDS and RDS, there is a way to construct a blank record given the query name provided, which we do, and this satisfies Envoy, unblocking the startup process.

In addition to tests at the `internal/contour` and `internal/e2e` level I have also tested it in my cluster repeatedly scaling a service to zero, restarting Envoy, and validating that prior to this change Envoy would block on startup when a Service with zero active pods was referenced via an Ingress record. Post this change, Envoy starts immediately.