### PR TITLE
Add stable sorting to https listener creation.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,15 +21,10 @@ test: install
 test-race: | test
 	go test -race -mod=readonly ./...
 
-test-repeated: | test
-	# Added for some tests that can be nondeterministic
-	# (Specifically, TestListenerCacheContents in listener_test.go)
-	go test -mod=readonly ./internal/contour/ -count=10
-
 vet: | test
 	go vet ./...
 
-check: test test-race test-repeated vet gofmt staticcheck misspell unconvert unparam ineffassign
+check: test test-race vet gofmt staticcheck misspell unconvert unparam ineffassign
 	@echo Checking rendered files are up to date
 	@(cd deployment && bash render.sh && git diff --exit-code . || (echo "rendered files are out of date" && exit 1))
 

--- a/Makefile
+++ b/Makefile
@@ -21,10 +21,15 @@ test: install
 test-race: | test
 	go test -race -mod=readonly ./...
 
+test-repeated: | test
+	# Added for some tests that can be nondeterministic
+	# (Specifically, TestListenerCacheContents in listener_test.go)
+	go test -mod=readonly ./internal/contour/ -count=10
+
 vet: | test
 	go vet ./...
 
-check: test test-race vet gofmt staticcheck misspell unconvert unparam ineffassign
+check: test test-race test-repeated vet gofmt staticcheck misspell unconvert unparam ineffassign
 	@echo Checking rendered files are up to date
 	@(cd deployment && bash render.sh && git diff --exit-code . || (echo "rendered files are out of date" && exit 1))
 

--- a/internal/contour/listener.go
+++ b/internal/contour/listener.go
@@ -262,16 +262,16 @@ func visitListeners(root dag.Vertex, lvc *ListenerVisitorConfig) map[string]*v2.
 	// remove the https listener if there are no vhosts bound to it.
 	if len(lv.listeners[ENVOY_HTTPS_LISTENER].FilterChains) == 0 {
 		delete(lv.listeners, ENVOY_HTTPS_LISTENER)
-		// } else {
-		// 	// there's some https listeners, we need to sort the filter chains
-		// 	// to ensure that the LDS entries are identical.
-		// 	sort.SliceStable(lv.listeners[ENVOY_HTTPS_LISTENER].FilterChains,
-		// 		func(i, j int) bool {
-		// 			// The ServerNames field will only ever have a single entry
-		// 			// in our FilterChain config, so it's okay to only sort
-		// 			// on the first slice entry.
-		// 			return lv.listeners[ENVOY_HTTPS_LISTENER].FilterChains[i].FilterChainMatch.ServerNames[0] < lv.listeners[ENVOY_HTTPS_LISTENER].FilterChains[j].FilterChainMatch.ServerNames[0]
-		// 		})
+	} else {
+		// there's some https listeners, we need to sort the filter chains
+		// to ensure that the LDS entries are identical.
+		sort.SliceStable(lv.listeners[ENVOY_HTTPS_LISTENER].FilterChains,
+			func(i, j int) bool {
+				// The ServerNames field will only ever have a single entry
+				// in our FilterChain config, so it's okay to only sort
+				// on the first slice entry.
+				return lv.listeners[ENVOY_HTTPS_LISTENER].FilterChains[i].FilterChainMatch.ServerNames[0] < lv.listeners[ENVOY_HTTPS_LISTENER].FilterChains[j].FilterChainMatch.ServerNames[0]
+			})
 	}
 
 	return lv.listeners

--- a/internal/contour/listener.go
+++ b/internal/contour/listener.go
@@ -262,6 +262,16 @@ func visitListeners(root dag.Vertex, lvc *ListenerVisitorConfig) map[string]*v2.
 	// remove the https listener if there are no vhosts bound to it.
 	if len(lv.listeners[ENVOY_HTTPS_LISTENER].FilterChains) == 0 {
 		delete(lv.listeners, ENVOY_HTTPS_LISTENER)
+		// } else {
+		// 	// there's some https listeners, we need to sort the filter chains
+		// 	// to ensure that the LDS entries are identical.
+		// 	sort.SliceStable(lv.listeners[ENVOY_HTTPS_LISTENER].FilterChains,
+		// 		func(i, j int) bool {
+		// 			// The ServerNames field will only ever have a single entry
+		// 			// in our FilterChain config, so it's okay to only sort
+		// 			// on the first slice entry.
+		// 			return lv.listeners[ENVOY_HTTPS_LISTENER].FilterChains[i].FilterChainMatch.ServerNames[0] < lv.listeners[ENVOY_HTTPS_LISTENER].FilterChains[j].FilterChainMatch.ServerNames[0]
+		// 		})
 	}
 
 	return lv.listeners

--- a/internal/contour/listener_test.go
+++ b/internal/contour/listener_test.go
@@ -15,7 +15,6 @@ package contour
 
 import (
 	"encoding/json"
-	"reflect"
 	"testing"
 
 	v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
@@ -620,11 +619,8 @@ func TestListenerVisit(t *testing.T) {
 			}
 			root := reh.Build()
 			got := visitListeners(root, &tc.ListenerVisitorConfig)
-			if !reflect.DeepEqual(tc.want, got) {
-				weWant := prettyPrint(tc.want)
-				weGot := prettyPrint(got)
-				t.Fatal(cmp.Diff(weWant, weGot))
-				//t.Fatalf("expected:\n%+v\ngot:\n%+v", weWant, weGot)
+			if !cmp.Equal(tc.want, got) {
+				t.Fatalf("expected:\n%+v\ngot:\n%+v", tc.want, got)
 			}
 		})
 	}

