### PR TITLE
all: remove Maglev and RingHash as supported load balancer strategies

### DIFF
--- a/design/ingressroute-design.md
+++ b/design/ingressroute-design.md
@@ -159,8 +159,6 @@ The following list are the options available to choose from:
 
 - **RoundRobin:** Each healthy upstream host is selected in round robin order
 - **WeightedLeastRequest:** The least request load balancer uses an O(1) algorithm which selects two random healthy hosts and picks the host which has fewer active requests. _Note: This algorithm is simple and sufficient for load testing. It should not be used where true weighted least request behavior is desired_
-- **Ring hash:** The ring/modulo hash load balancer implements consistent hashing to upstream hosts
-- **Maglev:** The Maglev load balancer implements consistent hashing to upstream hosts
 - **Random:** The random load balancer selects a random healthy host
 
 More documentation on Envoy's lb support can be found here: [https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/load_balancing.html](https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/load_balancing.html)

--- a/docs/ingressroute.md
+++ b/docs/ingressroute.md
@@ -489,8 +489,6 @@ The following list are the options available to choose from:
 
 - `RoundRobin`: Each healthy upstream Endpoint is selected in round robin order (Default strategy if none selected).
 - `WeightedLeastRequest`: The least request strategy uses an O(1) algorithm which selects two random healthy Endpoints and picks the Endpoint which has fewer active requests. Note: This algorithm is simple and sufficient for load testing. It should not be used where true weighted least request behavior is desired.
-- `RingHash`: The ring/modulo hash load balancer implements consistent hashing to upstream Endpoints.
-- `Maglev`: The Maglev strategy implements consistent hashing to upstream Endpoints
 - `Random`: The random strategy selects a random healthy Endpoints.
 
 More information on the load balancing strategy can be found in [Envoy's documentation](https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/load_balancing.html).

--- a/examples/common/common.yaml
+++ b/examples/common/common.yaml
@@ -70,8 +70,6 @@ spec:
                 - RoundRobin
                 - WeightedLeastRequest
                 - Random
-                - RingHash
-                - Maglev
             healthCheck:
               type: object
               required:
@@ -129,8 +127,6 @@ spec:
                             - RoundRobin
                             - WeightedLeastRequest
                             - Random
-                            - RingHash
-                            - Maglev
                         healthCheck:
                           type: object
                           required:

--- a/examples/render/daemonset-rbac.yaml
+++ b/examples/render/daemonset-rbac.yaml
@@ -73,8 +73,6 @@ spec:
                 - RoundRobin
                 - WeightedLeastRequest
                 - Random
-                - RingHash
-                - Maglev
             healthCheck:
               type: object
               required:
@@ -132,8 +130,6 @@ spec:
                             - RoundRobin
                             - WeightedLeastRequest
                             - Random
-                            - RingHash
-                            - Maglev
                         healthCheck:
                           type: object
                           required:

--- a/examples/render/deployment-rbac.yaml
+++ b/examples/render/deployment-rbac.yaml
@@ -73,8 +73,6 @@ spec:
                 - RoundRobin
                 - WeightedLeastRequest
                 - Random
-                - RingHash
-                - Maglev
             healthCheck:
               type: object
               required:
@@ -132,8 +130,6 @@ spec:
                             - RoundRobin
                             - WeightedLeastRequest
                             - Random
-                            - RingHash
-                            - Maglev
                         healthCheck:
                           type: object
                           required:

--- a/internal/contour/cluster_test.go
+++ b/internal/contour/cluster_test.go
@@ -612,92 +612,6 @@ func TestClusterVisit(t *testing.T) {
 				},
 			),
 		},
