### PR TITLE
Add flag to set Contour log level and reduce default xds logs verbosity

### DIFF
--- a/cmd/contour/contour.go
+++ b/cmd/contour/contour.go
@@ -48,6 +48,7 @@ var ingressrouteRootNamespaceFlag string
 func main() {
 	log := logrus.StandardLogger()
 	app := kingpin.New("contour", "Heptio Contour Kubernetes ingress controller.")
+	logLevel := app.Flag("log-level", "Contour log level.").Default("info").String()
 	var config envoy.BootstrapConfig
 	bootstrap := app.Command("bootstrap", "Generate bootstrap configuration.")
 	path := bootstrap.Arg("path", "Configuration file.").Required().String()
@@ -141,7 +142,15 @@ func main() {
 	serve.Flag("ingressroute-root-namespaces", "Restrict contour to searching these namespaces for root ingress routes").StringVar(&ingressrouteRootNamespaceFlag)
 
 	args := os.Args[1:]
-	switch kingpin.MustParse(app.Parse(args)) {
+	command := kingpin.MustParse(app.Parse(args))
+
+	lvl, err := logrus.ParseLevel(*logLevel)
+	if err != nil {
+		log.Fatalf("invalid log level: %s", err)
+	}
+	log.SetLevel(lvl)
+
+	switch command {
 	case bootstrap.FullCommand():
 		writeBootstrapConfig(&config, *path)
 	case cds.FullCommand():

--- a/internal/grpc/xds.go
+++ b/internal/grpc/xds.go
@@ -93,7 +93,7 @@ func (xh *xdsHandler) stream(st grpcStream) (err error) {
 			return fmt.Errorf("no resource registered for typeURL %q", req.TypeUrl)
 		}
 
-		// stick some debugging details on the logger, not that we redeclare log in this scope
+		// stick some debugging details on the logger, note that we redeclare log in this scope
 		// so the next time around the loop all is forgotten.
 		log := log.WithField("version_info", req.VersionInfo).WithField("resource_names", req.ResourceNames).WithField("type_url", req.TypeUrl).WithField("response_nonce", req.ResponseNonce).WithField("error_detail", req.ErrorDetail)
 

--- a/internal/grpc/xds.go
+++ b/internal/grpc/xds.go
@@ -98,7 +98,7 @@ func (xh *xdsHandler) stream(st grpcStream) (err error) {
 		log := log.WithField("version_info", req.VersionInfo).WithField("resource_names", req.ResourceNames).WithField("type_url", req.TypeUrl).WithField("response_nonce", req.ResponseNonce).WithField("error_detail", req.ErrorDetail)
 
 		for {
-			log.Info("stream_wait")
+			log.Debug("stream_wait")
 
 			// now we wait for a notification, if this is the first time through the loop
 			// then last will be less than zero and that will trigger a notification immediately.
@@ -134,7 +134,7 @@ func (xh *xdsHandler) stream(st grpcStream) (err error) {
 				if err := st.Send(resp); err != nil {
 					return err
 				}
-				log.WithField("count", len(resources)).Info("response")
+				log.WithField("count", len(resources)).Debug("response")
 
 				// ok, the client hung up, return any error stored in the context and we're done.
 			case <-ctx.Done():


### PR DESCRIPTION
Contour outputs debug logs from `internal/grpc/xds.go:xdsHandler.stream` main loop by default, which may be quite verbose (in a small cluster I've seen around 400 log lines each couple of seconds).

In an attempt to reduce this verbosity by default, this PR adds a new flag to Contour: `--log-level`, which defaults to `info`, and sets the `internal/grpc/xds.go:xdsHandler.stream` main loop logs to `log.Debug`, reducing the amount of logs for each loop. The old behavior can be restored by setting `--log-level=debug` on Contour startup.
I've also fixed a typo in the comments related to the before mentioned log section.