### PR TITLE
internal/metrics: Implemented healthcheck for Contour

### DIFF
--- a/cmd/contour/contour.go
+++ b/cmd/contour/contour.go
@@ -193,6 +193,7 @@ func main() {
 		reh.IngressRouteRootNamespaces = parseRootNamespaces(ingressrouteRootNamespaceFlag)
 
 		client, contourClient := newClient(*kubeconfig, *inCluster)
+		metricsvc.Client = client
 
 		// resync timer disabled for Contour
 		coreInformers := coreinformers.NewSharedInformerFactory(client, 0)


### PR DESCRIPTION
Fixes #283 by implementing health check for Contour. It does this by using the kubernetes client Contour uses and checks the server version. This api is simple enough to test the connection to the api server, and doesn't require understanding namespaces or anything additional from the cluster.
 
I think some future PR's should move this out of the `metrics` package. It was initially added there so Prometheus would be able to scrape metrics, but now does a bit more.

// cc #1132

Signed-off-by: Steve Sloka <slokas@vmware.com>