-		"ingressroute with RingHash lb algorithm": {
-			objs: []interface{}{
-				&ingressroutev1.IngressRoute{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "simple",
-						Namespace: "default",
-					},
-					Spec: ingressroutev1.IngressRouteSpec{
-						VirtualHost: &ingressroutev1.VirtualHost{
-							Fqdn: "www.example.com",
-						},
-						Routes: []ingressroutev1.Route{{
-							Match: "/",
-							Services: []ingressroutev1.Service{{
-								Name:     "backend",
-								Port:     80,
-								Strategy: "RingHash",
-							}},
-						}},
-					},
-				},
-				service("default", "backend", v1.ServicePort{
-					Name:       "http",
-					Protocol:   "TCP",
-					Port:       80,
-					TargetPort: intstr.FromInt(6502),
-				}),
-			},
-			want: clustermap(
-				&v2.Cluster{
-					Name:                 "default/backend/80/40633a6ca9",
-					AltStatName:          "default_backend_80",
-					ClusterDiscoveryType: envoy.ClusterDiscoveryType(v2.Cluster_EDS),
-					EdsClusterConfig: &v2.Cluster_EdsClusterConfig{
-						EdsConfig:   envoy.ConfigSource("contour"),
-						ServiceName: "default/backend/http",
-					},
-					ConnectTimeout: 250 * time.Millisecond,
-					LbPolicy:       v2.Cluster_RING_HASH,
-					CommonLbConfig: envoy.ClusterCommonLBConfig(),
-				},
-			),
-		},
-		"ingressroute with Maglev lb algorithm": {
-			objs: []interface{}{
-				&ingressroutev1.IngressRoute{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "simple",
-						Namespace: "default",
-					},
-					Spec: ingressroutev1.IngressRouteSpec{
-						VirtualHost: &ingressroutev1.VirtualHost{
-							Fqdn: "www.example.com",
-						},
-						Routes: []ingressroutev1.Route{{
-							Match: "/",
-							Services: []ingressroutev1.Service{{
-								Name:     "backend",
-								Port:     80,
-								Strategy: "Maglev",
-							}},
-						}},
-					},
-				},
-				service("default", "backend", v1.ServicePort{
-					Name:       "http",
-					Protocol:   "TCP",
-					Port:       80,
-					TargetPort: intstr.FromInt(6502),
-				}),
-			},
-			want: clustermap(
-				&v2.Cluster{
-					Name:                 "default/backend/80/843e4ded8f",
-					AltStatName:          "default_backend_80",
-					ClusterDiscoveryType: envoy.ClusterDiscoveryType(v2.Cluster_EDS),
-					EdsClusterConfig: &v2.Cluster_EdsClusterConfig{
-						EdsConfig:   envoy.ConfigSource("contour"),
-						ServiceName: "default/backend/http",
-					},
-					ConnectTimeout: 250 * time.Millisecond,
-					LbPolicy:       v2.Cluster_MAGLEV,
-					CommonLbConfig: envoy.ClusterCommonLBConfig(),
-				},
-			),
-		},
 		"ingressroute with Random lb algorithm": {
 			objs: []interface{}{
 				&ingressroutev1.IngressRoute{
@@ -764,7 +678,7 @@ func TestClusterVisit(t *testing.T) {
 							Services: []ingressroutev1.Service{{
 								Name:     "backend",
 								Port:     80,
-								Strategy: "Maglev",
+								Strategy: "WeightedLeastRequest",
 							}},
 						}},
 					},
@@ -790,7 +704,7 @@ func TestClusterVisit(t *testing.T) {
 					CommonLbConfig: envoy.ClusterCommonLBConfig(),
 				},
 				&v2.Cluster{
-					Name:                 "default/backend/80/843e4ded8f",
+					Name:                 "default/backend/80/8bf87fefba",
 					AltStatName:          "default_backend_80",
 					ClusterDiscoveryType: envoy.ClusterDiscoveryType(v2.Cluster_EDS),
 					EdsClusterConfig: &v2.Cluster_EdsClusterConfig{
@@ -798,7 +712,7 @@ func TestClusterVisit(t *testing.T) {
 						ServiceName: "default/backend/http",
 					},
 					ConnectTimeout: 250 * time.Millisecond,
-					LbPolicy:       v2.Cluster_MAGLEV,
+					LbPolicy:       v2.Cluster_LEAST_REQUEST,
 					CommonLbConfig: envoy.ClusterCommonLBConfig(),
 				},
 			),

--- a/internal/e2e/cds_test.go
+++ b/internal/e2e/cds_test.go
@@ -674,7 +674,7 @@ func TestClusterLoadBalancerStrategyPerRoute(t *testing.T) {
 				Services: []ingressroutev1.Service{{
 					Name:     "kuard",
 					Port:     80,
-					Strategy: "Maglev",
+					Strategy: "WeightedLeastRequest",
 				}},
 			}},
 		},
@@ -696,7 +696,7 @@ func TestClusterLoadBalancerStrategyPerRoute(t *testing.T) {
 				CommonLbConfig: envoy.ClusterCommonLBConfig(),
 			}),
 			any(t, &v2.Cluster{
-				Name:                 "default/kuard/80/843e4ded8f",
+				Name:                 "default/kuard/80/8bf87fefba",
 				AltStatName:          "default_kuard_80",
 				ClusterDiscoveryType: envoy.ClusterDiscoveryType(v2.Cluster_EDS),
 				EdsClusterConfig: &v2.Cluster_EdsClusterConfig{
@@ -704,7 +704,7 @@ func TestClusterLoadBalancerStrategyPerRoute(t *testing.T) {
 					ServiceName: "default/kuard",
 				},
 				ConnectTimeout: 250 * time.Millisecond,
-				LbPolicy:       v2.Cluster_MAGLEV,
+				LbPolicy:       v2.Cluster_LEAST_REQUEST,
 				CommonLbConfig: envoy.ClusterCommonLBConfig(),
 			}),
 		},