--- a/internal/contour/listener_test.go
+++ b/internal/contour/listener_test.go
@@ -14,6 +14,7 @@
 package contour
 
 import (
+	"encoding/json"
 	"reflect"
 	"testing"
 
@@ -232,6 +233,76 @@ func TestListenerVisit(t *testing.T) {
 					TlsContext: tlscontext(auth.TlsParameters_TLSv1_1, "h2", "http/1.1"),
 					Filters:    filters(envoy.HTTPConnectionManager(ENVOY_HTTPS_LISTENER, DEFAULT_HTTPS_ACCESS_LOG)),
 				}},
+			}),
+		},
+		"multiple tls ingress with secrets should be sorted": {
+			objs: []interface{}{
+				&v1beta1.Ingress{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "sortedsecond",
+						Namespace: "default",
+					},
+					Spec: v1beta1.IngressSpec{
+						TLS: []v1beta1.IngressTLS{{
+							Hosts:      []string{"sortedsecond.example.com"},
+							SecretName: "secret",
+						}},
+						Backend: &v1beta1.IngressBackend{
+							ServiceName: "kuard",
+							ServicePort: intstr.FromInt(8080),
+						},
+					},
+				},
+				&v1beta1.Ingress{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "sortedfirst",
+						Namespace: "default",
+					},
+					Spec: v1beta1.IngressSpec{
+						TLS: []v1beta1.IngressTLS{{
+							Hosts:      []string{"sortedfirst.example.com"},
+							SecretName: "secret",
+						}},
+						Backend: &v1beta1.IngressBackend{
+							ServiceName: "kuard",
+							ServicePort: intstr.FromInt(8080),
+						},
+					},
+				},
+				&v1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "secret",
+						Namespace: "default",
+					},
+					Data: secretdata("certificate", "key"),
+				},
+			},
+			want: listenermap(&v2.Listener{
+				Name:         ENVOY_HTTP_LISTENER,
+				Address:      *envoy.SocketAddress("0.0.0.0", 8080),
+				FilterChains: filterchain(envoy.HTTPConnectionManager(ENVOY_HTTP_LISTENER, DEFAULT_HTTP_ACCESS_LOG)),
+			}, &v2.Listener{
+				Name:    ENVOY_HTTPS_LISTENER,
+				Address: *envoy.SocketAddress("0.0.0.0", 8443),
+				ListenerFilters: []listener.ListenerFilter{
+					envoy.TLSInspector(),
+				},
+				FilterChains: []listener.FilterChain{
+					{
+						FilterChainMatch: &listener.FilterChainMatch{
+							ServerNames: []string{"sortedfirst.example.com"},
+						},
+						TlsContext: tlscontext(auth.TlsParameters_TLSv1_1, "h2", "http/1.1"),
+						Filters:    filters(envoy.HTTPConnectionManager(ENVOY_HTTPS_LISTENER, DEFAULT_HTTPS_ACCESS_LOG)),
+					},
+					{
+						FilterChainMatch: &listener.FilterChainMatch{
+							ServerNames: []string{"sortedsecond.example.com"},
+						},
+						TlsContext: tlscontext(auth.TlsParameters_TLSv1_1, "h2", "http/1.1"),
+						Filters:    filters(envoy.HTTPConnectionManager(ENVOY_HTTPS_LISTENER, DEFAULT_HTTPS_ACCESS_LOG)),
+					},
+				},
 			}),
 		},
 		"simple ingress with missing secret": {
@@ -550,10 +621,19 @@ func TestListenerVisit(t *testing.T) {
 			root := reh.Build()
 			got := visitListeners(root, &tc.ListenerVisitorConfig)
 			if !reflect.DeepEqual(tc.want, got) {
-				t.Fatalf("expected:\n%+v\ngot:\n%+v", tc.want, got)
+				weWant := prettyPrint(tc.want)
+				weGot := prettyPrint(got)
+				t.Fatal(cmp.Diff(weWant, weGot))
+				//t.Fatalf("expected:\n%+v\ngot:\n%+v", weWant, weGot)
 			}
 		})
 	}
+}
+
+// added to make the test output minimally readable.
+func prettyPrint(i interface{}) string {
+	s, _ := json.MarshalIndent(i, "", "\t")
+	return string(s)
 }
 
 func filters(first listener.Filter, rest ...listener.Filter) []listener.Filter {

--- a/internal/contour/listener_test.go
+++ b/internal/contour/listener_test.go
@@ -14,7 +14,6 @@
 package contour
 
 import (
-	"encoding/json"
 	"testing"
 
 	v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
@@ -624,12 +623,6 @@ func TestListenerVisit(t *testing.T) {
 			}
 		})
 	}
-}
-
-// added to make the test output minimally readable.
-func prettyPrint(i interface{}) string {
-	s, _ := json.MarshalIndent(i, "", "\t")
-	return string(s)
 }
 
 func filters(first listener.Filter, rest ...listener.Filter) []listener.Filter {


### PR DESCRIPTION
Fixes #1096 

Should cut down LDS updates by ensuring a stable LDS cache, with no map ordering perturbing it.

Signed-off-by: Nick Young <ynick@vmware.com>