### PR TITLE
cmd/contour: move debug service params to serveContext

### DIFF
--- a/cmd/contour/serve.go
+++ b/cmd/contour/serve.go
@@ -32,10 +32,16 @@ func registerServe(app *kingpin.Application) (*kingpin.CmdClause, *serveContext)
 	serve := app.Command("serve", "Serve xDS API traffic")
 	serve.Flag("incluster", "use in cluster configuration.").BoolVar(&ctx.inCluster)
 	serve.Flag("kubeconfig", "path to kubeconfig (if not in running inside a cluster)").Default(filepath.Join(os.Getenv("HOME"), ".kube", "config")).StringVar(&ctx.kubeconfig)
+
 	serve.Flag("xds-address", "xDS gRPC API address").Default("127.0.0.1").StringVar(&ctx.xdsAddr)
 	serve.Flag("xds-port", "xDS gRPC API port").Default("8001").IntVar(&ctx.xdsPort)
+
 	serve.Flag("stats-address", "Envoy /stats interface address").Default("0.0.0.0").StringVar(&ctx.statsAddr)
 	serve.Flag("stats-port", "Envoy /stats interface port").Default("8002").IntVar(&ctx.statsPort)
+
+	serve.Flag("debug-http-address", "address the debug http endpoint will bind to").Default("127.0.0.1").StringVar(&ctx.debugAddr)
+	serve.Flag("debug-http-port", "port the debug http endpoint will bind to").Default("6060").IntVar(&ctx.debugPort)
+
 	serve.Flag("contour-cafile", "CA bundle file name for serving gRPC with TLS").Envar("CONTOUR_CAFILE").StringVar(&ctx.caFile)
 	serve.Flag("contour-cert-file", "Contour certificate file name for serving gRPC over TLS").Envar("CONTOUR_CERT_FILE").StringVar(&ctx.contourCert)
 	serve.Flag("contour-key-file", "Contour key file name for serving gRPC over TLS").Envar("CONTOUR_KEY_FILE").StringVar(&ctx.contourKey)
@@ -44,13 +50,22 @@ func registerServe(app *kingpin.Application) (*kingpin.CmdClause, *serveContext)
 }
 
 type serveContext struct {
-	inCluster                       bool
-	kubeconfig                      string
+	// kubernetes client parameters
+	inCluster  bool
+	kubeconfig string
+
+	// xds service parameters
 	xdsAddr                         string
 	xdsPort                         int
-	statsAddr                       string
-	statsPort                       int
 	caFile, contourCert, contourKey string
+
+	// stats handling parameters
+	statsAddr string
+	statsPort int
+
+	// debug handler parameters
+	debugAddr string
+	debugPort int
 }
 
 // tlsconfig returns a new *tls.Config. If the context is not properly configured


### PR DESCRIPTION
Keep chipping away at main.main.

Signed-off-by: Dave Cheney <dave@cheney.net>