### PR TITLE
internal/contour: Allow circuitbreaking values to be defaulted from Config file

### DIFF
--- a/cmd/contour/serve.go
+++ b/cmd/contour/serve.go
@@ -38,7 +38,7 @@ import (
 	"github.com/heptio/contour/internal/workgroup"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
-	kingpin "gopkg.in/alecthomas/kingpin.v2"
+	"gopkg.in/alecthomas/kingpin.v2"
 	coreinformers "k8s.io/client-go/informers"
 )
 
@@ -151,6 +151,12 @@ type serveContext struct {
 	httpsAddr      string
 	httpsPort      int
 	httpsAccessLog string
+
+	// cluster config parameters
+	MaxConnections     int `json:"max-connections"`
+	MaxPendingRequests int `json:"max-pending-requests"`
+	MaxRequests        int `json:"max-requests"`
+	MaxRetries         int `json:"max-retries"`
 }
 
 // tlsconfig returns a new *tls.Config. If the context is not properly configured
@@ -218,6 +224,12 @@ func doServe(log logrus.FieldLogger, ctx *serveContext) error {
 			HTTPSAddress:   ctx.httpsAddr,
 			HTTPSPort:      ctx.httpsPort,
 			HTTPSAccessLog: ctx.httpsAccessLog,
+		},
+		ClusterVistorConfig: contour.ClusterVistorConfig{
+			MaxConnections:     ctx.MaxConnections,
+			MaxPendingRequests: ctx.MaxPendingRequests,
+			MaxRequests:        ctx.MaxRequests,
+			MaxRetries:         ctx.MaxRetries,
 		},
 		ListenerCache: contour.NewListenerCache(ctx.statsAddr, ctx.statsPort),
 		FieldLogger:   log.WithField("context", "CacheHandler"),

--- a/cmd/contour/serve.go
+++ b/cmd/contour/serve.go
@@ -153,6 +153,10 @@ type serveContext struct {
 	httpsAccessLog string
 
 	// cluster config parameters
+	circuitBreakerOptions `json:"circuitbreaker"`
+}
+
+type circuitBreakerOptions struct {
 	MaxConnections     int `json:"max-connections"`
 	MaxPendingRequests int `json:"max-pending-requests"`
 	MaxRequests        int `json:"max-requests"`

--- a/internal/contour/cachehandler.go
+++ b/internal/contour/cachehandler.go
@@ -29,6 +29,7 @@ import (
 // CacheHandler manages the state of xDS caches.
 type CacheHandler struct {
 	ListenerVisitorConfig
+	ClusterVistorConfig
 	ListenerCache
 	RouteCache
 	ClusterCache
@@ -81,7 +82,7 @@ func (ch *CacheHandler) updateRoutes(root dag.Visitable) {
 }
 
 func (ch *CacheHandler) updateClusters(root dag.Visitable) {
-	clusters := visitClusters(root)
+	clusters := visitClusters(root, &ch.ClusterVistorConfig)
 	ch.ClusterCache.Update(clusters)
 }
 

--- a/internal/contour/visitor_test.go
+++ b/internal/contour/visitor_test.go
@@ -31,8 +31,9 @@ import (
 
 func TestVisitClusters(t *testing.T) {
 	tests := map[string]struct {
-		root dag.Visitable
-		want map[string]*v2.Cluster
+		root   dag.Visitable
+		config *ClusterVistorConfig
+		want   map[string]*v2.Cluster
 	}{
 		"TCPService forward": {
 			root: &dag.Listener{
@@ -59,6 +60,7 @@ func TestVisitClusters(t *testing.T) {
 					},
 				),
 			},
+			config: &ClusterVistorConfig{},
 			want: clustermap(
 				&v2.Cluster{
 					Name:                 "default/example/443/da39a3ee5e",
@@ -78,7 +80,7 @@ func TestVisitClusters(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			got := visitClusters(tc.root)
+			got := visitClusters(tc.root, tc.config)
 			if diff := cmp.Diff(tc.want, got); diff != "" {
 				t.Fatal(diff)
 			}

--- a/internal/dag/builder.go
+++ b/internal/dag/builder.go
@@ -149,6 +149,7 @@ func (b *builder) addHTTPService(svc *v1.Service, port *v1.ServicePort) *HTTPSer
 		},
 		Protocol: protocol,
 	}
+
 	b.services[s.toMeta()] = s
 	return s
 }

--- a/internal/envoy/cluster.go
+++ b/internal/envoy/cluster.go
@@ -24,7 +24,7 @@ import (
 	v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	envoy_cluster "github.com/envoyproxy/go-control-plane/envoy/api/v2/cluster"
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
-	endpoint "github.com/envoyproxy/go-control-plane/envoy/api/v2/endpoint"
+	"github.com/envoyproxy/go-control-plane/envoy/api/v2/endpoint"
 	envoy_type "github.com/envoyproxy/go-control-plane/envoy/type"
 	"github.com/gogo/protobuf/types"
 	"github.com/heptio/contour/internal/dag"


### PR DESCRIPTION
Fixes #1192 by allowing maxconnection, maxpendingrequest, maxrequest, and maxretries to be set as global defaults for a Contour cluster from a config file. Specifying values using
the service annotation still overrides.

Sample configfile looks like this:
```json
{
  "circuitbreaker": {
    "max-connections": 100,
    "max-pending-requests": 200,
    "max-requests": 300,
    "max-retries": 400
  }
}
```

Contour can be run like this: 
```bash
$ contour serve -c config.json 
```

Signed-off-by: Steve Sloka <slokas@vmware.com>