### PR TITLE
Dockerfile: bump Go version to 1.12.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.12.5 AS build
+FROM golang:1.12.7 AS build
 WORKDIR /contour
 
 ENV GOPROXY=https://gocenter.io


### PR DESCRIPTION
Signed-off-by: Dave Cheney <dave@cheney.net>