### PR TITLE
internal/dag: Fix constant dag rebuild when invalid secret found

### DIFF
--- a/internal/contour/cachehandler.go
+++ b/internal/contour/cachehandler.go
@@ -40,7 +40,7 @@ type CacheHandler struct {
 }
 
 type statusable interface {
-	Statuses() []dag.Status
+	Statuses() map[dag.Meta]dag.Status
 }
 
 func (ch *CacheHandler) OnChange(kc *dag.KubernetesCache) {

--- a/internal/dag/cache.go
+++ b/internal/dag/cache.go
@@ -35,15 +35,15 @@ type KubernetesCache struct {
 
 	mu sync.RWMutex
 
-	ingresses     map[meta]*v1beta1.Ingress
-	ingressroutes map[meta]*ingressroutev1.IngressRoute
-	secrets       map[meta]*v1.Secret
-	delegations   map[meta]*ingressroutev1.TLSCertificateDelegation
-	services      map[meta]*v1.Service
+	ingresses     map[Meta]*v1beta1.Ingress
+	ingressroutes map[Meta]*ingressroutev1.IngressRoute
+	secrets       map[Meta]*v1.Secret
+	delegations   map[Meta]*ingressroutev1.TLSCertificateDelegation
+	services      map[Meta]*v1.Service
 }
 
-// meta holds the name and namespace of a Kubernetes object.
-type meta struct {
+// Meta holds the name and namespace of a Kubernetes object.
+type Meta struct {
 	name, namespace string
 }
 
@@ -54,33 +54,33 @@ func (kc *KubernetesCache) Insert(obj interface{}) {
 	defer kc.mu.Unlock()
 	switch obj := obj.(type) {
 	case *v1.Secret:
-		m := meta{name: obj.Name, namespace: obj.Namespace}
+		m := Meta{name: obj.Name, namespace: obj.Namespace}
 		if kc.secrets == nil {
-			kc.secrets = make(map[meta]*v1.Secret)
+			kc.secrets = make(map[Meta]*v1.Secret)
 		}
 		kc.secrets[m] = obj
 	case *v1.Service:
-		m := meta{name: obj.Name, namespace: obj.Namespace}
+		m := Meta{name: obj.Name, namespace: obj.Namespace}
 		if kc.services == nil {
-			kc.services = make(map[meta]*v1.Service)
+			kc.services = make(map[Meta]*v1.Service)
 		}
 		kc.services[m] = obj
 	case *v1beta1.Ingress:
-		m := meta{name: obj.Name, namespace: obj.Namespace}
+		m := Meta{name: obj.Name, namespace: obj.Namespace}
 		if kc.ingresses == nil {
-			kc.ingresses = make(map[meta]*v1beta1.Ingress)
+			kc.ingresses = make(map[Meta]*v1beta1.Ingress)
 		}
 		kc.ingresses[m] = obj
 	case *ingressroutev1.IngressRoute:
-		m := meta{name: obj.Name, namespace: obj.Namespace}
+		m := Meta{name: obj.Name, namespace: obj.Namespace}
 		if kc.ingressroutes == nil {
-			kc.ingressroutes = make(map[meta]*ingressroutev1.IngressRoute)
+			kc.ingressroutes = make(map[Meta]*ingressroutev1.IngressRoute)
 		}
 		kc.ingressroutes[m] = obj
 	case *ingressroutev1.TLSCertificateDelegation:
-		m := meta{name: obj.Name, namespace: obj.Namespace}
+		m := Meta{name: obj.Name, namespace: obj.Namespace}
 		if kc.delegations == nil {
-			kc.delegations = make(map[meta]*ingressroutev1.TLSCertificateDelegation)
+			kc.delegations = make(map[Meta]*ingressroutev1.TLSCertificateDelegation)
 		}
 		kc.delegations[m] = obj
 
@@ -105,19 +105,19 @@ func (kc *KubernetesCache) remove(obj interface{}) {
 	defer kc.mu.Unlock()
 	switch obj := obj.(type) {
 	case *v1.Secret:
-		m := meta{name: obj.Name, namespace: obj.Namespace}
+		m := Meta{name: obj.Name, namespace: obj.Namespace}
 		delete(kc.secrets, m)
 	case *v1.Service:
-		m := meta{name: obj.Name, namespace: obj.Namespace}
+		m := Meta{name: obj.Name, namespace: obj.Namespace}
 		delete(kc.services, m)
 	case *v1beta1.Ingress:
-		m := meta{name: obj.Name, namespace: obj.Namespace}
+		m := Meta{name: obj.Name, namespace: obj.Namespace}
 		delete(kc.ingresses, m)
 	case *ingressroutev1.IngressRoute:
-		m := meta{name: obj.Name, namespace: obj.Namespace}
+		m := Meta{name: obj.Name, namespace: obj.Namespace}
 		delete(kc.ingressroutes, m)
 	case *ingressroutev1.TLSCertificateDelegation:
-		m := meta{name: obj.Name, namespace: obj.Namespace}
+		m := Meta{name: obj.Name, namespace: obj.Namespace}
 		delete(kc.delegations, m)
 	default:
 		// not interesting

--- a/internal/dag/dag.go
+++ b/internal/dag/dag.go
@@ -31,7 +31,7 @@ type DAG struct {
 	roots []Vertex
 
 	// status computed while building this dag.
-	statuses []Status
+	statuses map[Meta]Status
 }
 
 // Visit calls fn on each root of this DAG.
@@ -43,7 +43,7 @@ func (d *DAG) Visit(fn func(Vertex)) {
 
 // Statuses returns a slice of Status objects associated with
 // the computation of this DAG.
-func (d *DAG) Statuses() []Status {
+func (d *DAG) Statuses() map[Meta]Status {
 	return d.statuses
 }
 
@@ -308,8 +308,8 @@ func (s *Secret) PrivateKey() []byte {
 	return s.Object.Data[v1.TLSPrivateKeyKey]
 }
 
-func (s *Secret) toMeta() meta {
-	return meta{
+func (s *Secret) toMeta() Meta {
+	return Meta{
 		name:      s.Name(),
 		namespace: s.Namespace(),
 	}


### PR DESCRIPTION
Fixes #1206 by changing how status is set within the DAG. Previously, the set status method took a slice and status was pushed onto it. When an invalid secret was found, a status for the invalid secret was appended to the slice. Later, a 'valid' status was appended. This caused a loop in how the status got updated and forced a dag to rebuild over and over. 

I changed to using a map of `Status` types, if a status is set, then do not overwrite if an existing status already 

Signed-off-by: Steve Sloka <slokas@vmware.com>