### PR TITLE
Add example kind configuration to examples directory

### DIFF
--- a/docs/deploy-options.md
+++ b/docs/deploy-options.md
@@ -78,11 +78,11 @@ nodes:
     listenAddress: "0.0.0.0"
 ```
 
-Save the previous yaml to a file named `kind.config.yaml`.
-Then run the create cluster command passing the config file as a parameter:
+Then run the create cluster command passing the config file as a parameter.
+This file is in the `examples/kind` directory:
 
 ```bash
-$ kind create cluster --config kind.config.yaml  
+$ kind create cluster --config examples/kind/kind-expose-port.yaml
 ```
 
 Then, your CONTOUR_IP (as used below) will just be `localhost:8080`.

--- a/examples/kind/kind-expose-port.yaml
+++ b/examples/kind/kind-expose-port.yaml
@@ -1,0 +1,9 @@
+kind: Cluster
+apiVersion: kind.sigs.k8s.io/v1alpha3
+nodes:
+- role: control-plane
+- role: worker
+  extraPortMappings:
+  - containerPort: 8080
+    hostPort: 8080
+    listenAddress: "0.0.0.0"


### PR DESCRIPTION
Updates #1196 by adding kind configuration to the `examples` directory.

Signed-off-by: Steve Sloka <slokas@vmware.com>