--- a/internal/e2e/rds_test.go
+++ b/internal/e2e/rds_test.go
@@ -2542,8 +2542,6 @@ func TestLoadBalancingStrategies(t *testing.T) {
 	}{
 		{"s1", "f3b72af6a9", "RoundRobin", "RoundRobin lb algorithm"},
 		{"s2", "8bf87fefba", "WeightedLeastRequest", "WeightedLeastRequest lb algorithm"},
-		{"s3", "40633a6ca9", "RingHash", "RingHash lb algorithm"},
-		{"s4", "843e4ded8f", "Maglev", "Maglev lb algorithm"},
 		{"s5", "58d888c08a", "Random", "Random lb algorithm"},
 		{"s6", "da39a3ee5e", "", "Default lb algorithm"},
 	}
@@ -2587,7 +2585,7 @@ func TestLoadBalancingStrategies(t *testing.T) {
 			},
 		},
 	}}
-	assertRDS(t, cc, "7", want, nil)
+	assertRDS(t, cc, "5", want, nil)
 }
 
 func assertRDS(t *testing.T, cc *grpc.ClientConn, versioninfo string, ingress_http, ingress_https []route.VirtualHost) {

--- a/internal/envoy/cluster.go
+++ b/internal/envoy/cluster.go
@@ -166,10 +166,6 @@ func lbPolicy(strategy string) v2.Cluster_LbPolicy {
 	switch strategy {
 	case "WeightedLeastRequest":
 		return v2.Cluster_LEAST_REQUEST
-	case "RingHash":
-		return v2.Cluster_RING_HASH
-	case "Maglev":
-		return v2.Cluster_MAGLEV
 	case "Random":
 		return v2.Cluster_RANDOM
 	default:

--- a/internal/envoy/cluster_test.go
+++ b/internal/envoy/cluster_test.go
@@ -428,7 +428,7 @@ func TestClustername(t *testing.T) {
 						Port:       80,
 						TargetPort: intstr.FromInt(6502),
 					},
-					LoadBalancerStrategy: "Maglev",
+					LoadBalancerStrategy: "Random",
 					HealthCheck: &ingressroutev1.HealthCheck{
 						Path:                    "/healthz",
 						IntervalSeconds:         5,
@@ -438,7 +438,7 @@ func TestClustername(t *testing.T) {
 					},
 				},
 			},
-			want: "default/backend/80/32737eb011",
+			want: "default/backend/80/5c26077e1d",
 		},
 		"upstream tls validation with subject alt name": {
 			cluster: &dag.Cluster{
@@ -451,7 +451,7 @@ func TestClustername(t *testing.T) {
 						Port:       80,
 						TargetPort: intstr.FromInt(6502),
 					},
-					LoadBalancerStrategy: "Maglev",
+					LoadBalancerStrategy: "Random",
 				},
 				UpstreamValidation: &dag.UpstreamValidation{
 					CACertificate: &dag.Secret{
@@ -468,7 +468,7 @@ func TestClustername(t *testing.T) {
 					SubjectName: "foo.com",
 				},
 			},
-			want: "default/backend/80/a18ebaa0d6",
+			want: "default/backend/80/6bf46b7b3a",
 		},
 	}
 
@@ -485,11 +485,14 @@ func TestClustername(t *testing.T) {
 func TestLBPolicy(t *testing.T) {
 	tests := map[string]v2.Cluster_LbPolicy{
 		"WeightedLeastRequest": v2.Cluster_LEAST_REQUEST,
-		"RingHash":             v2.Cluster_RING_HASH,
-		"Maglev":               v2.Cluster_MAGLEV,
 		"Random":               v2.Cluster_RANDOM,
 		"":                     v2.Cluster_ROUND_ROBIN,
 		"unknown":              v2.Cluster_ROUND_ROBIN,
+
+		// RingHash and Maglev were removed as options in 0.13.
+		// See #1150
+		"RingHash": v2.Cluster_ROUND_ROBIN,
+		"Maglev":   v2.Cluster_ROUND_ROBIN,
 	}
 
 	for strategy, want := range tests {


### PR DESCRIPTION
Fixes #1150
Fixes #1030
Updates #1005

RingHash and Maglev are two balancing / affinity strategies that can be
configured per Cluster, however they are not useful by themselves.
Without the ability to configure the hash key, which is usually some for
of session af session or cookie, these strategies are not useful and
cannot be used correctly.

As such, remove them from the list of selectable options. Support for
session affinity will be added later.

Signed-off-by: Dave Cheney <dave@cheney.net>