### PR TITLE
examples: switch to downstream API and env var for Envoy's cluster & node params

### DIFF
--- a/examples/deployment-grpc-v2/02-contour.yaml
+++ b/examples/deployment-grpc-v2/02-contour.yaml
@@ -43,9 +43,20 @@ spec:
         command: ["envoy"]
         args:
         - --config-path /config/contour.json
-        - --service-cluster cluster0
-        - --service-node node0
+        - --service-cluster $(CONTOUR_NAMESPACE)
+        - --service-node $(ENVOY_POD_NAME)
         - --log-level info
+        env:
+        - name: CONTOUR_NAMESPACE
+          valueFrom:
+             fieldRef:
+               apiVersion: v1
+               fieldPath: metadata.namespace
+        - name: ENVOY_POD_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.name
         readinessProbe:
           httpGet:
             path: /healthz

--- a/examples/ds-grpc-v2/02-contour.yaml
+++ b/examples/ds-grpc-v2/02-contour.yaml
@@ -44,9 +44,20 @@ spec:
         command: ["envoy"]
         args:
         - --config-path /config/contour.json
-        - --service-cluster cluster0
-        - --service-node node0
+        - --service-cluster $(CONTOUR_NAMESPACE)
+        - --service-node $(ENVOY_POD_NAME)
         - --log-level info
+        env:
+        - name: CONTOUR_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        - name: ENVOY_POD_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.name
         readinessProbe:
           httpGet:
             path: /healthz

--- a/examples/ds-hostnet-split/03-envoy.yaml
+++ b/examples/ds-hostnet-split/03-envoy.yaml
@@ -26,15 +26,25 @@ spec:
       - args:
         - -c
         - /config/contour.json
-        - --service-cluster
-        - cluster0
-        - --service-node
-        - node0
+        - --service-cluster $(CONTOUR_NAMESPACE)
+        - --service-node $(ENVOY_POD_NAME)
+        - --log-level info
         command:
         - envoy
         image: docker.io/envoyproxy/envoy:v1.10.0
         imagePullPolicy: IfNotPresent
         name: envoy
+        env:
+        - name: CONTOUR_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        - name: ENVOY_POD_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.name
         ports:
         - containerPort: 80
           hostPort: 80

--- a/examples/ds-hostnet/02-contour.yaml
+++ b/examples/ds-hostnet/02-contour.yaml
@@ -48,9 +48,20 @@ spec:
         command: ["envoy"]
         args:
         - --config-path /config/contour.json
-        - --service-cluster cluster0
-        - --service-node node0
+        - --service-cluster $(CONTOUR_NAMESPACE)
+        - --service-node $(ENVOY_POD_NAME)
         - --log-level info
+        env:
+        - name: CONTOUR_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        - name: ENVOY_POD_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.name
         readinessProbe:
           httpGet:
             path: /healthz

--- a/examples/render/daemonset-rbac.yaml
+++ b/examples/render/daemonset-rbac.yaml
@@ -234,9 +234,20 @@ spec:
         command: ["envoy"]
         args:
         - --config-path /config/contour.json
-        - --service-cluster cluster0
-        - --service-node node0
+        - --service-cluster $(CONTOUR_NAMESPACE)
+        - --service-node $(ENVOY_POD_NAME)
         - --log-level info
+        env:
+        - name: CONTOUR_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        - name: ENVOY_POD_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.name
         readinessProbe:
           httpGet:
             path: /healthz

--- a/examples/render/deployment-rbac.yaml
+++ b/examples/render/deployment-rbac.yaml
@@ -233,9 +233,20 @@ spec:
         command: ["envoy"]
         args:
         - --config-path /config/contour.json
-        - --service-cluster cluster0
-        - --service-node node0
+        - --service-cluster $(CONTOUR_NAMESPACE)
+        - --service-node $(ENVOY_POD_NAME)
         - --log-level info
+        env:
+        - name: CONTOUR_NAMESPACE
+          valueFrom:
+             fieldRef:
+               apiVersion: v1
+               fieldPath: metadata.namespace
+        - name: ENVOY_POD_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.name
         readinessProbe:
           httpGet:
             path: /healthz


### PR DESCRIPTION
Fixes #1244 by updating example deployments to switch to downstream API and env var for Envoy's --service-cluster and --service-node flags.

This can be verified by looking at the admin page: `http://localhost:9001/server_info`

e.g. 
```
{
  "service_cluster": "heptio-contour",
  "service_node": "envoy-qc96l",
}
```

Signed-off-by: Steve Sloka <slokas@vmware.com>