### PR TITLE
cmd/contour: move CacheHandler and ResourceEventHandler cli params to serveContext

### DIFF
--- a/cmd/contour/serve.go
+++ b/cmd/contour/serve.go
@@ -52,6 +52,8 @@ func registerServe(app *kingpin.Application) (*kingpin.CmdClause, *serveContext)
 
 	serve.Flag("ingressroute-root-namespaces", "Restrict contour to searching these namespaces for root ingress routes").StringVar(&ctx.rootNamespaces)
 
+	serve.Flag("ingress-class-name", "Contour IngressClass name").StringVar(&ctx.ingressClass)
+
 	return serve, &ctx
 }
 
@@ -79,6 +81,9 @@ type serveContext struct {
 
 	// ingressroute root namespaces
 	rootNamespaces string
+
+	// ingress class
+	ingressClass string
 }
 
 // tlsconfig returns a new *tls.Config. If the context is not properly configured

--- a/cmd/contour/serve.go
+++ b/cmd/contour/serve.go
@@ -23,6 +23,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/heptio/contour/internal/contour"
 	kingpin "gopkg.in/alecthomas/kingpin.v2"
 )
 
@@ -54,6 +55,14 @@ func registerServe(app *kingpin.Application) (*kingpin.CmdClause, *serveContext)
 
 	serve.Flag("ingress-class-name", "Contour IngressClass name").StringVar(&ctx.ingressClass)
 
+	serve.Flag("envoy-http-access-log", "Envoy HTTP access log").Default(contour.DEFAULT_HTTP_ACCESS_LOG).StringVar(&ctx.httpAccessLog)
+	serve.Flag("envoy-https-access-log", "Envoy HTTPS access log").Default(contour.DEFAULT_HTTPS_ACCESS_LOG).StringVar(&ctx.httpsAccessLog)
+	serve.Flag("envoy-service-http-address", "Kubernetes Service address for HTTP requests").Default("0.0.0.0").StringVar(&ctx.httpAddr)
+	serve.Flag("envoy-service-https-address", "Kubernetes Service address for HTTPS requests").Default("0.0.0.0").StringVar(&ctx.httpsAddr)
+	serve.Flag("envoy-service-http-port", "Kubernetes Service port for HTTP requests").Default("8080").IntVar(&ctx.httpPort)
+	serve.Flag("envoy-service-https-port", "Kubernetes Service port for HTTPS requests").Default("8443").IntVar(&ctx.httpsPort)
+	serve.Flag("use-proxy-protocol", "Use PROXY protocol for all listeners").BoolVar(&ctx.useProxyProto)
+
 	return serve, &ctx
 }
 
@@ -66,10 +75,6 @@ type serveContext struct {
 	xdsAddr                         string
 	xdsPort                         int
 	caFile, contourCert, contourKey string
-
-	// envoy's stats listener parameters
-	statsAddr string
-	statsPort int
 
 	// contour's debug handler parameters
 	debugAddr string
@@ -84,6 +89,23 @@ type serveContext struct {
 
 	// ingress class
 	ingressClass string
+
+	// envoy's stats listener parameters
+	statsAddr string
+	statsPort int
+
+	// envoy's listener parameters
+	useProxyProto bool
+
+	// envoy's http listener parameters
+	httpAddr      string
+	httpPort      int
+	httpAccessLog string
+
+	// envoy's https listener parameters
+	httpsAddr      string
+	httpsPort      int
+	httpsAccessLog string
 }
 
 // tlsconfig returns a new *tls.Config. If the context is not properly configured


### PR DESCRIPTION
This PR continues the work of last week migrating the various CacheHandler and ResourceEventHandler parameters to `contour serve`'s `serveContext` type.

At this point the entire serve subcommand can be migrated out of `main.main`, which will be the subject of the next PR.