### PR TITLE
Update `make local` target to work with local `contour serve`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ vendor/
 .idea/
 .DS_Store
 go.sum
+localenvoyconfig.yaml


### PR DESCRIPTION
Fixes #1114 

Turns out that the easiest way to do this is to pass a host IP to the `contour bootstrap` invocation inside the `make local` target. Obviously this means that `contour serve` must be listening on that IP, which means that it should either be run with `contour serve --xds-address=0.0.0.0` or with a local IP on the host in place of 0.0.0.0. (Listening on all interfaces carries obvious security concerns).

I'm not sure where the best place to document this process is, willing to be educated on that front.

Signed-off-by: Nick Young <ynick@vmware.com>