### PR TITLE
Rename Contour health check endpoint for consistency, add probes to examples

### DIFF
--- a/examples/deployment-grpc-v2/02-contour.yaml
+++ b/examples/deployment-grpc-v2/02-contour.yaml
@@ -25,6 +25,14 @@ spec:
         name: contour
         command: ["contour"]
         args: ["serve", "--incluster", "--envoy-service-http-port", "8080", "--envoy-service-https-port", "8443"]
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8000
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: 8000
       - image: docker.io/envoyproxy/envoy:v1.10.0
         name: envoy
         ports:

--- a/examples/ds-grpc-v2/02-contour.yaml
+++ b/examples/ds-grpc-v2/02-contour.yaml
@@ -26,6 +26,14 @@ spec:
         name: contour
         command: ["contour"]
         args: ["serve", "--incluster", "--envoy-service-http-port", "8080", "--envoy-service-https-port", "8443"]
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8000
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: 8000
       - image: docker.io/envoyproxy/envoy:v1.10.0
         name: envoy
         ports:

--- a/examples/ds-hostnet-split/03-contour.yaml
+++ b/examples/ds-hostnet-split/03-contour.yaml
@@ -46,5 +46,13 @@ spec:
         - containerPort: 8000
           name: debug
           protocol: TCP
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8000
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: 8000
       dnsPolicy: ClusterFirst
       serviceAccountName: contour

--- a/examples/ds-hostnet/02-contour.yaml
+++ b/examples/ds-hostnet/02-contour.yaml
@@ -30,6 +30,14 @@ spec:
         name: contour
         command: ["contour"]
         args: ["serve", "--incluster", "--envoy-service-http-port", "8080", "--envoy-service-https-port", "8443"]
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8000
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: 8000
       - image: docker.io/envoyproxy/envoy:v1.10.0
         name: envoy
         ports:

--- a/examples/render/daemonset-rbac.yaml
+++ b/examples/render/daemonset-rbac.yaml
@@ -206,6 +206,14 @@ spec:
         name: contour
         command: ["contour"]
         args: ["serve", "--incluster", "--envoy-service-http-port", "8080", "--envoy-service-https-port", "8443"]
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8000
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: 8000
       - image: docker.io/envoyproxy/envoy:v1.10.0
         name: envoy
         ports:

--- a/examples/render/deployment-rbac.yaml
+++ b/examples/render/deployment-rbac.yaml
@@ -205,6 +205,14 @@ spec:
         name: contour
         command: ["contour"]
         args: ["serve", "--incluster", "--envoy-service-http-port", "8080", "--envoy-service-https-port", "8443"]
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8000
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: 8000
       - image: docker.io/envoyproxy/envoy:v1.10.0
         name: envoy
         ports:

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -219,7 +219,7 @@ func (svc *Service) Start(stop <-chan struct{}) error {
 }
 
 func registerHealthCheck(mux *http.ServeMux, client *kubernetes.Clientset) {
-	mux.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
+	healthCheckHandler := func(w http.ResponseWriter, r *http.Request) {
 		// Try and lookup Kubernetes server version as a quick and dirty check
 		_, err := client.ServerVersion()
 		if err != nil {
@@ -229,7 +229,9 @@ func registerHealthCheck(mux *http.ServeMux, client *kubernetes.Clientset) {
 		}
 		w.WriteHeader(http.StatusOK)
 		fmt.Fprintln(w, "OK")
-	})
+	}
+	mux.HandleFunc("/health", healthCheckHandler)
+	mux.HandleFunc("/healthz", healthCheckHandler)
 }
 
 func registerMetrics(mux *http.ServeMux, registry *prometheus.Registry) {


### PR DESCRIPTION
This PR renames Contour health check endpoint from `/health` to `/healthz` to improve consistency with other components and adds liveness and readiness probes for this endpoint in the examples directory.

Related to #283

:warning: even though I've been using this endpoint in my environment, I've not tested all the examples manifests.