### PR TITLE
cmd/contour: add -c config-path flag

### DIFF
--- a/cmd/contour/contour.go
+++ b/cmd/contour/contour.go
@@ -77,6 +77,10 @@ func main() {
 		stream := client.RouteStream()
 		watchstream(stream, cache.SecretType, resources)
 	case serve.FullCommand():
+		// parse args a second time so cli flags are applied
+		// on top of any values sourced from -c's config file.
+		_, err := app.Parse(args)
+		check(err)
 		log.Infof("args: %v", args)
 		doServe(log, serveCtx)
 	default:

--- a/cmd/contour/serve.go
+++ b/cmd/contour/serve.go
@@ -52,7 +52,7 @@ func registerServe(app *kingpin.Application) (*kingpin.CmdClause, *serveContext)
 	// however, as -c is a cli flag, we don't know its valye til cli flags
 	// have been parsed. To correct this ordering we assign a post parse
 	// action to -c, then parse cli flags twice (see main.main). On the second
-	// parse our action will return early, resulting in the precendence order
+	// parse our action will return early, resulting in the precedence order
 	// we want.
 	var (
 		configFile string
@@ -77,8 +77,8 @@ func registerServe(app *kingpin.Application) (*kingpin.CmdClause, *serveContext)
 	}
 	serve.Flag("config-path", "path to base configuration").Short('c').Action(parseConfig).ExistingFileVar(&configFile)
 
-	serve.Flag("incluster", "use in cluster configuration.").BoolVar(&ctx.inCluster)
-	serve.Flag("kubeconfig", "path to kubeconfig (if not in running inside a cluster)").Default(filepath.Join(os.Getenv("HOME"), ".kube", "config")).StringVar(&ctx.kubeconfig)
+	serve.Flag("incluster", "use in cluster configuration.").BoolVar(&ctx.InCluster)
+	serve.Flag("kubeconfig", "path to kubeconfig (if not in running inside a cluster)").Default(filepath.Join(os.Getenv("HOME"), ".kube", "config")).StringVar(&ctx.Kubeconfig)
 
 	serve.Flag("xds-address", "xDS gRPC API address").Default("127.0.0.1").StringVar(&ctx.xdsAddr)
 	serve.Flag("xds-port", "xDS gRPC API port").Default("8001").IntVar(&ctx.xdsPort)
@@ -113,8 +113,8 @@ func registerServe(app *kingpin.Application) (*kingpin.CmdClause, *serveContext)
 
 type serveContext struct {
 	// contour's kubernetes client parameters
-	inCluster  bool
-	kubeconfig string
+	InCluster  bool   `json:"incluster"`
+	Kubeconfig string `json:"kubeconfig"`
 
 	// contour's xds service parameters
 	xdsAddr                         string
@@ -201,7 +201,7 @@ func (ctx *serveContext) ingressRouteRootNamespaces() []string {
 func doServe(log logrus.FieldLogger, ctx *serveContext) error {
 
 	// step 1. establish k8s client connection
-	client, contourClient := newClient(ctx.kubeconfig, ctx.inCluster)
+	client, contourClient := newClient(ctx.Kubeconfig, ctx.InCluster)
 
 	// step 2. create informers
 	// note: 0 means resync timers are disabled


### PR DESCRIPTION
Fixes #1130

This PR adds the ability to supply configuration values to contour serve
from a configuration file. Some gymnastics are required to make this
work with kingpin and keep the precedence of config file -> env vars ->
cli flags.

At the moment only a few values are plumbed into the config file, mainly
to keep the linters happy. More will be added in 0.15.

Signed-off-by: Dave Cheney <dave@cheney.net>