### PR TITLE
example: replace wget with bash magic

### DIFF
--- a/examples/deployment-grpc-v2/02-contour.yaml
+++ b/examples/deployment-grpc-v2/02-contour.yaml
@@ -69,7 +69,14 @@ spec:
         lifecycle:
           preStop:
             exec:
-              command: ["wget", "-qO-", "--post-data=''", "http://localhost:9001/healthcheck/fail"] 
+              command:
+              - bash
+              - -c
+              - --
+              - echo
+              - -ne
+              - "POST /healthcheck/fail HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n"
+              - '>/dev/tcp/localhost/9001'
       initContainers:
       - image: gcr.io/heptio-images/contour:master
         imagePullPolicy: Always

--- a/examples/ds-grpc-v2/02-contour.yaml
+++ b/examples/ds-grpc-v2/02-contour.yaml
@@ -70,7 +70,14 @@ spec:
         lifecycle:
           preStop:
             exec:
-              command: ["wget", "-qO-", "--post-data=''", "http://localhost:9001/healthcheck/fail"] 
+              command:
+              - bash
+              - -c
+              - --
+              - echo
+              - -ne
+              - "POST /healthcheck/fail HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n"
+              - '>/dev/tcp/localhost/9001'
       initContainers:
       - image: gcr.io/heptio-images/contour:master
         imagePullPolicy: Always

--- a/examples/ds-hostnet-split/03-envoy.yaml
+++ b/examples/ds-hostnet-split/03-envoy.yaml
@@ -70,7 +70,14 @@ spec:
         lifecycle:
           preStop:
             exec:
-              command: ["wget", "-qO-", "--post-data=''", "http://localhost:9001/healthcheck/fail"] 
+              command:
+              - bash
+              - -c
+              - --
+              - echo
+              - -ne
+              - "POST /healthcheck/fail HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n"
+              - '>/dev/tcp/localhost/9001'
       dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
       initContainers:

--- a/examples/ds-hostnet/02-contour.yaml
+++ b/examples/ds-hostnet/02-contour.yaml
@@ -74,7 +74,14 @@ spec:
         lifecycle:
           preStop:
             exec:
-              command: ["wget", "-qO-", "--post-data=''", "http://localhost:9001/healthcheck/fail"] 
+              command:
+              - bash
+              - -c
+              - --
+              - echo
+              - -ne
+              - "POST /healthcheck/fail HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n"
+              - '>/dev/tcp/localhost/9001'
       initContainers:
       - image: gcr.io/heptio-images/contour:master
         imagePullPolicy: Always

--- a/examples/render/daemonset-rbac.yaml
+++ b/examples/render/daemonset-rbac.yaml
@@ -260,7 +260,14 @@ spec:
         lifecycle:
           preStop:
             exec:
-              command: ["wget", "-qO-", "--post-data=''", "http://localhost:9001/healthcheck/fail"] 
+              command:
+              - bash
+              - -c
+              - --
+              - echo
+              - -ne
+              - "POST /healthcheck/fail HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n"
+              - '>/dev/tcp/localhost/9001'
       initContainers:
       - image: gcr.io/heptio-images/contour:master
         imagePullPolicy: Always

--- a/examples/render/deployment-rbac.yaml
+++ b/examples/render/deployment-rbac.yaml
@@ -259,7 +259,14 @@ spec:
         lifecycle:
           preStop:
             exec:
-              command: ["wget", "-qO-", "--post-data=''", "http://localhost:9001/healthcheck/fail"] 
+              command:
+              - bash
+              - -c
+              - --
+              - echo
+              - -ne
+              - "POST /healthcheck/fail HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n"
+              - '>/dev/tcp/localhost/9001'
       initContainers:
       - image: gcr.io/heptio-images/contour:master
         imagePullPolicy: Always


### PR DESCRIPTION
Fixes #1254

Sadly envoyproxy/proxy does not ship with wget, or curl, so resort to
bash-fu to hit Envoy's healthcheck/fail endpoint.

Signed-off-by: Dave Cheney <dave@cheney.net>