### PR TITLE
internal/contour: move rebuild timestamp closer to where it occurs

### DIFF
--- a/cmd/contour/contour.go
+++ b/cmd/contour/contour.go
@@ -117,15 +117,11 @@ func main() {
 	registry.MustRegister(prometheus.NewProcessCollector(prometheus.ProcessCollectorOpts{}))
 	registry.MustRegister(prometheus.NewGoCollector())
 
-	// register our custom metrics
-	metrics := metrics.NewMetrics(registry)
-
 	reh := contour.ResourceEventHandler{
 		FieldLogger: log.WithField("context", "resourceEventHandler"),
 		Notifier: &contour.HoldoffNotifier{
 			Notifier:    &ch,
 			FieldLogger: log.WithField("context", "HoldoffNotifier"),
-			Metrics:     metrics,
 		},
 	}
 
@@ -214,6 +210,8 @@ func main() {
 		g.Add(startInformer(coreInformers, log.WithField("context", "coreinformers")))
 		g.Add(startInformer(contourInformers, log.WithField("context", "contourinformers")))
 
+		// register our custom metrics
+		metrics := metrics.NewMetrics(registry)
 		ch.Metrics = metrics
 		reh.Metrics = metrics
 

--- a/internal/contour/cachehandler.go
+++ b/internal/contour/cachehandler.go
@@ -17,6 +17,8 @@
 package contour
 
 import (
+	"time"
+
 	"github.com/heptio/contour/internal/dag"
 	"github.com/heptio/contour/internal/k8s"
 	"github.com/heptio/contour/internal/metrics"
@@ -51,6 +53,7 @@ func (ch *CacheHandler) OnChange(kc *dag.KubernetesCache) {
 	ch.updateRoutes(dag)
 	ch.updateClusters(dag)
 	ch.updateIngressRouteMetric(dag)
+	ch.SetDAGLastRebuilt(time.Now())
 }
 
 func (ch *CacheHandler) setIngressRouteStatus(st statusable) {

--- a/internal/contour/holdoff.go
+++ b/internal/contour/holdoff.go
@@ -22,7 +22,6 @@ import (
 	"time"
 
 	"github.com/heptio/contour/internal/dag"
-	"github.com/heptio/contour/internal/metrics"
 	"github.com/sirupsen/logrus"
 )
 
@@ -36,7 +35,6 @@ const (
 type HoldoffNotifier struct {
 	// Notifier to be called after delay.
 	Notifier
-	*metrics.Metrics
 
 	logrus.FieldLogger
 
@@ -59,7 +57,6 @@ func (hn *HoldoffNotifier) OnChange(kc *dag.KubernetesCache) {
 		hn.WithField("last_update", since).WithField("pending", hn.pending.reset()).Info("forcing update")
 		hn.Notifier.OnChange(kc)
 		hn.last = time.Now()
-		hn.Metrics.SetDAGLastRebuilt(hn.last)
 		return
 	}
 
@@ -69,7 +66,6 @@ func (hn *HoldoffNotifier) OnChange(kc *dag.KubernetesCache) {
 		hn.WithField("last_update", time.Since(hn.last)).WithField("pending", hn.pending.reset()).Info("performing delayed update")
 		hn.Notifier.OnChange(kc)
 		hn.last = time.Now()
-		hn.Metrics.SetDAGLastRebuilt(hn.last)
 	})
 }
 

--- a/internal/contour/holdoff.go
+++ b/internal/contour/holdoff.go
@@ -59,7 +59,7 @@ func (hn *HoldoffNotifier) OnChange(kc *dag.KubernetesCache) {
 		hn.WithField("last_update", since).WithField("pending", hn.pending.reset()).Info("forcing update")
 		hn.Notifier.OnChange(kc)
 		hn.last = time.Now()
-		hn.Metrics.SetDAGRebuiltMetric(hn.last.Unix())
+		hn.Metrics.SetDAGLastRebuilt(hn.last)
 		return
 	}
 
@@ -69,7 +69,7 @@ func (hn *HoldoffNotifier) OnChange(kc *dag.KubernetesCache) {
 		hn.WithField("last_update", time.Since(hn.last)).WithField("pending", hn.pending.reset()).Info("performing delayed update")
 		hn.Notifier.OnChange(kc)
 		hn.last = time.Now()
-		hn.Metrics.SetDAGRebuiltMetric(hn.last.Unix())
+		hn.Metrics.SetDAGLastRebuilt(hn.last)
 	})
 }
 

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -17,6 +17,7 @@ package metrics
 import (
 	"fmt"
 	"net/http"
+	"time"
 
 	"k8s.io/client-go/kubernetes"
 
@@ -145,9 +146,9 @@ func (m *Metrics) register(registry *prometheus.Registry) {
 	)
 }
 
-// SetDAGRebuiltMetric records the last time the DAG was rebuilt
-func (m *Metrics) SetDAGRebuiltMetric(timestamp int64) {
-	m.ingressRouteDAGRebuildGauge.WithLabelValues().Set(float64(timestamp))
+// SetDAGLastRebuilt records the last time the DAG was rebuilt.
+func (m *Metrics) SetDAGLastRebuilt(ts time.Time) {
+	m.ingressRouteDAGRebuildGauge.WithLabelValues().Set(float64(ts.Unix()))
 }
 
 // SetIngressRouteMetric sets metric values for a set of IngressRoutes

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -18,7 +18,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/prometheus/client_model/go"
+	io_prometheus_client "github.com/prometheus/client_model/go"
 
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -28,13 +28,13 @@ type testMetric struct {
 	want   []*io_prometheus_client.Metric
 }
 
-func TestWriteDAGTimestampMetric(t *testing.T) {
+func TestSetDAGLastRebuilt(t *testing.T) {
 	tests := map[string]struct {
 		timestampMetric testMetric
-		value           int64
+		value           time.Time
 	}{
 		"simple": {
-			value: time.Date(2009, 11, 17, 20, 34, 58, 651387237, time.UTC).Unix(),
+			value: time.Date(2009, 11, 17, 20, 34, 58, 651387237, time.UTC),
 			timestampMetric: testMetric{
 				metric: IngressRouteDAGRebuildGauge,
 				want: []*io_prometheus_client.Metric{
@@ -52,7 +52,7 @@ func TestWriteDAGTimestampMetric(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			r := prometheus.NewRegistry()
 			m := NewMetrics(r)
-			m.SetDAGRebuiltMetric(tc.value)
+			m.SetDAGLastRebuilt(tc.value)
 
 			gatherers := prometheus.Gatherers{
 				r,


### PR DESCRIPTION
Updates #1142 

This change moves the responsibility of maintaining the DAG rebuild metric closer to where it occurs. This has the side effect of removing that responsibility from the holdoff interposer which now has no connection to our metrics. This will be useful in a followup change to simplify dag.KubernetesCache