### PR TITLE
Enable ipv4_compat for ipv6-any (::) addresses

### DIFF
--- a/internal/envoy/listener.go
+++ b/internal/envoy/listener.go
@@ -189,6 +189,20 @@ func (c clustersByNameAndWeight) Less(i, j int) bool {
 
 // SocketAddress creates a new TCP core.Address.
 func SocketAddress(address string, port int) *core.Address {
+	if address == "::" {
+		return &core.Address{
+			Address: &core.Address_SocketAddress{
+				SocketAddress: &core.SocketAddress{
+					Protocol:   core.TCP,
+					Address:    address,
+					Ipv4Compat: true,
+					PortSpecifier: &core.SocketAddress_PortValue{
+						PortValue: uint32(port),
+					},
+				},
+			},
+		}
+	}
 	return &core.Address{
 		Address: &core.Address_SocketAddress{
 			SocketAddress: &core.SocketAddress{

--- a/internal/envoy/listener_test.go
+++ b/internal/envoy/listener_test.go
@@ -142,6 +142,23 @@ func TestSocketAddress(t *testing.T) {
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Fatal(diff)
 	}
+
+	got = SocketAddress("::", port)
+	want = &core.Address{
+		Address: &core.Address_SocketAddress{
+			SocketAddress: &core.SocketAddress{
+				Protocol:   core.TCP,
+				Address:    "::",
+				Ipv4Compat: true, // Set only for ipv6-any "::"
+				PortSpecifier: &core.SocketAddress_PortValue{
+					PortValue: port,
+				},
+			},
+		},
+	}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Fatal(diff)
+	}
 }
 
 func TestDownstreamTLSContext(t *testing.T) {


### PR DESCRIPTION
This makes envoy open port for both ipv4 and ipv6 if the ipv6-any address is used ("::"). This makes it possible to use the same config for ipv4-only and ipv6-only k8s, and enables dual-stack.

The contour addresses are configured to "::" like;
```
        command: ["contour"]
        args:
        - serve
        - --incluster
        - --envoy-service-http-port=8080
        - --envoy-service-https-port=8443
        - "--stats-address=::"
        - "--envoy-service-https-address=::"
        - "--envoy-service-http-address=::"
```
