### PR TITLE
Add commit guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,8 +89,10 @@ with a colon as delimiter. For example 'docs:', 'internal/(packagename):', 'desi
 tend to squash before opening the PR, then have PR feedback as
 extra commits.
 - If master has moved on, you'll need to rebase before we can merge,
-so merging upstream master or rebasing from upstream before opening your PR will probably save you some time.
-- PRs *must* include a `Fixes #NNNN` or `Updates #NNNN` comment.
+so merging upstream master or rebasing from upstream before opening your
+PR will probably save you some time.
+- PRs *must* include a `Fixes #NNNN` or `Updates #NNNN` comment. Remember that
+`Fixes` will close the associated issue, and `Updates` will link the PR to it.
 
 #### Commit message template
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,24 +78,48 @@ If you plan to submit a pull request for anything more than a typo or obvious bu
 Depending on the size of the feature you may be expected to first write a design proposal.
 A proposal template is [available here](https://github.com/heptio/contour/tree/master/design/design-document-tmpl.md)
 
-### Rules of thumb for commits
-
-Generally, we try to have our commits stick to the following rules of thumb:
+### Commit message and PR guidelines
 
 - Have a short subject on the first line and a body. The body can be empty.
 - Use the imperative mood (ie "If applied, this commit will (subject)" should make sense).
 - There must be a DCO line ("Signed-off-by: David Cheney <cheneyd@vmware.com>"), see [DCO Sign Off](#dco-sign-off) below
-- Try to put a summary of the main area affected by the commit at the start, with a colon as delimiter. For example 'docs:', 'internal/(packagename):', 'design:' or something similar.
-
-We won't turn away commits for *not* being like this, this is what we tend to do right now.
-
-## Rules of thumb for PRs
-
-- Try to keep your number of commits low. Most of us tend to squash
-before opening the PR, then have PR feedback as extra commits.
+- Put a summary of the main area affected by the commit at the start,
+with a colon as delimiter. For example 'docs:', 'internal/(packagename):', 'design:' or something similar.
+- Try to keep your number of commits in a PR low. Generally we
+tend to squash before opening the PR, then have PR feedback as
+extra commits.
 - If master has moved on, you'll need to rebase before we can merge,
 so merging upstream master or rebasing from upstream before opening your PR will probably save you some time.
-- PR titles generally use similar rules of thumb for commit subjects.
+- PRs *must* include a `Fixes #NNNN` or `Updates #NNNN` comment.
+
+#### Commit message template
+
+```
+<packagename>: <imperative mood short description>
+
+Updates #NNNN
+Fixes #MMMM
+
+Signed-off-by: Your Name you@youremail.com
+
+<longer change description/justification>
+
+```
+
+#### Sample commit message
+
+```
+internal\contour: Add quux functions
+
+Fixes #xxyyz
+
+Signed-off-by: Your Name you@youremail.com
+
+To implement the quux functions from #xxyyz, we need to
+florble the greep dots, then ensure that the florble is
+warbed.
+```
+
 
 ### Pre commit CI
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,6 +78,25 @@ If you plan to submit a pull request for anything more than a typo or obvious bu
 Depending on the size of the feature you may be expected to first write a design proposal.
 A proposal template is [available here](https://github.com/heptio/contour/tree/master/design/design-document-tmpl.md)
 
+### Rules of thumb for commits
+
+Generally, we try to have our commits stick to the following rules of thumb:
+
+- Have a short subject on the first line and a body. The body can be empty.
+- Use the imperative mood (ie "If applied, this commit will (subject)" should make sense).
+- There must be a DCO line ("Signed-off-by: David Cheney <cheneyd@vmware.com>"), see [DCO Sign Off](#dco-sign-off) below
+- Try to put a summary of the main area affected by the commit at the start, with a colon as delimiter. For example 'docs:', 'internal/(packagename):', 'design:' or something similar.
+
+We won't turn away commits for *not* being like this, this is what we tend to do right now.
+
+## Rules of thumb for PRs
+
+- Try to keep your number of commits low. Most of us tend to squash
+before opening the PR, then have PR feedback as extra commits.
+- If master has moved on, you'll need to rebase before we can merge,
+so merging upstream master or rebasing from upstream before opening your PR will probably save you some time.
+- PR titles generally use similar rules of thumb for commit subjects.
+
 ### Pre commit CI
 
 Before a change is submitted it should pass all the pre commit CI jobs.


### PR DESCRIPTION
Fixes #1136 

Just a small change with some rules of thumb. I've tried to make it clear these are guidelines rather than firm rules, suggestions on wording welcomed.

Signed-off-by: Nick Young <ynick@vmware.com>