### PR TITLE
internal/dag: replace dag.Builder with dag.KubernetesCache

### DIFF
--- a/cmd/contour/contour.go
+++ b/cmd/contour/contour.go
@@ -134,9 +134,7 @@ func main() {
 		Service: httpsvc.Service{
 			FieldLogger: log.WithField("context", "debugsvc"),
 		},
-		// plumb the DAGAdapter's Builder through
-		// to the debug handler
-		Builder: &reh.Builder,
+		KubernetesCache: &reh.KubernetesCache,
 	}
 
 	serve.Flag("debug-http-address", "address the debug http endpoint will bind to").Default("127.0.0.1").StringVar(&debugsvc.Addr)

--- a/internal/contour/cachehandler.go
+++ b/internal/contour/cachehandler.go
@@ -41,10 +41,10 @@ type statusable interface {
 	Statuses() []dag.Status
 }
 
-func (ch *CacheHandler) OnChange(b *dag.Builder) {
+func (ch *CacheHandler) OnChange(kc *dag.KubernetesCache) {
 	timer := prometheus.NewTimer(ch.CacheHandlerOnUpdateSummary)
 	defer timer.ObserveDuration()
-	dag := dag.BuildDAG(&b.KubernetesCache)
+	dag := dag.BuildDAG(kc)
 	ch.setIngressRouteStatus(dag)
 	ch.updateSecrets(dag)
 	ch.updateListeners(dag)

--- a/internal/contour/cachehandler.go
+++ b/internal/contour/cachehandler.go
@@ -44,7 +44,7 @@ type statusable interface {
 func (ch *CacheHandler) OnChange(b *dag.Builder) {
 	timer := prometheus.NewTimer(ch.CacheHandlerOnUpdateSummary)
 	defer timer.ObserveDuration()
-	dag := b.Build()
+	dag := dag.BuildDAG(&b.KubernetesCache)
 	ch.setIngressRouteStatus(dag)
 	ch.updateSecrets(dag)
 	ch.updateListeners(dag)

--- a/internal/contour/cachehandler_test.go
+++ b/internal/contour/cachehandler_test.go
@@ -529,7 +529,7 @@ func TestIngressRouteMetrics(t *testing.T) {
 			for _, o := range tc.objs {
 				b.Insert(o)
 			}
-			dag := b.Build()
+			dag := dag.BuildDAG(&b.KubernetesCache)
 			gotMetrics := calculateIngressRouteMetric(dag)
 			if !reflect.DeepEqual(tc.want.Root, gotMetrics.Root) {
 				t.Fatalf("(metrics-Root) expected to find: %v but got: %v", tc.want.Root, gotMetrics.Root)

--- a/internal/contour/cachehandler_test.go
+++ b/internal/contour/cachehandler_test.go
@@ -521,15 +521,13 @@ func TestIngressRouteMetrics(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			b := dag.Builder{
-				KubernetesCache: dag.KubernetesCache{
-					IngressRouteRootNamespaces: tc.rootNamespaces,
-				},
+			kc := &dag.KubernetesCache{
+				IngressRouteRootNamespaces: tc.rootNamespaces,
 			}
 			for _, o := range tc.objs {
-				b.Insert(o)
+				kc.Insert(o)
 			}
-			dag := dag.BuildDAG(&b.KubernetesCache)
+			dag := dag.BuildDAG(kc)
 			gotMetrics := calculateIngressRouteMetric(dag)
 			if !reflect.DeepEqual(tc.want.Root, gotMetrics.Root) {
 				t.Fatalf("(metrics-Root) expected to find: %v but got: %v", tc.want.Root, gotMetrics.Root)

--- a/internal/contour/cluster_test.go
+++ b/internal/contour/cluster_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/gogo/protobuf/proto"
 	"github.com/google/go-cmp/cmp"
 	ingressroutev1 "github.com/heptio/contour/apis/contour/v1beta1"
+	"github.com/heptio/contour/internal/dag"
 	"github.com/heptio/contour/internal/envoy"
 	"github.com/heptio/contour/internal/metrics"
 	"github.com/prometheus/client_golang/prometheus"
@@ -866,7 +867,7 @@ func TestClusterVisit(t *testing.T) {
 			for _, o := range tc.objs {
 				reh.OnAdd(o)
 			}
-			root := reh.Build()
+			root := dag.BuildDAG(&reh.KubernetesCache)
 			got := visitClusters(root)
 			if diff := cmp.Diff(tc.want, got); diff != "" {
 				t.Fatal(diff)

--- a/internal/contour/contour_test.go
+++ b/internal/contour/contour_test.go
@@ -65,4 +65,4 @@ func ports(ps ...int32) []v1.EndpointPort {
 
 type nullNotifier int
 
-func (nn *nullNotifier) OnChange(b *dag.Builder) {}
+func (nn *nullNotifier) OnChange(kc *dag.KubernetesCache) {}

--- a/internal/contour/holdoff.go
+++ b/internal/contour/holdoff.go
@@ -46,7 +46,7 @@ type HoldoffNotifier struct {
 	pending counter
 }
 
-func (hn *HoldoffNotifier) OnChange(builder *dag.Builder) {
+func (hn *HoldoffNotifier) OnChange(kc *dag.KubernetesCache) {
 	hn.pending.inc()
 	hn.mu.Lock()
 	defer hn.mu.Unlock()
@@ -57,7 +57,7 @@ func (hn *HoldoffNotifier) OnChange(builder *dag.Builder) {
 	if since > holdoffMaxDelay {
 		// update immediately
 		hn.WithField("last_update", since).WithField("pending", hn.pending.reset()).Info("forcing update")
-		hn.Notifier.OnChange(builder)
+		hn.Notifier.OnChange(kc)
 		hn.last = time.Now()
 		hn.Metrics.SetDAGRebuiltMetric(hn.last.Unix())
 		return
@@ -67,7 +67,7 @@ func (hn *HoldoffNotifier) OnChange(builder *dag.Builder) {
 		hn.mu.Lock()
 		defer hn.mu.Unlock()
 		hn.WithField("last_update", time.Since(hn.last)).WithField("pending", hn.pending.reset()).Info("performing delayed update")
-		hn.Notifier.OnChange(builder)
+		hn.Notifier.OnChange(kc)
 		hn.last = time.Now()
 		hn.Metrics.SetDAGRebuiltMetric(hn.last.Unix())
 	})

--- a/internal/contour/k8s.go
+++ b/internal/contour/k8s.go
@@ -39,7 +39,7 @@ type ResourceEventHandler struct {
 	// If not set, defaults to DEFAULT_INGRESS_CLASS.
 	IngressClass string
 
-	dag.Builder
+	dag.KubernetesCache
 
 	Notifier
 
@@ -52,8 +52,8 @@ type ResourceEventHandler struct {
 // to a dag.Builder.
 type Notifier interface {
 	// OnChange is called to notify the callee that the
-	// contents of the *dag.Builder have changed.
-	OnChange(*dag.Builder)
+	// contents of the *dag.KubernetesCache have changed.
+	OnChange(*dag.KubernetesCache)
 }
 
 func (reh *ResourceEventHandler) OnAdd(obj interface{}) {
@@ -104,7 +104,7 @@ func (reh *ResourceEventHandler) OnDelete(obj interface{}) {
 }
 
 func (reh *ResourceEventHandler) update() {
-	reh.OnChange(&reh.Builder)
+	reh.OnChange(&reh.KubernetesCache)
 }
 
 // validIngressClass returns true iff:

--- a/internal/contour/listener_test.go
+++ b/internal/contour/listener_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/gogo/protobuf/proto"
 	"github.com/google/go-cmp/cmp"
 	ingressroutev1 "github.com/heptio/contour/apis/contour/v1beta1"
+	"github.com/heptio/contour/internal/dag"
 	"github.com/heptio/contour/internal/envoy"
 	"github.com/heptio/contour/internal/metrics"
 	"github.com/prometheus/client_golang/prometheus"
@@ -624,7 +625,7 @@ func TestListenerVisit(t *testing.T) {
 			for _, o := range tc.objs {
 				reh.OnAdd(o)
 			}
-			root := reh.Build()
+			root := dag.BuildDAG(&reh.KubernetesCache)
 			got := visitListeners(root, &tc.ListenerVisitorConfig)
 			if !cmp.Equal(tc.want, got) {
 				t.Fatalf("expected:\n%+v\ngot:\n%+v", tc.want, got)

--- a/internal/contour/route_test.go
+++ b/internal/contour/route_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/gogo/protobuf/proto"
 	"github.com/google/go-cmp/cmp"
 	ingressroutev1 "github.com/heptio/contour/apis/contour/v1beta1"
+	"github.com/heptio/contour/internal/dag"
 	"github.com/heptio/contour/internal/envoy"
 	"github.com/heptio/contour/internal/metrics"
 	"github.com/prometheus/client_golang/prometheus"
@@ -1838,7 +1839,7 @@ func TestRouteVisit(t *testing.T) {
 			for _, o := range tc.objs {
 				reh.OnAdd(o)
 			}
-			root := reh.Build()
+			root := dag.BuildDAG(&reh.KubernetesCache)
 			got := visitRoutes(root)
 			if diff := cmp.Diff(tc.want, got); diff != "" {
 				t.Fatal(diff)

--- a/internal/contour/secret_test.go
+++ b/internal/contour/secret_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/gogo/protobuf/proto"
 	"github.com/google/go-cmp/cmp"
 	ingressroutev1 "github.com/heptio/contour/apis/contour/v1beta1"
+	"github.com/heptio/contour/internal/dag"
 	"github.com/heptio/contour/internal/metrics"
 	"github.com/prometheus/client_golang/prometheus"
 	v1 "k8s.io/api/core/v1"
@@ -372,7 +373,7 @@ func TestSecretVisit(t *testing.T) {
 			for _, o := range tc.objs {
 				reh.OnAdd(o)
 			}
-			root := reh.Build()
+			root := dag.BuildDAG(&reh.KubernetesCache)
 			got := visitSecrets(root)
 			if !reflect.DeepEqual(tc.want, got) {
 				t.Fatalf("expected:\n%+v\ngot:\n%+v", tc.want, got)

--- a/internal/dag/builder.go
+++ b/internal/dag/builder.go
@@ -43,9 +43,9 @@ type Builder struct {
 
 }
 
-// Build builds a new *DAG.
-func (b *Builder) Build() *DAG {
-	builder := &builder{source: b}
+// BuildDAG returns a new DAG from the supplied KubernetesCache.
+func BuildDAG(kc *KubernetesCache) *DAG {
+	builder := &builder{source: &Builder{KubernetesCache: *kc}}
 	return builder.compute()
 }
 

--- a/internal/dag/builder.go
+++ b/internal/dag/builder.go
@@ -35,24 +35,16 @@ const (
 	StatusOrphaned = "orphaned"
 )
 
-// A Builder builds a *DAGs
-type Builder struct {
-	KubernetesCache
-
-	// TODO(youngnick) merge Builder and Kubernetes cache? See #1142
-
-}
-
 // BuildDAG returns a new DAG from the supplied KubernetesCache.
 func BuildDAG(kc *KubernetesCache) *DAG {
-	builder := &builder{source: &Builder{KubernetesCache: *kc}}
+	builder := &builder{source: kc}
 	return builder.compute()
 }
 
 // A builder holds the state of one invocation of Builder.Build.
 // Once used, the builder should be discarded.
 type builder struct {
-	source *Builder
+	source *KubernetesCache
 
 	services  map[servicemeta]Service
 	secrets   map[meta]*Secret
@@ -258,8 +250,8 @@ func (b *builder) listener(port int) *Listener {
 }
 
 func (b *builder) compute() *DAG {
-	b.source.KubernetesCache.mu.RLock() // blocks mutation of the underlying cache until compute is done.
-	defer b.source.KubernetesCache.mu.RUnlock()
+	b.source.mu.RLock() // blocks mutation of the underlying cache until compute is done.
+	defer b.source.mu.RUnlock()
 
 	// setup secure vhosts if there is a matching secret
 	// we do this first so that the set of active secure vhosts is stable

--- a/internal/dag/builder_test.go
+++ b/internal/dag/builder_test.go
@@ -2909,7 +2909,7 @@ func TestDAGInsert(t *testing.T) {
 			for _, o := range tc.objs {
 				b.Insert(o)
 			}
-			dag := b.Build()
+			dag := BuildDAG(&b.KubernetesCache)
 
 			got := make(map[int]*Listener)
 			dag.Visit(listenerMap(got).Visit)
@@ -3121,7 +3121,7 @@ func TestDAGRootNamespaces(t *testing.T) {
 			for _, o := range tc.objs {
 				b.Insert(o)
 			}
-			dag := b.Build()
+			dag := BuildDAG(&b.KubernetesCache)
 
 			var count int
 			dag.Visit(func(v Vertex) {
@@ -3584,7 +3584,8 @@ func TestDAGIngressRouteStatus(t *testing.T) {
 			for _, o := range tc.objs {
 				b.Insert(o)
 			}
-			got := b.Build().Statuses()
+			dag := BuildDAG(&b.KubernetesCache)
+			got := dag.Statuses()
 			if len(tc.want) != len(got) {
 				t.Fatalf("expected:\n%v\ngot\n%v", tc.want, got)
 			}
@@ -3704,7 +3705,7 @@ func TestDAGIngressRouteUniqueFQDNs(t *testing.T) {
 			for _, o := range tc.objs {
 				b.Insert(o)
 			}
-			dag := b.Build()
+			dag := BuildDAG(&b.KubernetesCache)
 			got := make(map[int]*Listener)
 			dag.Visit(listenerMap(got).Visit)
 

--- a/internal/dag/builder_test.go
+++ b/internal/dag/builder_test.go
@@ -2905,11 +2905,11 @@ func TestDAGInsert(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			var b Builder
+			var kc KubernetesCache
 			for _, o := range tc.objs {
-				b.Insert(o)
+				kc.Insert(o)
 			}
-			dag := BuildDAG(&b.KubernetesCache)
+			dag := BuildDAG(&kc)
 
 			got := make(map[int]*Listener)
 			dag.Visit(listenerMap(got).Visit)
@@ -3012,10 +3012,8 @@ func TestBuilderLookupHTTPService(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			b := builder{
-				source: &Builder{
-					KubernetesCache: KubernetesCache{
-						services: services,
-					},
+				source: &KubernetesCache{
+					services: services,
 				},
 			}
 			got := b.lookupHTTPService(tc.meta, tc.port)
@@ -3113,15 +3111,13 @@ func TestDAGRootNamespaces(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			b := Builder{
-				KubernetesCache: KubernetesCache{
-					IngressRouteRootNamespaces: tc.rootNamespaces,
-				},
+			kc := &KubernetesCache{
+				IngressRouteRootNamespaces: tc.rootNamespaces,
 			}
 			for _, o := range tc.objs {
-				b.Insert(o)
+				kc.Insert(o)
 			}
-			dag := BuildDAG(&b.KubernetesCache)
+			dag := BuildDAG(kc)
 
 			var count int
 			dag.Visit(func(v Vertex) {
@@ -3576,15 +3572,13 @@ func TestDAGIngressRouteStatus(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			b := Builder{
-				KubernetesCache: KubernetesCache{
-					IngressRouteRootNamespaces: []string{"roots"},
-				},
+			kc := &KubernetesCache{
+				IngressRouteRootNamespaces: []string{"roots"},
 			}
 			for _, o := range tc.objs {
-				b.Insert(o)
+				kc.Insert(o)
 			}
-			dag := BuildDAG(&b.KubernetesCache)
+			dag := BuildDAG(kc)
 			got := dag.Statuses()
 			if len(tc.want) != len(got) {
 				t.Fatalf("expected:\n%v\ngot\n%v", tc.want, got)
@@ -3701,11 +3695,11 @@ func TestDAGIngressRouteUniqueFQDNs(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			var b Builder
+			var kc KubernetesCache
 			for _, o := range tc.objs {
-				b.Insert(o)
+				kc.Insert(o)
 			}
-			dag := BuildDAG(&b.KubernetesCache)
+			dag := BuildDAG(&kc)
 			got := make(map[int]*Listener)
 			dag.Visit(listenerMap(got).Visit)
 

--- a/internal/debug/debug.go
+++ b/internal/debug/debug.go
@@ -27,14 +27,14 @@ import (
 type Service struct {
 	httpsvc.Service
 
-	*dag.Builder
+	KubernetesCache *dag.KubernetesCache
 }
 
 // Start fulfills the g.Start contract.
 // When stop is closed the http server will shutdown.
 func (svc *Service) Start(stop <-chan struct{}) error {
 	registerProfile(&svc.ServeMux)
-	registerDotWriter(&svc.ServeMux, svc.Builder)
+	registerDotWriter(&svc.ServeMux, svc.KubernetesCache)
 	return svc.Service.Start(stop)
 }
 
@@ -50,10 +50,10 @@ func registerProfile(mux *http.ServeMux) {
 	mux.Handle("/debug/pprof/threadcreate", pprof.Handler("threadcreate"))
 }
 
-func registerDotWriter(mux *http.ServeMux, b *dag.Builder) {
+func registerDotWriter(mux *http.ServeMux, kc *dag.KubernetesCache) {
 	mux.HandleFunc("/debug/dag", func(w http.ResponseWriter, r *http.Request) {
 		dw := &dotWriter{
-			Builder: b,
+			kc: kc,
 		}
 		dw.writeDot(w)
 	})

--- a/internal/debug/dot.go
+++ b/internal/debug/dot.go
@@ -90,7 +90,7 @@ func (dw *dotWriter) writeDot(w io.Writer) {
 		})
 	}
 
-	dw.Builder.Build().Visit(visit)
+	dag.BuildDAG(&dw.Builder.KubernetesCache).Visit(visit)
 
 	fmt.Fprintln(w, "}")
 }

--- a/internal/debug/dot.go
+++ b/internal/debug/dot.go
@@ -24,7 +24,7 @@ import (
 // quick and dirty dot debugging package
 
 type dotWriter struct {
-	*dag.Builder
+	kc *dag.KubernetesCache
 }
 
 type pair struct {
@@ -90,7 +90,7 @@ func (dw *dotWriter) writeDot(w io.Writer) {
 		})
 	}
 
-	dag.BuildDAG(&dw.Builder.KubernetesCache).Visit(visit)
+	dag.BuildDAG(dw.kc).Visit(visit)
 
 	fmt.Fprintln(w, "}")
 }


### PR DESCRIPTION
Updates #1142

Removes the dag.Builder type and propagate dag.KubernetesCache in its place.

The next PR will move KubernetesCache.IngressRootNamespaces to contour.ResourceEventHandler.