### PR TITLE
internal/dag: move LoadBalancingStrategy from dag.Service to dag.Cluster

### DIFF
--- a/internal/dag/builder_test.go
+++ b/internal/dag/builder_test.go
@@ -2940,7 +2940,6 @@ func TestBuilderLookupHTTPService(t *testing.T) {
 	tests := map[string]struct {
 		meta
 		port        intstr.IntOrString
-		strategy    string
 		healthcheck *ingressroutev1.HealthCheck
 		want        *HTTPService
 	}{
@@ -2975,7 +2974,7 @@ func TestBuilderLookupHTTPService(t *testing.T) {
 					},
 				},
 			}
-			got := b.lookupHTTPService(tc.meta, tc.port, tc.strategy, tc.healthcheck)
+			got := b.lookupHTTPService(tc.meta, tc.port, tc.healthcheck)
 			if diff := cmp.Diff(tc.want, got); diff != "" {
 				t.Fatal(diff)
 			}

--- a/internal/dag/dag.go
+++ b/internal/dag/dag.go
@@ -103,11 +103,12 @@ type UpstreamValidation struct {
 	SubjectName string
 }
 
-func (r *Route) addHTTPService(s *HTTPService, weight int, uv *UpstreamValidation) {
+func (r *Route) addHTTPService(s *HTTPService, strategy string, weight int, uv *UpstreamValidation) {
 	r.Clusters = append(r.Clusters, &Cluster{
-		Upstream:           s,
-		Weight:             weight,
-		UpstreamValidation: uv,
+		Upstream:             s,
+		LoadBalancerStrategy: strategy,
+		Weight:               weight,
+		UpstreamValidation:   uv,
 	})
 }
 
@@ -216,10 +217,6 @@ type TCPService struct {
 
 	*v1.ServicePort
 
-	// The load balancer type to use when picking a host in the cluster.
-	// See https://www.envoyproxy.io/docs/envoy/latest/api-v2/api/v2/cds.proto#envoy-api-enum-cluster-lbpolicy
-	LoadBalancerStrategy string
-
 	// Circuit breaking limits
 
 	// Max connections is maximum number of connections
@@ -248,7 +245,6 @@ type servicemeta struct {
 	name        string
 	namespace   string
 	port        int32
-	strategy    string
 	healthcheck string // %#v of *ingressroutev1.HealthCheck
 }
 
@@ -257,7 +253,6 @@ func (s *TCPService) toMeta() servicemeta {
 		name:        s.Name,
 		namespace:   s.Namespace,
 		port:        s.Port,
-		strategy:    s.LoadBalancerStrategy,
 		healthcheck: healthcheckToString(s.HealthCheck),
 	}
 }
@@ -279,6 +274,10 @@ type Cluster struct {
 
 	// UpstreamValidation defines how to verify the backend service's certificate
 	UpstreamValidation *UpstreamValidation
+
+	// The load balancer type to use when picking a host in the cluster.
+	// See https://www.envoyproxy.io/docs/envoy/latest/api-v2/api/v2/cds.proto#envoy-api-enum-cluster-lbpolicy
+	LoadBalancerStrategy string
 }
 
 func (c Cluster) Visit(f func(Vertex)) {

--- a/internal/envoy/cluster.go
+++ b/internal/envoy/cluster.go
@@ -82,7 +82,7 @@ func cluster(cluster *dag.Cluster, service *dag.TCPService) *v2.Cluster {
 		Name:           Clustername(cluster),
 		AltStatName:    altStatName(service),
 		ConnectTimeout: 250 * time.Millisecond,
-		LbPolicy:       lbPolicy(service.LoadBalancerStrategy),
+		LbPolicy:       lbPolicy(cluster.LoadBalancerStrategy),
 		CommonLbConfig: ClusterCommonLBConfig(),
 		HealthChecks:   edshealthcheck(service),
 	}
@@ -193,7 +193,7 @@ func Clustername(cluster *dag.Cluster) string {
 	default:
 		panic(fmt.Sprintf("unsupported upstream type: %T", s))
 	}
-	buf := service.LoadBalancerStrategy
+	buf := cluster.LoadBalancerStrategy
 	if hc := service.HealthCheck; hc != nil {
 		if hc.TimeoutSeconds > 0 {
 			buf += (time.Duration(hc.TimeoutSeconds) * time.Second).String()

--- a/internal/envoy/cluster_test.go
+++ b/internal/envoy/cluster_test.go
@@ -428,7 +428,6 @@ func TestClustername(t *testing.T) {
 						Port:       80,
 						TargetPort: intstr.FromInt(6502),
 					},
-					LoadBalancerStrategy: "Random",
 					HealthCheck: &ingressroutev1.HealthCheck{
 						Path:                    "/healthz",
 						IntervalSeconds:         5,
@@ -437,6 +436,7 @@ func TestClustername(t *testing.T) {
 						HealthyThresholdCount:   1,
 					},
 				},
+				LoadBalancerStrategy: "Random",
 			},
 			want: "default/backend/80/5c26077e1d",
 		},
@@ -451,8 +451,8 @@ func TestClustername(t *testing.T) {
 						Port:       80,
 						TargetPort: intstr.FromInt(6502),
 					},
-					LoadBalancerStrategy: "Random",
 				},
+				LoadBalancerStrategy: "Random",
 				UpstreamValidation: &dag.UpstreamValidation{
 					CACertificate: &dag.Secret{
 						Object: &v1.Secret{


### PR DESCRIPTION
Updates #1145

Move the LoadBalancingStrategy key from dag.Service to dag.Cluster. The
latter is more appropriate because it represents the load balancing
strategy used on the path between a route and the k8s service
represented by the dag.Service object.

Signed-off-by: Dave Cheney <dave@cheney.net>