### PR TITLE
internal/dag: rebuild should not trigger on unrelated secrets and services

### DIFF
--- a/internal/contour/cachehandler.go
+++ b/internal/contour/cachehandler.go
@@ -24,6 +24,7 @@ import (
 	"github.com/heptio/contour/internal/metrics"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
+	v1 "k8s.io/api/core/v1"
 )
 
 // CacheHandler manages the state of xDS caches.
@@ -37,6 +38,10 @@ type CacheHandler struct {
 	IngressRouteStatus *k8s.IngressRouteStatus
 	logrus.FieldLogger
 	*metrics.Metrics
+
+	// Kubernetes objects in the DAG that are referenced
+	secrets  map[dag.Meta]dag.Empty
+	services map[dag.Meta]dag.Empty
 }
 
 type statusable interface {
@@ -46,7 +51,7 @@ type statusable interface {
 func (ch *CacheHandler) OnChange(kc *dag.KubernetesCache) {
 	timer := prometheus.NewTimer(ch.CacheHandlerOnUpdateSummary)
 	defer timer.ObserveDuration()
-	dag := dag.BuildDAG(kc)
+	dag, cache := dag.BuildDAG(kc)
 	ch.setIngressRouteStatus(dag)
 	ch.updateSecrets(dag)
 	ch.updateListeners(dag)
@@ -54,6 +59,29 @@ func (ch *CacheHandler) OnChange(kc *dag.KubernetesCache) {
 	ch.updateClusters(dag)
 	ch.updateIngressRouteMetric(dag)
 	ch.SetDAGLastRebuilt(time.Now())
+
+	// store the referenced services/secret for comparison with the next build
+	ch.services = cache.Services
+	ch.secrets = cache.Secrets
+}
+
+// ShouldUpdate is called to determine if the object changing
+// is referenced from an Ingress / IngressRoute object
+func (ch *CacheHandler) ShouldUpdate(obj interface{}) bool {
+	exists := true
+	switch obj := obj.(type) {
+	case *v1.Secret:
+		if ch.secrets == nil {
+			return true
+		}
+		_, exists = ch.secrets[dag.Meta{Name: obj.Name, Namespace: obj.Namespace}]
+	case *v1.Service:
+		if ch.services == nil {
+			return true
+		}
+		_, exists = ch.services[dag.Meta{Name: obj.Name, Namespace: obj.Namespace}]
+	}
+	return exists
 }
 
 func (ch *CacheHandler) setIngressRouteStatus(st statusable) {

--- a/internal/contour/contour_test.go
+++ b/internal/contour/contour_test.go
@@ -65,4 +65,5 @@ func ports(ps ...int32) []v1.EndpointPort {
 
 type nullNotifier int
 
-func (nn *nullNotifier) OnChange(kc *dag.KubernetesCache) {}
+func (nn *nullNotifier) OnChange(kc *dag.KubernetesCache)  {}
+func (nn *nullNotifier) ShouldUpdate(obj interface{}) bool { return true }

--- a/internal/contour/listener_test.go
+++ b/internal/contour/listener_test.go
@@ -625,7 +625,7 @@ func TestListenerVisit(t *testing.T) {
 			for _, o := range tc.objs {
 				reh.OnAdd(o)
 			}
-			root := dag.BuildDAG(&reh.KubernetesCache)
+			root, _ := dag.BuildDAG(&reh.KubernetesCache)
 			got := visitListeners(root, &tc.ListenerVisitorConfig)
 			if !cmp.Equal(tc.want, got) {
 				t.Fatalf("expected:\n%+v\ngot:\n%+v", tc.want, got)

--- a/internal/contour/route_test.go
+++ b/internal/contour/route_test.go
@@ -1839,7 +1839,7 @@ func TestRouteVisit(t *testing.T) {
 			for _, o := range tc.objs {
 				reh.OnAdd(o)
 			}
-			root := dag.BuildDAG(&reh.KubernetesCache)
+			root, _ := dag.BuildDAG(&reh.KubernetesCache)
 			got := visitRoutes(root)
 			if diff := cmp.Diff(tc.want, got); diff != "" {
 				t.Fatal(diff)

--- a/internal/contour/secret_test.go
+++ b/internal/contour/secret_test.go
@@ -373,7 +373,7 @@ func TestSecretVisit(t *testing.T) {
 			for _, o := range tc.objs {
 				reh.OnAdd(o)
 			}
-			root := dag.BuildDAG(&reh.KubernetesCache)
+			root, _ := dag.BuildDAG(&reh.KubernetesCache)
 			got := visitSecrets(root)
 			if !reflect.DeepEqual(tc.want, got) {
 				t.Fatalf("expected:\n%+v\ngot:\n%+v", tc.want, got)

--- a/internal/dag/builder_test.go
+++ b/internal/dag/builder_test.go
@@ -2909,7 +2909,7 @@ func TestDAGInsert(t *testing.T) {
 			for _, o := range tc.objs {
 				kc.Insert(o)
 			}
-			dag := BuildDAG(&kc)
+			dag, _ := BuildDAG(&kc)
 
 			got := make(map[int]*Listener)
 			dag.Visit(listenerMap(got).Visit)
@@ -2978,32 +2978,32 @@ func TestBuilderLookupHTTPService(t *testing.T) {
 			}},
 		},
 	}
-	services := map[meta]*v1.Service{
-		{name: "service1", namespace: "default"}: s1,
+	services := map[Meta]*v1.Service{
+		{Name: "service1", Namespace: "default"}: s1,
 	}
 
 	tests := map[string]struct {
-		meta
+		Meta
 		port intstr.IntOrString
 		want *HTTPService
 	}{
 		"lookup service by port number": {
-			meta: meta{name: "service1", namespace: "default"},
+			Meta: Meta{Name: "service1", Namespace: "default"},
 			port: intstr.FromInt(8080),
 			want: httpService(s1),
 		},
-		"lookup service by port name": {
-			meta: meta{name: "service1", namespace: "default"},
+		"lookup service by port Name": {
+			Meta: Meta{Name: "service1", Namespace: "default"},
 			port: intstr.FromString("http"),
 			want: httpService(s1),
 		},
 		"lookup service by port number (as string)": {
-			meta: meta{name: "service1", namespace: "default"},
+			Meta: Meta{Name: "service1", Namespace: "default"},
 			port: intstr.Parse("8080"),
 			want: httpService(s1),
 		},
 		"lookup service by port number (from string)": {
-			meta: meta{name: "service1", namespace: "default"},
+			Meta: Meta{Name: "service1", Namespace: "default"},
 			port: intstr.FromString("8080"),
 			want: httpService(s1),
 		},
@@ -3016,7 +3016,7 @@ func TestBuilderLookupHTTPService(t *testing.T) {
 					services: services,
 				},
 			}
-			got := b.lookupHTTPService(tc.meta, tc.port)
+			got := b.lookupHTTPService(tc.Meta, tc.port)
 			if diff := cmp.Diff(tc.want, got); diff != "" {
 				t.Fatal(diff)
 			}
@@ -3117,7 +3117,7 @@ func TestDAGRootNamespaces(t *testing.T) {
 			for _, o := range tc.objs {
 				kc.Insert(o)
 			}
-			dag := BuildDAG(kc)
+			dag, _ := BuildDAG(kc)
 
 			var count int
 			dag.Visit(func(v Vertex) {
@@ -3578,7 +3578,7 @@ func TestDAGIngressRouteStatus(t *testing.T) {
 			for _, o := range tc.objs {
 				kc.Insert(o)
 			}
-			dag := BuildDAG(kc)
+			dag, _ := BuildDAG(kc)
 			got := dag.Statuses()
 			if len(tc.want) != len(got) {
 				t.Fatalf("expected:\n%v\ngot\n%v", tc.want, got)
@@ -3699,7 +3699,7 @@ func TestDAGIngressRouteUniqueFQDNs(t *testing.T) {
 			for _, o := range tc.objs {
 				kc.Insert(o)
 			}
-			dag := BuildDAG(&kc)
+			dag, _ := BuildDAG(&kc)
 			got := make(map[int]*Listener)
 			dag.Visit(listenerMap(got).Visit)
 
@@ -3826,38 +3826,38 @@ func TestEnforceRoute(t *testing.T) {
 func TestSplitSecret(t *testing.T) {
 	tests := map[string]struct {
 		secret, defns string
-		want          meta
+		want          Meta
 	}{
 		"no namespace": {
 			secret: "secret",
 			defns:  "default",
-			want: meta{
-				name:      "secret",
-				namespace: "default",
+			want: Meta{
+				Name:      "secret",
+				Namespace: "default",
 			},
 		},
 		"with namespace": {
 			secret: "ns1/secret",
 			defns:  "default",
-			want: meta{
-				name:      "secret",
-				namespace: "ns1",
+			want: Meta{
+				Name:      "secret",
+				Namespace: "ns1",
 			},
 		},
 		"missing namespace": {
 			secret: "/secret",
 			defns:  "default",
-			want: meta{
-				name:      "secret",
-				namespace: "default",
+			want: Meta{
+				Name:      "secret",
+				Namespace: "default",
 			},
 		},
 		"missing secret name": {
 			secret: "secret/",
 			defns:  "default",
-			want: meta{
-				name:      "",
-				namespace: "secret",
+			want: Meta{
+				Name:      "",
+				Namespace: "secret",
 			},
 		},
 	}
@@ -3866,7 +3866,7 @@ func TestSplitSecret(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			got := splitSecret(tc.secret, tc.defns)
 			opts := []cmp.Option{
-				cmp.AllowUnexported(meta{}),
+				cmp.AllowUnexported(Meta{}),
 			}
 			if diff := cmp.Diff(tc.want, got, opts...); diff != "" {
 				t.Fatal(diff)

--- a/internal/dag/dag.go
+++ b/internal/dag/dag.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2/auth"
 	ingressroutev1 "github.com/heptio/contour/apis/contour/v1beta1"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 )
 
 // A DAG represents a directed acylic graph of objects representing the relationship
@@ -32,6 +32,10 @@ type DAG struct {
 
 	// status computed while building this dag.
 	statuses []Status
+
+	// Kubernetes objects in the DAG that are referenced
+	Secrets  map[Meta]Empty
+	Services map[Meta]Empty
 }
 
 // Visit calls fn on each root of this DAG.
@@ -308,9 +312,9 @@ func (s *Secret) PrivateKey() []byte {
 	return s.Object.Data[v1.TLSPrivateKeyKey]
 }
 
-func (s *Secret) toMeta() meta {
-	return meta{
-		name:      s.Name(),
-		namespace: s.Namespace(),
+func (s *Secret) toMeta() Meta {
+	return Meta{
+		Name:      s.Name(),
+		Namespace: s.Namespace(),
 	}
 }

--- a/internal/debug/dot.go
+++ b/internal/debug/dot.go
@@ -90,7 +90,8 @@ func (dw *dotWriter) writeDot(w io.Writer) {
 		})
 	}
 
-	dag.BuildDAG(dw.kc).Visit(visit)
+	d, _ := dag.BuildDAG(dw.kc)
+	d.Visit(visit)
 
 	fmt.Fprintln(w, "}")
 }

--- a/internal/e2e/cds_test.go
+++ b/internal/e2e/cds_test.go
@@ -955,6 +955,84 @@ func TestExternalNameService(t *testing.T) {
 	}, streamCDS(t, cc))
 }
 
+// Test processing a service that exists but is not referenced
+func TestUnreferencedService(t *testing.T) {
+	rh, cc, done := setup(t)
+	defer done()
+
+	rh.OnAdd(&v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "kuard",
+			Namespace: "default",
+		},
+		Spec: v1.ServiceSpec{
+			Ports: []v1.ServicePort{{
+				Protocol:   "TCP",
+				Port:       80,
+				TargetPort: intstr.FromInt(8080),
+			}},
+		},
+	})
+
+	rh.OnAdd(&ingressroutev1.IngressRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "simple",
+			Namespace: "default",
+		},
+		Spec: ingressroutev1.IngressRouteSpec{
+			VirtualHost: &ingressroutev1.VirtualHost{Fqdn: "www.example.com"},
+			Routes: []ingressroutev1.Route{{
+				Match: "/a",
+				Services: []ingressroutev1.Service{{
+					Name:   "kuard",
+					Port:   80,
+					Weight: 90,
+				}},
+			}, {
+				Match: "/b",
+				Services: []ingressroutev1.Service{{
+					Name:   "kuard",
+					Port:   80,
+					Weight: 60,
+				}},
+			}},
+		},
+	})
+
+	assertEqual(t, &v2.DiscoveryResponse{
+		VersionInfo: "2",
+		Resources: []types.Any{
+			any(t, cluster("default/kuard/80/da39a3ee5e", "default/kuard", "default_kuard_80")),
+		},
+		TypeUrl: clusterType,
+		Nonce:   "2",
+	}, streamCDS(t, cc))
+
+	// This service which is added should not cause a DAG rebuild
+	rh.OnAdd(&v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "kuard-notreferenced",
+			Namespace: "default",
+		},
+		Spec: v1.ServiceSpec{
+			Ports: []v1.ServicePort{{
+				Protocol:   "TCP",
+				Port:       80,
+				TargetPort: intstr.FromInt(8080),
+			}},
+		},
+	})
+
+	assertEqual(t, &v2.DiscoveryResponse{
+		VersionInfo: "2",
+		Resources: []types.Any{
+			any(t, cluster("default/kuard/80/da39a3ee5e", "default/kuard", "default_kuard_80")),
+		},
+		TypeUrl: clusterType,
+		Nonce:   "2",
+	}, streamCDS(t, cc))
+}
+
 func serviceWithAnnotations(ns, name string, annotations map[string]string, ports ...v1.ServicePort) *v1.Service {
 	return &v1.Service{
 		ObjectMeta: metav1.ObjectMeta{

--- a/internal/e2e/rds_test.go
+++ b/internal/e2e/rds_test.go
@@ -303,7 +303,7 @@ func TestEditIngressInPlace(t *testing.T) {
 	rh.OnAdd(s2)
 
 	assertEqual(t, &v2.DiscoveryResponse{
-		VersionInfo: "3",
+		VersionInfo: "2",
 		Resources: []types.Any{
 			any(t, &v2.RouteConfiguration{
 				Name: "ingress_http",
@@ -322,7 +322,7 @@ func TestEditIngressInPlace(t *testing.T) {
 			}),
 		},
 		TypeUrl: routeType,
-		Nonce:   "3",
+		Nonce:   "2",
 	}, streamRDS(t, cc))
 
 	// i2 is like i1 but adds a second route
@@ -353,7 +353,7 @@ func TestEditIngressInPlace(t *testing.T) {
 	}
 	rh.OnUpdate(i1, i2)
 	assertEqual(t, &v2.DiscoveryResponse{
-		VersionInfo: "4",
+		VersionInfo: "3",
 		Resources: []types.Any{
 			any(t, &v2.RouteConfiguration{
 				Name: "ingress_http",
@@ -376,7 +376,7 @@ func TestEditIngressInPlace(t *testing.T) {
 			}),
 		},
 		TypeUrl: routeType,
-		Nonce:   "4",
+		Nonce:   "3",
 	}, streamRDS(t, cc))
 
 	// i3 is like i2, but adds the ingress.kubernetes.io/force-ssl-redirect: "true" annotation
@@ -412,7 +412,7 @@ func TestEditIngressInPlace(t *testing.T) {
 	}
 	rh.OnUpdate(i2, i3)
 	assertEqual(t, &v2.DiscoveryResponse{
-		VersionInfo: "5",
+		VersionInfo: "4",
 		Resources: []types.Any{
 			any(t, &v2.RouteConfiguration{
 				Name: "ingress_http",
@@ -430,7 +430,7 @@ func TestEditIngressInPlace(t *testing.T) {
 			any(t, &v2.RouteConfiguration{Name: "ingress_https"}),
 		},
 		TypeUrl: routeType,
-		Nonce:   "5",
+		Nonce:   "4",
 	}, streamRDS(t, cc))
 
 	rh.OnAdd(&v1.Secret{
@@ -483,7 +483,7 @@ func TestEditIngressInPlace(t *testing.T) {
 	}
 	rh.OnUpdate(i3, i4)
 	assertEqual(t, &v2.DiscoveryResponse{
-		VersionInfo: "7",
+		VersionInfo: "6",
 		Resources: []types.Any{
 			any(t, &v2.RouteConfiguration{
 				Name: "ingress_http",
@@ -515,7 +515,7 @@ func TestEditIngressInPlace(t *testing.T) {
 				}}}),
 		},
 		TypeUrl: routeType,
-		Nonce:   "7",
+		Nonce:   "6",
 	}, streamRDS(t, cc))
 }
 

--- a/internal/e2e/sds_test.go
+++ b/internal/e2e/sds_test.go
@@ -164,10 +164,6 @@ func TestSDSShouldNotIncrementVersionNumberForUnrelatedSecret(t *testing.T) {
 	}
 	rh.OnAdd(s2)
 
-	t.Skipf("See issue 1166")
-
-	// TODO(dfc) 1166: currently Contour will rebuild all the xDS tables
-	// when an unrelated secret changes.
 	c.Request(secretType).Equals(&v2.DiscoveryResponse{
 		VersionInfo: "2",
 		Resources: []types.Any{


### PR DESCRIPTION
Fixes #1166 & #1172 by adding a check to see when a secret/service is added or updated if any Ingress or IngressRoute references. If the secret/service is not referenced, then skip any dag rebuild, however, still add the secret/service to the cache so that if later the Ingress or IngressRoute object later references, then the secret/service will be available.

Signed-off-by: Steve Sloka <slokas@vmware.com>