### PR TITLE
internal/contour: fix format directive in status error message

### DIFF
--- a/internal/contour/cachehandler.go
+++ b/internal/contour/cachehandler.go
@@ -57,7 +57,7 @@ func (ch *CacheHandler) setIngressRouteStatus(st statusable) {
 	for _, s := range st.Statuses() {
 		err := ch.IngressRouteStatus.SetStatus(s.Status, s.Description, s.Object)
 		if err != nil {
-			ch.Errorf("Error Setting Status of IngressRoute: ", err)
+			ch.Errorf("Error Setting Status of IngressRoute: %v", err)
 		}
 	}
 }

--- a/internal/e2e/e2e.go
+++ b/internal/e2e/e2e.go
@@ -77,6 +77,7 @@ func setup(t *testing.T, opts ...func(*contour.ResourceEventHandler)) (cache.Res
 		},
 		Metrics:       metrics.NewMetrics(r),
 		ListenerCache: contour.NewListenerCache(statsAddress, statsPort),
+		FieldLogger:   log,
 	}
 
 	reh := contour.ResourceEventHandler{


### PR DESCRIPTION
Fix formatting directive in status error message and missing TestLogger
in e2e setup. Both of these problems were found while upgrading the
client Go libraries.

Signed-off-by: Dave Cheney <dave@cheney.net>