### PR TITLE
update to apps/v1 for deployment and ds

### DIFF
--- a/docs/cert-manager.md
+++ b/docs/cert-manager.md
@@ -196,7 +196,7 @@ We start with the deployment.
 Copy the following to a file called `deployment.yaml`:
 
 ```
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:

--- a/examples/deployment-grpc-v2/02-contour.yaml
+++ b/examples/deployment-grpc-v2/02-contour.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:

--- a/examples/ds-grpc-v2/02-contour.yaml
+++ b/examples/ds-grpc-v2/02-contour.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   labels:

--- a/examples/ds-hostnet-split/03-envoy.yaml
+++ b/examples/ds-hostnet-split/03-envoy.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   labels:

--- a/examples/ds-hostnet/02-contour.yaml
+++ b/examples/ds-hostnet/02-contour.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   labels:

--- a/examples/example-workload/ingressroute/00-common/02-deployments.yaml
+++ b/examples/example-workload/ingressroute/00-common/02-deployments.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: kuard
@@ -17,7 +17,7 @@ spec:
       - image: gcr.io/kuar-demo/kuard-amd64:1
         name: kuard
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: kuard

--- a/examples/grafana/03-grafana-deployment.yaml
+++ b/examples/grafana/03-grafana-deployment.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:

--- a/examples/prometheus/03-prometheus-alertmanager-deployment.yaml
+++ b/examples/prometheus/03-prometheus-alertmanager-deployment.yaml
@@ -26,7 +26,7 @@ spec:
     component: alertmanager
   type: ClusterIP
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:

--- a/examples/prometheus/03-prometheus-deployment.yaml
+++ b/examples/prometheus/03-prometheus-deployment.yaml
@@ -54,7 +54,7 @@ spec:
     app: prometheus
     component: server
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: prometheus

--- a/examples/prometheus/03-prometheus-node-exporter.yaml
+++ b/examples/prometheus/03-prometheus-node-exporter.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   labels:

--- a/examples/render/daemonset-rbac.yaml
+++ b/examples/render/daemonset-rbac.yaml
@@ -188,7 +188,7 @@ spec:
                   targetNamespaces:
                     type: array
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   labels:

--- a/examples/render/deployment-rbac.yaml
+++ b/examples/render/deployment-rbac.yaml
@@ -188,7 +188,7 @@ spec:
                   targetNamespaces:
                     type: array
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:


### PR DESCRIPTION
Updates `apiVersion` 
- for `Deployments` and `Daemonsets`.
- at documentation and examples.
- from `extensions/v1beta1` to `apps/v1`.

Fixes #1181 

**NOT** fixed
- `Ingress` resources are served since 1.14 under `networking.k8s.io/v1beta1` but will remain working at `extensions/v1beta1` until 1.19. For backwards compatibility (pre 1.14 clusters using contour) upgrading `ingress` should not be done yet.


Signed-off-by: Pablo Mercado <odacremolbap@gmail.com>