### PR TITLE
cmd/contour: break serve flag setup into helper function

### DIFF
--- a/cmd/contour/cli.go
+++ b/cmd/contour/cli.go
@@ -43,42 +43,37 @@ func (c *Client) dial() *grpc.ClientConn {
 	// Check the TLS setup
 	switch {
 	case c.CAFile != "" || c.ClientCert != "" || c.ClientKey != "":
-		{
-			// If one of the three TLS commands is not empty, they all must be not empty
-			if !(c.CAFile != "" && c.ClientCert != "" && c.ClientKey != "") {
-				log.Fatal("You must supply all three TLS parameters - --cafile, --cert-file, --key-file, or none of them.")
-			}
-			// Load the client certificates from disk
-			certificate, err := tls.LoadX509KeyPair(c.ClientCert, c.ClientKey)
-			check(err)
-
-			// Create a certificate pool from the certificate authority
-			certPool := x509.NewCertPool()
-			ca, err := ioutil.ReadFile(c.CAFile)
-			check(err)
-
-			// Append the certificates from the CA
-			if ok := certPool.AppendCertsFromPEM(ca); !ok {
-				// TODO(nyoung) OMG yuck, thanks for this, crypto/tls. Suggestions on alternates welcomed.
-				check(errors.New("failed to append ca certs"))
-			}
-
-			creds := credentials.NewTLS(&tls.Config{
-				// TODO(youngnick): Does this need to be defaulted with a cli flag to
-				// override?
-				// The ServerName here needs to be one of the SANs available in
-				// the serving cert used by contour serve.
-				ServerName:   "contour",
-				Certificates: []tls.Certificate{certificate},
-				RootCAs:      certPool,
-			})
-			options = append(options, grpc.WithTransportCredentials(creds))
-
+		// If one of the three TLS commands is not empty, they all must be not empty
+		if !(c.CAFile != "" && c.ClientCert != "" && c.ClientKey != "") {
+			log.Fatal("You must supply all three TLS parameters - --cafile, --cert-file, --key-file, or none of them.")
 		}
+		// Load the client certificates from disk
+		certificate, err := tls.LoadX509KeyPair(c.ClientCert, c.ClientKey)
+		check(err)
+
+		// Create a certificate pool from the certificate authority
+		certPool := x509.NewCertPool()
+		ca, err := ioutil.ReadFile(c.CAFile)
+		check(err)
+
+		// Append the certificates from the CA
+		if ok := certPool.AppendCertsFromPEM(ca); !ok {
+			// TODO(nyoung) OMG yuck, thanks for this, crypto/tls. Suggestions on alternates welcomed.
+			check(errors.New("failed to append ca certs"))
+		}
+
+		creds := credentials.NewTLS(&tls.Config{
+			// TODO(youngnick): Does this need to be defaulted with a cli flag to
+			// override?
+			// The ServerName here needs to be one of the SANs available in
+			// the serving cert used by contour serve.
+			ServerName:   "contour",
+			Certificates: []tls.Certificate{certificate},
+			RootCAs:      certPool,
+		})
+		options = append(options, grpc.WithTransportCredentials(creds))
 	default:
-		{
-			options = append(options, grpc.WithInsecure())
-		}
+		options = append(options, grpc.WithInsecure())
 	}
 
 	conn, err := grpc.Dial(c.ContourAddr, options...)

--- a/cmd/contour/serve.go
+++ b/cmd/contour/serve.go
@@ -1,0 +1,49 @@
+// Copyright © 2019 Heptio
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+
+	kingpin "gopkg.in/alecthomas/kingpin.v2"
+)
+
+// registerServe registers the serve subcommand and flags
+// with the Application provided.
+func registerServe(app *kingpin.Application) (*kingpin.CmdClause, *serveContext) {
+	var ctx serveContext
+	serve := app.Command("serve", "Serve xDS API traffic")
+	serve.Flag("incluster", "use in cluster configuration.").BoolVar(&ctx.inCluster)
+	serve.Flag("kubeconfig", "path to kubeconfig (if not in running inside a cluster)").Default(filepath.Join(os.Getenv("HOME"), ".kube", "config")).StringVar(&ctx.kubeconfig)
+	serve.Flag("xds-address", "xDS gRPC API address").Default("127.0.0.1").StringVar(&ctx.xdsAddr)
+	serve.Flag("xds-port", "xDS gRPC API port").Default("8001").IntVar(&ctx.xdsPort)
+	serve.Flag("stats-address", "Envoy /stats interface address").Default("0.0.0.0").StringVar(&ctx.statsAddr)
+	serve.Flag("stats-port", "Envoy /stats interface port").Default("8002").IntVar(&ctx.statsPort)
+	serve.Flag("contour-cafile", "CA bundle file name for serving gRPC with TLS").Envar("CONTOUR_CAFILE").StringVar(&ctx.caFile)
+	serve.Flag("contour-cert-file", "Contour certificate file name for serving gRPC over TLS").Envar("CONTOUR_CERT_FILE").StringVar(&ctx.contourCert)
+	serve.Flag("contour-key-file", "Contour key file name for serving gRPC over TLS").Envar("CONTOUR_KEY_FILE").StringVar(&ctx.contourKey)
+
+	return serve, &ctx
+}
+
+type serveContext struct {
+	inCluster                       bool
+	kubeconfig                      string
+	xdsAddr                         string
+	xdsPort                         int
+	statsAddr                       string
+	statsPort                       int
+	caFile, contourCert, contourKey string
+}


### PR DESCRIPTION
Similar to #1218, start to split out the serve subcommand into a helper
in its own file -- keep chipping away at main.main.

This PR doesn't completely move all the flags for serve into
registerServe, but makes a start. I'll tackle the rest in a followup PR.

Also, take the opportunity to do a small drive by simplification on
cli.go

Signed-off-by: Dave Cheney <dave@cheney.net>