### PR TITLE
 update split deployments with TLS secured gRPC

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ SRCDIRS := ./cmd ./internal ./apis
 PKGS := $(shell GO111MODULE=on go list -mod=readonly ./cmd/... ./internal/...)
 LOCAL_BOOTSTRAP_CONFIG = localenvoyconfig.yaml
 SECURE_LOCAL_BOOTSTRAP_CONFIG = securelocalenvoyconfig.yaml
+PHONY = gencerts
 
 TAG_LATEST ?= false
 # Used to supply a local Envoy docker container an IP to connect to that is running
@@ -118,3 +119,51 @@ updategenerated:
 gofmt:
 	@echo Checking code is gofmted
 	@test -z "$(shell gofmt -s -l -d -e $(SRCDIRS) | tee /dev/stderr)"
+
+gencerts: certs/contourcert.pem certs/envoycert.pem
+	@echo "certs are generated."
+
+applycerts: gencerts
+	@kubectl create secret -n heptio-contour generic cacert --from-file=./certs/CAcert.pem
+	@kubectl create secret -n heptio-contour generic contourcerts --from-file=./certs/contourkey.pem --from-file=./certs/contourcert.pem
+	@kubectl create secret -n heptio-contour generic envoycerts --from-file=./certs/envoykey.pem --from-file=./certs/envoycert.pem
+
+certs/CAkey.pem:
+	@echo No CA keypair present, generating
+	openssl req -x509 -new -nodes -keyout certs/CAkey.pem \
+		-sha256 -days 1825 -out certs/CAcert.pem \
+		-subj "/O=Project Contour/CN=Contour CA"
+
+certs/contourkey.pem:
+	@echo Generating new contour key
+	openssl genrsa -out certs/contourkey.pem 2048
+
+certs/contourcert.pem: certs/CAkey.pem certs/contourkey.pem
+	@echo Generating new contour cert
+	openssl req -new -key certs/contourkey.pem \
+		-out certs/contour.csr \
+		-subj "/O=Project Contour/CN=contour"
+	openssl x509 -req -in certs/contour.csr \
+		-CA certs/CAcert.pem \
+		-CAkey certs/CAkey.pem \
+		-CAcreateserial \
+		-out certs/contourcert.pem \
+		-days 1825 -sha256 \
+		-extfile _integration/cert-contour.ext
+
+certs/envoykey.pem:
+	@echo Generating new Envoy key
+	openssl genrsa -out certs/envoykey.pem 2048
+
+certs/envoycert.pem: certs/CAkey.pem certs/envoykey.pem
+	@echo generating new Envoy Cert
+	openssl req -new -key certs/envoykey.pem \
+		-out certs/envoy.csr \
+		-subj "/O=Project Contour/CN=envoy"
+	openssl x509 -req -in certs/envoy.csr \
+		-CA certs/CAcert.pem \
+		-CAkey certs/CAkey.pem \
+		-CAcreateserial \
+		-out certs/envoycert.pem \
+		-days 1825 -sha256 \
+		-extfile _integration/cert-envoy.ext

--- a/Makefile
+++ b/Makefile
@@ -125,8 +125,11 @@ gencerts: certs/contourcert.pem certs/envoycert.pem
 
 applycerts: gencerts
 	@kubectl create secret -n heptio-contour generic cacert --from-file=./certs/CAcert.pem
-	@kubectl create secret -n heptio-contour generic contourcerts --from-file=./certs/contourkey.pem --from-file=./certs/contourcert.pem
-	@kubectl create secret -n heptio-contour generic envoycerts --from-file=./certs/envoykey.pem --from-file=./certs/envoycert.pem
+	@kubectl create secret -n heptio-contour tls contourcert --key=./certs/contourkey.pem --cert=./certs/contourcert.pem
+	@kubectl create secret -n heptio-contour tls envoycert --key=./certs/envoykey.pem --cert=./certs/envoycert.pem
+
+cleancerts:
+	@kubectl delete secret -n heptio-contour cacert contourcert envoycert
 
 certs/CAkey.pem:
 	@echo No CA keypair present, generating

--- a/_integration/cert-contour.ext
+++ b/_integration/cert-contour.ext
@@ -1,0 +1,11 @@
+authorityKeyIdentifier=keyid,issuer
+basicConstraints=CA:FALSE
+keyUsage = digitalSignature, nonRepudiation, keyEncipherment, dataEncipherment
+subjectAltName = @alt_names
+
+[alt_names]
+DNS.1 = contour
+DNS.2 = 127.0.0.1
+DNS.4 = contour.heptio-contour
+DNS.5 = contour.heptio-contour.svc
+DNS.5 = contour.heptio-contour.svc.cluster.local

