### PR TITLE
go.mod: update to go-control-plane v0.8.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.12
 require (
 	cloud.google.com/go v0.37.4 // indirect
 	github.com/client9/misspell v0.3.4
-	github.com/envoyproxy/go-control-plane v0.8.0
+	github.com/envoyproxy/go-control-plane v0.8.1
 	github.com/evanphx/json-patch v4.1.0+incompatible
 	github.com/ghodss/yaml v1.0.0 // indirect
 	github.com/gogo/protobuf v1.2.1

--- a/internal/grpc/server.go
+++ b/internal/grpc/server.go
@@ -70,8 +70,16 @@ func (s *grpcServer) FetchEndpoints(_ context.Context, req *v2.DiscoveryRequest)
 	return nil, status.Errorf(codes.Unimplemented, "FetchEndpoints unimplemented")
 }
 
+func (s *grpcServer) DeltaEndpoints(v2.EndpointDiscoveryService_DeltaEndpointsServer) error {
+	return status.Errorf(codes.Unimplemented, "DeltaEndpoints unimplemented")
+}
+
 func (s *grpcServer) FetchListeners(_ context.Context, req *v2.DiscoveryRequest) (*v2.DiscoveryResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "FetchListeners unimplemented")
+}
+
+func (s *grpcServer) DeltaListeners(v2.ListenerDiscoveryService_DeltaListenersServer) error {
+	return status.Errorf(codes.Unimplemented, "DeltaListeners unimplemented")
 }
 
 func (s *grpcServer) FetchRoutes(_ context.Context, req *v2.DiscoveryRequest) (*v2.DiscoveryResponse, error) {
@@ -80,6 +88,10 @@ func (s *grpcServer) FetchRoutes(_ context.Context, req *v2.DiscoveryRequest) (*
 
 func (s *grpcServer) FetchSecrets(_ context.Context, req *v2.DiscoveryRequest) (*v2.DiscoveryResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "FetchSecrets unimplemented")
+}
+
+func (s *grpcServer) DeltaSecrets(discovery.SecretDiscoveryService_DeltaSecretsServer) error {
+	return status.Errorf(codes.Unimplemented, "DeltaSecrets unimplemented")
 }
 
 func (s *grpcServer) StreamClusters(srv v2.ClusterDiscoveryService_StreamClustersServer) error {


### PR DESCRIPTION
Fixes #1173

Also stub out some new gRPC methods which we don't implement.

Signed-off-by: Dave Cheney <dave@cheney.net>