### PR TITLE
examples: simplify validation for spec.virtualhost.fqdn

### DIFF
--- a/examples/common/common.yaml
+++ b/examples/common/common.yaml
@@ -49,10 +49,11 @@ spec:
         spec:
           properties:
             virtualhost:
+              required:      
+                - fqdn
               properties:
                 fqdn:
                   type: string
-                  pattern: ^([a-zA-Z0-9]+(-[a-zA-Z0-9]+)*\.)+[a-z0-9]{2,}$
                 tls:
                   properties:
                     secretName:

--- a/examples/render/daemonset-rbac.yaml
+++ b/examples/render/daemonset-rbac.yaml
@@ -52,10 +52,11 @@ spec:
         spec:
           properties:
             virtualhost:
+              required:      
+                - fqdn
               properties:
                 fqdn:
                   type: string
-                  pattern: ^([a-zA-Z0-9]+(-[a-zA-Z0-9]+)*\.)+[a-z0-9]{2,}$
                 tls:
                   properties:
                     secretName:

--- a/examples/render/deployment-rbac.yaml
+++ b/examples/render/deployment-rbac.yaml
@@ -52,10 +52,11 @@ spec:
         spec:
           properties:
             virtualhost:
+              required:      
+                - fqdn
               properties:
                 fqdn:
                   type: string
-                  pattern: ^([a-zA-Z0-9]+(-[a-zA-Z0-9]+)*\.)+[a-z0-9]{2,}$
                 tls:
                   properties:
                     secretName:


### PR DESCRIPTION
Fixes #1117

We've tried a few times to find a regex that fits the domain names that
people want to use but there are always edge cases.

Give up and simply require that the fqdn field is required. Ultimately
if the string isn't a valid DNS name, nothing will be able to route to
it, so the cost of writing nonsense here is low.

Signed-off-by: Dave Cheney <dave@cheney.net>