### PR TITLE
internal/dag: Reject invalid service configuration if referenced service is missing

### DIFF
--- a/internal/contour/listener_test.go
+++ b/internal/contour/listener_test.go
@@ -182,6 +182,19 @@ func TestListenerVisit(t *testing.T) {
 						},
 					},
 				},
+				&v1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "backend",
+						Namespace: "default",
+					},
+					Spec: v1.ServiceSpec{
+						Ports: []v1.ServicePort{{
+							Name:     "http",
+							Protocol: "TCP",
+							Port:     80,
+						}},
+					},
+				},
 			},
 			want: listenermap(&v2.Listener{
 				Name:         ENVOY_HTTP_LISTENER,
@@ -372,6 +385,19 @@ func TestListenerVisit(t *testing.T) {
 					},
 					Type: "kubernetes.io/tls",
 					Data: secretdata("certificate", "key"),
+				},
+				&v1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "backend",
+						Namespace: "default",
+					},
+					Spec: v1.ServiceSpec{
+						Ports: []v1.ServicePort{{
+							Name:     "http",
+							Protocol: "TCP",
+							Port:     80,
+						}},
+					},
 				},
 			},
 			want: listenermap(&v2.Listener{

--- a/internal/dag/builder.go
+++ b/internal/dag/builder.go
@@ -659,7 +659,7 @@ func (b *builder) processRoutes(ir *ingressroutev1.IngressRoute, prefixMatch str
 				s := b.lookupHTTPService(m, intstr.FromInt(service.Port))
 
 				if s == nil {
-					b.setStatus(Status{Object: ir, Status: StatusInvalid, Description: "Service referenced is invalid or missing"})
+					b.setStatus(Status{Object: ir, Status: StatusInvalid, Description: fmt.Sprintf("Service [%s:%d] is invalid or missing", service.Name, service.Port)})
 					return
 				}
 

--- a/internal/dag/builder_test.go
+++ b/internal/dag/builder_test.go
@@ -3706,7 +3706,7 @@ func TestDAGIngressRouteStatus(t *testing.T) {
 		},
 		"missing service shows invalid status": {
 			objs: []interface{}{ir16},
-			want: []Status{{Object: ir16, Status: "invalid", Description: `Service referenced is invalid or missing`, Vhost: ""}},
+			want: []Status{{Object: ir16, Status: "invalid", Description: `Service [invalid:8080] is invalid or missing`, Vhost: ""}},
 		},
 	}
 


### PR DESCRIPTION
Fixes #520 by rejecting any IngressRoute object that references a Kubernetes service that doesn't exist or is malformed. When this situation is encountered, the status of the IngressRoute object will be updated and the object will be ignored.

Signed-off-by: Steve Sloka <slokas@vmware.com>