### PR TITLE
go.mod: go mod tidy

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,6 @@ go 1.12
 require (
 	cloud.google.com/go v0.37.4 // indirect
 	github.com/client9/misspell v0.3.4
-	github.com/davecgh/go-spew v1.1.1
 	github.com/envoyproxy/go-control-plane v0.8.1
 	github.com/evanphx/json-patch v4.1.0+incompatible
 	github.com/gogo/protobuf v1.2.1


### PR DESCRIPTION
There doesn't seem to be an easy way to write a make target that will
fail the build if go mod tidy is needed.

Signed-off-by: Dave Cheney <dave@cheney.net>