--- a/_integration/cert-envoy.ext
+++ b/_integration/cert-envoy.ext
@@ -1,0 +1,8 @@
+authorityKeyIdentifier=keyid,issuer
+basicConstraints=CA:FALSE
+keyUsage = digitalSignature, nonRepudiation, keyEncipherment, dataEncipherment
+subjectAltName = @alt_names
+
+[alt_names]
+DNS.1 = envoy
+DNS.2 = 127.0.0.1

--- a/docs/deploy-seperate-pods.md
+++ b/docs/deploy-seperate-pods.md
@@ -5,23 +5,31 @@ This configuration has several advantages:
 
 1. Envoy runs as a daemonset which allows for distributed scaling across workers in the cluster
 2. Envoy runs on host networking which exposes Envoy directly without additional networking hops
+3. Communication between Contour and Envoy is secured by mutually-checked self-signed certificates.
 
 ## Moving parts
 
 - Contour is run as Deployment and Envoy as a Daemonset
 - Envoy runs on host networking
 - Envoy runs on ports 80 & 443
+- The following certificates must be present as Secrets in the `heptio-contour` namespace:
+    - `cacert`: must contain a `CAcert.pem` key that contains a CA certificate that signs the other certificates.
+    - `contourcerts`: must contain `contourcert.pem` and `contourkey.pem` keys that contain a certificate and key for Contour. The certificate must be valid for the name `contour` either via CN or SAN.
+    - `envoycerts`: must contain `envoycert.pem` and `envoykey.pem` keys that contain a certificate and key for Envoy.
 
 ## Deploy Contour
 
 1. [Clone the Contour repository][1] and cd into the repo.
-2. Run `kubectl apply -f examples/ds-hostnet-split/`
+2. Ensure you have `openssl` installed (or at least something that provides that command.`)
+2. Generate the keypairs required to secure the TLS connection between Contour and Envoy. You can do that using `make gencerts` and then `make applycerts`, assuming that your kubectl will connect to the cluster you want. If not, follow the [detailed generation directions][2]. 
+3. Run `kubectl apply -f examples/ds-hostnet-split/`
 
 **NOTE**: The current configuration exposes the `/stats` path from the Envoy Admin UI so that Prometheus can scrape for metrics.
 
 # Test
 
-1. Install a workload (see the kuard example in the [main deployment guide][2]).
+1. Install a workload (see the kuard example in the [main deployment guide][3]).
 
 [1]: ../CONTRIBUTING.md
-[2]: deploy-options.md#test
+[2]: ./grpc-tls-howto.md
+[3]: deploy-options.md#test

--- a/docs/grpc-tls-howto.md
+++ b/docs/grpc-tls-howto.md
@@ -1,0 +1,95 @@
+# Generating example gRPC TLS certificates
+
+## Outcomes
+
+The outcomes of this is that we will have three Secrets available in the `heptio-contour` namespace:
+- cacert: contains the CA's public certificate.
+- contourcerts: contains Contour's keypair, used for serving TLS secured gRPC. This must be a valid certificate for the name `contour` in order for this to work. This is currently hardcoded by Contour.
+- envoycerts: contains Envoy's keypair, used as a client for connecting to Contour.
+
+For the purposes of this documentation, we'll be doing the same thing the `Makefile` does and putting the certs in a `certs/` subdirectory of the downloaded repo.
+
+## Caveats and warnings
+
+**Don't use this to create your production certificate infrastructure!**
+This is intended as an example to help you get started. For any real deployment, you should **carefullY** manage all the certificates and control who has access to them. Make sure you don't commit them to any git repos either.
+
+## Generating a CA keypair
+
+First, we need to generate a keypair:
+```
+openssl req -x509 -new -nodes \
+    -keyout certs/CAkey.pem -sha256 \
+    -days 1825 -out certs/CAcert.pem \
+    -subj "/O=Project Contour/CN=Contour CA"
+```
+
+Then, the new CA key will be stored in `certs/CAkey.pem` and the cert in `certs/CAcert.pem`.
+
+## Generating Contour's keypair
+
+Then, we need to generate a keypair for Contour. First, we make a new private key:
+```
+openssl genrsa -out certs/contourkey.pem 2048
+```
+
+Then, we create a CSR and have our CA sign the CSR and issue a cert. This uses the file [_integration/cert-contour.ext](./_integration/cert-contour.ext), which ensures that at least one of the valid names of the certificate is the bareword `contour`. This is required for the handshake to succeed, as `contour bootstrap` configures Envoy to pass this as the SNI for the connection.
+
+```
+openssl req -new -key certs/contourkey.pem \
+	-out certs/contour.csr \
+	-subj "/O=Project Contour/CN=contour"
+openssl x509 -req -in certs/contour.csr \
+    -CA certs/CAcert.pem \
+    -CAkey certs/CAkey.pem \
+    -CAcreateserial \
+    -out certs/contourcert.pem \
+    -days 1825 -sha256 \
+    -extfile _integration/cert-contour.ext
+```
+
+At this point, the contour cert and key are in the files `certs/contourcert.pem` and `certs/contourkey.pem` respectively.
+
+## Generating Envoy's keypair
+
+Next, we generate a keypair for Envoy:
+```
+openssl genrsa -out certs/envoykey.pem 2048
+```
+
+Then, we generated a CSR and have the CA sign it:
+```
+openssl req -new -key certs/envoykey.pem \
+	-out certs/envoy.csr \
+	-subj "/O=Project Contour/CN=envoy"
+openssl x509 -req -in certs/envoy.csr \
+    -CA certs/CAcert.pem \
+    -CAkey certs/CAkey.pem \
+    -CAcreateserial \
+    -out certs/envoycert.pem \
+    -days 1825 -sha256 \
+    -extfile _integration/cert-envoy.ext
+```
+
+Like the contour cert, this CSR uses the file [_integration/cert-envoy.ext](./_integration/cert-envoy.ext). However, in this case, there are no special names required.
+
+## Putting the certs in the cluster
+
+Next, we create the required secrets in the target Kubernetes cluster:
+
+```
+kubectl create secret -n heptio-contour generic cacert --from-file=./certs/CAcert.pem
+kubectl create secret -n heptio-contour generic contourcerts --from-file=./certs/contourkey.pem --from-file=./certs/contourcert.pem
+kubectl create secret -n heptio-contour generic envoycerts --from-file=./certs/envoykey.pem --from-file=./certs/envoycert.pem
+```
+
+Note that we don't put the CA **key** into the cluster, there's no reason for that to be there, and that would create a security problem.
+
+# Conclusion
+
+Once this process is done, doing a 
+```
+kubectl apply -f examples/ds-hostnet-split/
+```
+
+Will successfully apply the pods. Otherwise, the pods will not be able to be created, since the required Secrets will not be present.

--- a/docs/grpc-tls-howto.md
+++ b/docs/grpc-tls-howto.md
@@ -79,11 +79,11 @@ Next, we create the required secrets in the target Kubernetes cluster:
 
 ```
 kubectl create secret -n heptio-contour generic cacert --from-file=./certs/CAcert.pem
-kubectl create secret -n heptio-contour generic contourcerts --from-file=./certs/contourkey.pem --from-file=./certs/contourcert.pem
-kubectl create secret -n heptio-contour generic envoycerts --from-file=./certs/envoykey.pem --from-file=./certs/envoycert.pem
+kubectl create secret -n heptio-contour tls contourcert --key=./certs/contourkey.pem --cert=./certs/contourcert.pem
+kubectl create secret -n heptio-contour generic envoycert --key=./certs/envoykey.pem --cert=./certs/envoycert.pem
 ```
 
-Note that we don't put the CA **key** into the cluster, there's no reason for that to be there, and that would create a security problem.
+Note that we don't put the CA **key** into the cluster, there's no reason for that to be there, and that would create a security problem. That also means that the `cacert` secret can't be a `tls` type secret, as they must be a keypair.
 
 # Conclusion
 

--- a/examples/ds-hostnet-split/03-contour.yaml
+++ b/examples/ds-hostnet-split/03-contour.yaml
@@ -32,9 +32,12 @@ spec:
         - serve
         - --incluster
         - --xds-address=0.0.0.0
-        - --xds-port=$(CONTOUR_SERVICE_PORT)
+        - --xds-port=8001
         - --envoy-service-http-port=80
         - --envoy-service-https-port=443
+        - --contour-cafile=/ca/CAcert.pem
+        - --contour-cert-file=/certs/contourcert.pem
+        - --contour-key-file=/certs/contourkey.pem
         command: ["contour"]
         image: gcr.io/heptio-images/contour:master
         imagePullPolicy: Always
@@ -54,5 +57,20 @@ spec:
           httpGet:
             path: /healthz
             port: 8000
+        volumeMounts:
+          - name: contourcerts
+            mountPath: "/certs"
+            readOnly: true
+          - name: cacert
+            mountPath: "/ca"
+            readOnly: true
       dnsPolicy: ClusterFirst
       serviceAccountName: contour
+      volumes:
+        - name: contourcerts
+          secret:
+            secretName: contourcerts
+        - name: cacert
+          secret:
+            secretName:   cacert
+

--- a/examples/ds-hostnet-split/03-contour.yaml
+++ b/examples/ds-hostnet-split/03-contour.yaml
@@ -36,8 +36,8 @@ spec:
         - --envoy-service-http-port=80
         - --envoy-service-https-port=443
         - --contour-cafile=/ca/CAcert.pem
-        - --contour-cert-file=/certs/contourcert.pem
-        - --contour-key-file=/certs/contourkey.pem
+        - --contour-cert-file=/certs/tls.crt
+        - --contour-key-file=/certs/tls.key
         command: ["contour"]
         image: gcr.io/heptio-images/contour:master
         imagePullPolicy: Always
@@ -58,7 +58,7 @@ spec:
             path: /healthz
             port: 8000
         volumeMounts:
-          - name: contourcerts
+          - name: contourcert
             mountPath: "/certs"
             readOnly: true
           - name: cacert
@@ -67,9 +67,9 @@ spec:
       dnsPolicy: ClusterFirst
       serviceAccountName: contour
       volumes:
-        - name: contourcerts
+        - name: contourcert
           secret:
-            secretName: contourcerts
+            secretName: contourcert
         - name: cacert
           secret:
             secretName:   cacert

--- a/examples/ds-hostnet-split/03-envoy.yaml
+++ b/examples/ds-hostnet-split/03-envoy.yaml
@@ -53,7 +53,7 @@ spec:
         volumeMounts:
           - name: contour-config
             mountPath: /config
-          - name: envoycerts
+          - name: envoycert
             mountPath: /certs
           - name: cacert
             mountPath: /ca
@@ -72,8 +72,8 @@ spec:
         - --xds-port
         - "8001"
         - --envoy-cafile=/ca/CAcert.pem
-        - --envoy-cert-file=/certs/envoycert.pem
-        - --envoy-key-file=/certs/envoykey.pem
+        - --envoy-cert-file=/certs/tls.crt
+        - --envoy-key-file=/certs/tls.key
         command:
         - contour
         image: gcr.io/heptio-images/contour:master
@@ -82,7 +82,7 @@ spec:
         volumeMounts:
         - name: contour-config
           mountPath: /config
-        - name: envoycerts
+        - name: envoycert
           mountPath: /certs
           readOnly: true
         - name: cacert
@@ -97,9 +97,9 @@ spec:
       volumes:
         - name: contour-config
           emptyDir: {}
-        - name: envoycerts
+        - name: envoycert
           secret:
-            secretName: envoycerts
+            secretName: envoycert
         - name: cacert
           secret:
             secretName:   cacert

--- a/examples/ds-hostnet-split/03-envoy.yaml
+++ b/examples/ds-hostnet-split/03-envoy.yaml
@@ -53,6 +53,10 @@ spec:
         volumeMounts:
           - name: contour-config
             mountPath: /config
+          - name: envoycerts
+            mountPath: /certs
+          - name: cacert
+            mountPath: /ca
         lifecycle:
           preStop:
             exec:
@@ -64,9 +68,12 @@ spec:
         - bootstrap
         - /config/contour.json
         - --xds-address
-        - $(CONTOUR_SERVICE_HOST)
+        - contour
         - --xds-port
-        - $(CONTOUR_SERVICE_PORT)
+        - "8001"
+        - --envoy-cafile=/ca/CAcert.pem
+        - --envoy-cert-file=/certs/envoycert.pem
+        - --envoy-key-file=/certs/envoykey.pem
         command:
         - contour
         image: gcr.io/heptio-images/contour:master
@@ -75,6 +82,12 @@ spec:
         volumeMounts:
         - name: contour-config
           mountPath: /config
+        - name: envoycerts
+          mountPath: /certs
+          readOnly: true
+        - name: cacert
+          mountPath: /ca
+          readOnly: true
         env:
         - name: CONTOUR_NAMESPACE
           valueFrom:
@@ -84,4 +97,10 @@ spec:
       volumes:
         - name: contour-config
           emptyDir: {}
+        - name: envoycerts
+          secret:
+            secretName: envoycerts
+        - name: cacert
+          secret:
+            secretName:   cacert
       restartPolicy: Always


### PR DESCRIPTION
- Add `make gencerts` and `make applycerts` to Makefile
- Update `ds-hostnet-split` to expect the new certs.
- Add documentation for gRPC with TLS including example.
- Change split deployments to use the 'contour' name instead of the service env vars. Fixes #1127 

Fixes #862
Updates #881 