### PR TITLE
internal/contour: Fix missing regex implementation for Ingress resources

### DIFF
--- a/internal/contour/route.go
+++ b/internal/contour/route.go
@@ -153,7 +153,7 @@ func (v *routeVisitor) visit(vertex dag.Vertex) {
 							return
 						}
 						rr := route.Route{
-							Match:               envoy.PrefixMatch(r.Prefix),
+							Match:               envoy.RouteMatch(r.Prefix),
 							Action:              envoy.RouteRoute(r),
 							RequestHeadersToAdd: envoy.RouteHeaders(),
 						}
@@ -179,7 +179,7 @@ func (v *routeVisitor) visit(vertex dag.Vertex) {
 							return
 						}
 						vhost.Routes = append(vhost.Routes, route.Route{
-							Match:               envoy.PrefixMatch(r.Prefix),
+							Match:               envoy.RouteMatch(r.Prefix),
 							Action:              envoy.RouteRoute(r),
 							RequestHeadersToAdd: envoy.RouteHeaders(),
 						})

--- a/internal/contour/route_test.go
+++ b/internal/contour/route_test.go
@@ -186,7 +186,7 @@ func TestRouteVisit(t *testing.T) {
 						Name:    "*",
 						Domains: []string{"*"},
 						Routes: []route.Route{{
-							Match:               envoy.PrefixMatch("/"),
+							Match:               envoy.RouteMatch("/"),
 							Action:              routecluster("default/kuard/8080/da39a3ee5e"),
 							RequestHeadersToAdd: envoy.RouteHeaders(),
 						}},
@@ -240,7 +240,7 @@ func TestRouteVisit(t *testing.T) {
 						Name:    "www.example.com",
 						Domains: domains("www.example.com"),
 						Routes: []route.Route{{
-							Match:               envoy.PrefixMatch("/"),
+							Match:               envoy.RouteMatch("/"),
 							Action:              routecluster("default/backend/80/da39a3ee5e"),
 							RequestHeadersToAdd: envoy.RouteHeaders(),
 						}},
@@ -298,7 +298,7 @@ func TestRouteVisit(t *testing.T) {
 						Name:    "*", // default backend
 						Domains: []string{"*"},
 						Routes: []route.Route{{
-							Match:               envoy.PrefixMatch("/"),
+							Match:               envoy.RouteMatch("/"),
 							Action:              routecluster("default/kuard/8080/da39a3ee5e"),
 							RequestHeadersToAdd: envoy.RouteHeaders(),
 						}},
@@ -366,7 +366,7 @@ func TestRouteVisit(t *testing.T) {
 						Name:    "www.example.com",
 						Domains: domains("www.example.com"),
 						Routes: []route.Route{{
-							Match:               envoy.PrefixMatch("/"),
+							Match:               envoy.RouteMatch("/"),
 							Action:              routecluster("default/kuard/8080/da39a3ee5e"),
 							RequestHeadersToAdd: envoy.RouteHeaders(),
 						}},
@@ -378,7 +378,7 @@ func TestRouteVisit(t *testing.T) {
 						Name:    "www.example.com",
 						Domains: domains("www.example.com"),
 						Routes: []route.Route{{
-							Match:               envoy.PrefixMatch("/"),
+							Match:               envoy.RouteMatch("/"),
 							Action:              routecluster("default/kuard/8080/da39a3ee5e"),
 							RequestHeadersToAdd: envoy.RouteHeaders(),
 						}},
@@ -440,7 +440,7 @@ func TestRouteVisit(t *testing.T) {
 						Name:    "www.example.com",
 						Domains: domains("www.example.com"),
 						Routes: []route.Route{{
-							Match: envoy.PrefixMatch("/"),
+							Match: envoy.RouteMatch("/"),
 							Action: &route.Route_Redirect{
 								Redirect: &route.RedirectAction{
 									SchemeRewriteSpecifier: &route.RedirectAction_HttpsRedirect{
@@ -457,7 +457,7 @@ func TestRouteVisit(t *testing.T) {
 						Name:    "www.example.com",
 						Domains: domains("www.example.com"),
 						Routes: []route.Route{{
-							Match:               envoy.PrefixMatch("/"),
+							Match:               envoy.RouteMatch("/"),
 							Action:              routecluster("default/backend/8080/da39a3ee5e"),
 							RequestHeadersToAdd: envoy.RouteHeaders(),
 						}},
@@ -528,7 +528,7 @@ func TestRouteVisit(t *testing.T) {
 						Name:    "www.example.com",
 						Domains: domains("www.example.com"),
 						Routes: []route.Route{{
-							Match:               envoy.PrefixMatch("/"),
+							Match:               envoy.RouteMatch("/"),
 							Action:              routecluster("default/kuard/8080/da39a3ee5e"),
 							RequestHeadersToAdd: envoy.RouteHeaders(),
 						}},
@@ -596,7 +596,7 @@ func TestRouteVisit(t *testing.T) {
 						Name:    "www.example.com",
 						Domains: domains("www.example.com"),
 						Routes: []route.Route{{
-							Match: envoy.PrefixMatch("/"),
+							Match: envoy.RouteMatch("/"),
 							Action: &route.Route_Redirect{
 								Redirect: &route.RedirectAction{
 									SchemeRewriteSpecifier: &route.RedirectAction_HttpsRedirect{
@@ -613,7 +613,7 @@ func TestRouteVisit(t *testing.T) {
 						Name:    "www.example.com",
 						Domains: domains("www.example.com"),
 						Routes: []route.Route{{
-							Match:               envoy.PrefixMatch("/"),
+							Match:               envoy.RouteMatch("/"),
 							Action:              routecluster("default/kuard/8080/da39a3ee5e"),
 							RequestHeadersToAdd: envoy.RouteHeaders(),
 						}},
@@ -676,11 +676,11 @@ func TestRouteVisit(t *testing.T) {
 						Name:    "www.example.com",
 						Domains: domains("www.example.com"),
 						Routes: []route.Route{{
-							Match:               envoy.PrefixMatch("/ws1"),
+							Match:               envoy.RouteMatch("/ws1"),
 							Action:              websocketroute("default/kuard/8080/da39a3ee5e"),
 							RequestHeadersToAdd: envoy.RouteHeaders(),
 						}, {
-							Match:               envoy.PrefixMatch("/"),
+							Match:               envoy.RouteMatch("/"),
 							Action:              routecluster("default/kuard/8080/da39a3ee5e"),
 							RequestHeadersToAdd: envoy.RouteHeaders(),
 						}},
@@ -729,7 +729,7 @@ func TestRouteVisit(t *testing.T) {
 						Name:    "*",
 						Domains: []string{"*"},
 						Routes: []route.Route{{
-							Match:               envoy.PrefixMatch("/"),
+							Match:               envoy.RouteMatch("/"),
 							Action:              routetimeout("default/kuard/8080/da39a3ee5e", duration(0)),
 							RequestHeadersToAdd: envoy.RouteHeaders(),
 						}},
@@ -778,7 +778,7 @@ func TestRouteVisit(t *testing.T) {
 						Name:    "*",
 						Domains: []string{"*"},
 						Routes: []route.Route{{
-							Match:               envoy.PrefixMatch("/"),
+							Match:               envoy.RouteMatch("/"),
 							Action:              routetimeout("default/kuard/8080/da39a3ee5e", duration(0)),
 							RequestHeadersToAdd: envoy.RouteHeaders(),
 						}},
@@ -827,7 +827,7 @@ func TestRouteVisit(t *testing.T) {
 						Name:    "*",
 						Domains: []string{"*"},
 						Routes: []route.Route{{
-							Match:               envoy.PrefixMatch("/"),
+							Match:               envoy.RouteMatch("/"),
 							Action:              routetimeout("default/kuard/8080/da39a3ee5e", duration(90*time.Second)),
 							RequestHeadersToAdd: envoy.RouteHeaders(),
 						}},
@@ -884,7 +884,7 @@ func TestRouteVisit(t *testing.T) {
 						Name:    "d31bb322ca62bb395acad00b3cbf45a3aa1010ca28dca7cddb4f7db786fa",
 						Domains: domains("my-very-very-long-service-host-name.subdomain.boring-dept.my.company"),
 						Routes: []route.Route{{
-							Match:               envoy.PrefixMatch("/"),
+							Match:               envoy.RouteMatch("/"),
 							Action:              routecluster("default/kuard/80/da39a3ee5e"),
 							RequestHeadersToAdd: envoy.RouteHeaders(),
 						}},
@@ -930,7 +930,7 @@ func TestRouteVisit(t *testing.T) {
 						Name:    "*",
 						Domains: []string{"*"},
 						Routes: []route.Route{{
-							Match:               envoy.PrefixMatch("/"),
+							Match:               envoy.RouteMatch("/"),
 							Action:              routecluster("default/kuard/8080/da39a3ee5e"),
 							RequestHeadersToAdd: envoy.RouteHeaders(),
 						}},
@@ -1059,7 +1059,7 @@ func TestRouteVisit(t *testing.T) {
 						Name:    "*",
 						Domains: []string{"*"},
 						Routes: []route.Route{{
-							Match:               envoy.PrefixMatch("/"),
+							Match:               envoy.RouteMatch("/"),
 							Action:              routecluster("default/kuard/8080/da39a3ee5e"),
 							RequestHeadersToAdd: envoy.RouteHeaders(),
 						}},
@@ -1108,7 +1108,7 @@ func TestRouteVisit(t *testing.T) {
 						Name:    "*",
 						Domains: []string{"*"},
 						Routes: []route.Route{{
-							Match:               envoy.PrefixMatch("/"),
+							Match:               envoy.RouteMatch("/"),
 							Action:              routecluster("default/kuard/8080/da39a3ee5e"),
 							RequestHeadersToAdd: envoy.RouteHeaders(),
 						}},
@@ -1162,7 +1162,7 @@ func TestRouteVisit(t *testing.T) {
 						Name:    "www.example.com",
 						Domains: domains("www.example.com"),
 						Routes: []route.Route{{
-							Match:               envoy.PrefixMatch("/"),
+							Match:               envoy.RouteMatch("/"),
 							Action:              routecluster("default/kuard/8080/da39a3ee5e"),
 							RequestHeadersToAdd: envoy.RouteHeaders(),
 						}},
@@ -1315,7 +1315,7 @@ func TestRouteVisit(t *testing.T) {
 						Name:    "www.example.com",
 						Domains: domains("www.example.com"),
 						Routes: []route.Route{{
-							Match:               envoy.PrefixMatch("/"),
+							Match:               envoy.RouteMatch("/"),
 							Action:              routecluster("default/kuard/8080/da39a3ee5e"),
 							RequestHeadersToAdd: envoy.RouteHeaders(),
 						}},
@@ -1372,7 +1372,7 @@ func TestRouteVisit(t *testing.T) {
 						Name:    "www.example.com",
 						Domains: domains("www.example.com"),
 						Routes: []route.Route{{
-							Match:               envoy.PrefixMatch("/"),
+							Match:               envoy.RouteMatch("/"),
 							Action:              routecluster("default/kuard/8080/da39a3ee5e"),
 							RequestHeadersToAdd: envoy.RouteHeaders(),
 						}},
@@ -1421,7 +1421,7 @@ func TestRouteVisit(t *testing.T) {
 						Name:    "*",
 						Domains: []string{"*"},
 						Routes: []route.Route{{
-							Match:               envoy.PrefixMatch("/"),
+							Match:               envoy.RouteMatch("/"),
 							Action:              routeretry("default/kuard/8080/da39a3ee5e", "5xx,gateway-error", 0, 0),
 							RequestHeadersToAdd: envoy.RouteHeaders(),
 						}},
@@ -1471,7 +1471,7 @@ func TestRouteVisit(t *testing.T) {
 						Name:    "*",
 						Domains: []string{"*"},
 						Routes: []route.Route{{
-							Match:               envoy.PrefixMatch("/"),
+							Match:               envoy.RouteMatch("/"),
 							Action:              routeretry("default/kuard/8080/da39a3ee5e", "5xx,gateway-error", 7, 0),
 							RequestHeadersToAdd: envoy.RouteHeaders(),
 						}},
@@ -1521,7 +1521,7 @@ func TestRouteVisit(t *testing.T) {
 						Name:    "*",
 						Domains: []string{"*"},
 						Routes: []route.Route{{
-							Match:               envoy.PrefixMatch("/"),
+							Match:               envoy.RouteMatch("/"),
 							Action:              routeretry("default/kuard/8080/da39a3ee5e", "5xx,gateway-error", 0, 150*time.Millisecond),
 							RequestHeadersToAdd: envoy.RouteHeaders(),
 						}},
@@ -1592,7 +1592,7 @@ func TestRouteVisit(t *testing.T) {
 						Name:    "www.example.com",
 						Domains: domains("www.example.com"),
 						Routes: []route.Route{{
-							Match: envoy.PrefixMatch("/"),
+							Match: envoy.RouteMatch("/"),
 							Action: &route.Route_Route{
 								Route: &route.RouteAction{
 									ClusterSpecifier: &route.RouteAction_WeightedClusters{
@@ -1676,7 +1676,7 @@ func TestRouteVisit(t *testing.T) {
 						Name:    "www.example.com",
 						Domains: domains("www.example.com"),
 						Routes: []route.Route{{
-							Match: envoy.PrefixMatch("/"),
+							Match: envoy.RouteMatch("/"),
 							Action: &route.Route_Route{
 								Route: &route.RouteAction{
 									ClusterSpecifier: &route.RouteAction_WeightedClusters{
@@ -1761,7 +1761,7 @@ func TestRouteVisit(t *testing.T) {
 						Name:    "www.example.com",
 						Domains: domains("www.example.com"),
 						Routes: []route.Route{{
-							Match: envoy.PrefixMatch("/"),
+							Match: envoy.RouteMatch("/"),
 							Action: &route.Route_Route{
 								Route: &route.RouteAction{
 									ClusterSpecifier: &route.RouteAction_WeightedClusters{

--- a/internal/e2e/rds_test.go
+++ b/internal/e2e/rds_test.go
@@ -106,7 +106,7 @@ func TestEditIngress(t *testing.T) {
 					Name:    "*",
 					Domains: []string{"*"},
 					Routes: []route.Route{{
-						Match:               envoy.PrefixMatch("/"),
+						Match:               envoy.RouteMatch("/"),
 						Action:              routecluster("default/kuard/80/da39a3ee5e"),
 						RequestHeadersToAdd: envoy.RouteHeaders(),
 					}},
@@ -150,7 +150,7 @@ func TestEditIngress(t *testing.T) {
 					Name:    "*",
 					Domains: []string{"*"},
 					Routes: []route.Route{{
-						Match:               envoy.PrefixMatch("/testing"),
+						Match:               envoy.RouteMatch("/testing"),
 						Action:              routecluster("default/kuard/80/da39a3ee5e"),
 						RequestHeadersToAdd: envoy.RouteHeaders(),
 					}},
@@ -230,7 +230,7 @@ func TestIngressPathRouteWithoutHost(t *testing.T) {
 					Name:    "*",
 					Domains: []string{"*"},
 					Routes: []route.Route{{
-						Match:               envoy.PrefixMatch("/hello"),
+						Match:               envoy.RouteMatch("/hello"),
 						Action:              routecluster("default/hello/80/da39a3ee5e"),
 						RequestHeadersToAdd: envoy.RouteHeaders(),
 					}},
@@ -311,7 +311,7 @@ func TestEditIngressInPlace(t *testing.T) {
 					Name:    "hello.example.com",
 					Domains: domains("hello.example.com"),
 					Routes: []route.Route{{
-						Match:               envoy.PrefixMatch("/"),
+						Match:               envoy.RouteMatch("/"),
 						Action:              routecluster("default/wowie/80/da39a3ee5e"),
 						RequestHeadersToAdd: envoy.RouteHeaders(),
 					}},
@@ -361,11 +361,11 @@ func TestEditIngressInPlace(t *testing.T) {
 					Name:    "hello.example.com",
 					Domains: domains("hello.example.com"),
 					Routes: []route.Route{{
-						Match:               envoy.PrefixMatch("/whoop"),
+						Match:               envoy.RouteMatch("/whoop"),
 						Action:              routecluster("default/kerpow/9000/da39a3ee5e"),
 						RequestHeadersToAdd: envoy.RouteHeaders(),
 					}, {
-						Match:               envoy.PrefixMatch("/"),
+						Match:               envoy.RouteMatch("/"),
 						Action:              routecluster("default/wowie/80/da39a3ee5e"),
 						RequestHeadersToAdd: envoy.RouteHeaders(),
 					}},
@@ -420,10 +420,10 @@ func TestEditIngressInPlace(t *testing.T) {
 					Name:    "hello.example.com",
 					Domains: domains("hello.example.com"),
 					Routes: []route.Route{{
-						Match:  envoy.PrefixMatch("/whoop"),
+						Match:  envoy.RouteMatch("/whoop"),
 						Action: envoy.UpgradeHTTPS(),
 					}, {
-						Match:  envoy.PrefixMatch("/"),
+						Match:  envoy.RouteMatch("/"),
 						Action: envoy.UpgradeHTTPS(),
 					}},
 				}}}),
@@ -491,10 +491,10 @@ func TestEditIngressInPlace(t *testing.T) {
 					Name:    "hello.example.com",
 					Domains: domains("hello.example.com"),
 					Routes: []route.Route{{
-						Match:  envoy.PrefixMatch("/whoop"),
+						Match:  envoy.RouteMatch("/whoop"),
 						Action: envoy.UpgradeHTTPS(),
 					}, {
-						Match:  envoy.PrefixMatch("/"),
+						Match:  envoy.RouteMatch("/"),
 						Action: envoy.UpgradeHTTPS(),
 					}},
 				}}}),
@@ -504,11 +504,11 @@ func TestEditIngressInPlace(t *testing.T) {
 					Name:    "hello.example.com",
 					Domains: domains("hello.example.com"),
 					Routes: []route.Route{{
-						Match:               envoy.PrefixMatch("/whoop"),
+						Match:               envoy.RouteMatch("/whoop"),
 						Action:              routecluster("default/kerpow/9000/da39a3ee5e"),
 						RequestHeadersToAdd: envoy.RouteHeaders(),
 					}, {
-						Match:               envoy.PrefixMatch("/"),
+						Match:               envoy.RouteMatch("/"),
 						Action:              routecluster("default/wowie/80/da39a3ee5e"),
 						RequestHeadersToAdd: envoy.RouteHeaders(),
 					}},
@@ -556,7 +556,7 @@ func TestRequestTimeout(t *testing.T) {
 		Name:    "*",
 		Domains: []string{"*"},
 		Routes: []route.Route{{
-			Match:               envoy.PrefixMatch("/"), // match all
+			Match:               envoy.RouteMatch("/"), // match all
 			Action:              routecluster("default/backend/80/da39a3ee5e"),
 			RequestHeadersToAdd: envoy.RouteHeaders(),
 		}},
@@ -578,7 +578,7 @@ func TestRequestTimeout(t *testing.T) {
 		Name:    "*",
 		Domains: []string{"*"},
 		Routes: []route.Route{{
-			Match:               envoy.PrefixMatch("/"), // match all
+			Match:               envoy.RouteMatch("/"), // match all
 			Action:              clustertimeout("default/backend/80/da39a3ee5e", durationInfinite),
 			RequestHeadersToAdd: envoy.RouteHeaders(),
 		}},
@@ -600,7 +600,7 @@ func TestRequestTimeout(t *testing.T) {
 		Name:    "*",
 		Domains: []string{"*"},
 		Routes: []route.Route{{
-			Match:               envoy.PrefixMatch("/"), // match all
+			Match:               envoy.RouteMatch("/"), // match all
 			Action:              clustertimeout("default/backend/80/da39a3ee5e", duration10Minutes),
 			RequestHeadersToAdd: envoy.RouteHeaders(),
 		}},
@@ -622,7 +622,7 @@ func TestRequestTimeout(t *testing.T) {
 		Name:    "*",
 		Domains: []string{"*"},
 		Routes: []route.Route{{
-			Match:               envoy.PrefixMatch("/"), // match all
+			Match:               envoy.RouteMatch("/"), // match all
 			Action:              clustertimeout("default/backend/80/da39a3ee5e", durationInfinite),
 			RequestHeadersToAdd: envoy.RouteHeaders(),
 		}},
@@ -735,22 +735,22 @@ func TestSSLRedirectOverlay(t *testing.T) {
 		Name:    "example.com",
 		Domains: domains("example.com"),
 		Routes: []route.Route{{
-			Match:               envoy.PrefixMatch("/.well-known/acme-challenge/gVJl5NWL2owUqZekjHkt_bo3OHYC2XNDURRRgLI5JTk"),
+			Match:               envoy.RouteMatch("/.well-known/acme-challenge/gVJl5NWL2owUqZekjHkt_bo3OHYC2XNDURRRgLI5JTk"),
 			Action:              routecluster("nginx-ingress/challenge-service/8009/da39a3ee5e"),
 			RequestHeadersToAdd: envoy.RouteHeaders(),
 		}, {
-			Match:  envoy.PrefixMatch("/"), // match all
+			Match:  envoy.RouteMatch("/"), // match all
 			Action: envoy.UpgradeHTTPS(),
 		}},
 	}}, []route.VirtualHost{{ // ingress_https
 		Name:    "example.com",
 		Domains: domains("example.com"),
 		Routes: []route.Route{{
-			Match:               envoy.PrefixMatch("/.well-known/acme-challenge/gVJl5NWL2owUqZekjHkt_bo3OHYC2XNDURRRgLI5JTk"),
+			Match:               envoy.RouteMatch("/.well-known/acme-challenge/gVJl5NWL2owUqZekjHkt_bo3OHYC2XNDURRRgLI5JTk"),
 			Action:              routecluster("nginx-ingress/challenge-service/8009/da39a3ee5e"),
 			RequestHeadersToAdd: envoy.RouteHeaders(),
 		}, {
-			Match:               envoy.PrefixMatch("/"), // match all
+			Match:               envoy.RouteMatch("/"), // match all
 			Action:              routecluster("default/app-service/8080/da39a3ee5e"),
 			RequestHeadersToAdd: envoy.RouteHeaders(),
 		}},
@@ -818,7 +818,7 @@ func TestInvalidCertInIngress(t *testing.T) {
 		Name:    "kuard.io",
 		Domains: domains("kuard.io"),
 		Routes: []route.Route{{
-			Match:               envoy.PrefixMatch("/"),
+			Match:               envoy.RouteMatch("/"),
 			Action:              routecluster("default/kuard/80/da39a3ee5e"),
 			RequestHeadersToAdd: envoy.RouteHeaders(),
 		}},
@@ -841,7 +841,7 @@ func TestInvalidCertInIngress(t *testing.T) {
 		Name:    "kuard.io",
 		Domains: domains("kuard.io"),
 		Routes: []route.Route{{
-			Match:               envoy.PrefixMatch("/"),
+			Match:               envoy.RouteMatch("/"),
 			Action:              routecluster("default/kuard/80/da39a3ee5e"),
 			RequestHeadersToAdd: envoy.RouteHeaders(),
 		}},
@@ -849,7 +849,7 @@ func TestInvalidCertInIngress(t *testing.T) {
 		Name:    "kuard.io",
 		Domains: domains("kuard.io"),
 		Routes: []route.Route{{
-			Match:               envoy.PrefixMatch("/"),
+			Match:               envoy.RouteMatch("/"),
 			Action:              routecluster("default/kuard/80/da39a3ee5e"),
 			RequestHeadersToAdd: envoy.RouteHeaders(),
 		}},
@@ -910,7 +910,7 @@ func TestIssue257(t *testing.T) {
 		Name:    "*",
 		Domains: []string{"*"},
 		Routes: []route.Route{{
-			Match:               envoy.PrefixMatch("/"), // match all
+			Match:               envoy.RouteMatch("/"), // match all
 			Action:              routecluster("default/kuard/80/da39a3ee5e"),
 			RequestHeadersToAdd: envoy.RouteHeaders(),
 		}},
@@ -964,7 +964,7 @@ func TestIssue257(t *testing.T) {
 		Name:    "kuard.db.gd-ms.com",
 		Domains: domains("kuard.db.gd-ms.com"),
 		Routes: []route.Route{{
-			Match:               envoy.PrefixMatch("/"), // match all
+			Match:               envoy.RouteMatch("/"), // match all
 			Action:              routecluster("default/kuard/80/da39a3ee5e"),
 			RequestHeadersToAdd: envoy.RouteHeaders(),
 		}},
@@ -1082,11 +1082,11 @@ func TestRDSFilter(t *testing.T) {
 					Name:    "example.com",
 					Domains: domains("example.com"),
 					Routes: []route.Route{{
-						Match:               envoy.PrefixMatch("/.well-known/acme-challenge/gVJl5NWL2owUqZekjHkt_bo3OHYC2XNDURRRgLI5JTk"),
+						Match:               envoy.RouteMatch("/.well-known/acme-challenge/gVJl5NWL2owUqZekjHkt_bo3OHYC2XNDURRRgLI5JTk"),
 						Action:              routecluster("nginx-ingress/challenge-service/8009/da39a3ee5e"),
 						RequestHeadersToAdd: envoy.RouteHeaders(),
 					}, {
-						Match:  envoy.PrefixMatch("/"), // match all
+						Match:  envoy.RouteMatch("/"), // match all
 						Action: envoy.UpgradeHTTPS(),
 					}},
 				}},
@@ -1105,11 +1105,11 @@ func TestRDSFilter(t *testing.T) {
 					Name:    "example.com",
 					Domains: domains("example.com"),
 					Routes: []route.Route{{
-						Match:               envoy.PrefixMatch("/.well-known/acme-challenge/gVJl5NWL2owUqZekjHkt_bo3OHYC2XNDURRRgLI5JTk"),
+						Match:               envoy.RouteMatch("/.well-known/acme-challenge/gVJl5NWL2owUqZekjHkt_bo3OHYC2XNDURRRgLI5JTk"),
 						Action:              routecluster("nginx-ingress/challenge-service/8009/da39a3ee5e"),
 						RequestHeadersToAdd: envoy.RouteHeaders(),
 					}, {
-						Match:               envoy.PrefixMatch("/"), // match all
+						Match:               envoy.RouteMatch("/"), // match all
 						Action:              routecluster("default/app-service/8080/da39a3ee5e"),
 						RequestHeadersToAdd: envoy.RouteHeaders(),
 					}},
@@ -1169,7 +1169,7 @@ func TestWebsocketIngress(t *testing.T) {
 		Name:    "websocket.hello.world",
 		Domains: domains("websocket.hello.world"),
 		Routes: []route.Route{{
-			Match:               envoy.PrefixMatch("/"), // match all
+			Match:               envoy.RouteMatch("/"), // match all
 			Action:              websocketroute("default/ws/80/da39a3ee5e"),
 			RequestHeadersToAdd: envoy.RouteHeaders(),
 		}},
@@ -1229,15 +1229,15 @@ func TestWebsocketIngressRoute(t *testing.T) {
 		Name:    "websocket.hello.world",
 		Domains: domains("websocket.hello.world"),
 		Routes: []route.Route{{
-			Match:               envoy.PrefixMatch("/ws-2"),
+			Match:               envoy.RouteMatch("/ws-2"),
 			Action:              websocketroute("default/ws/80/da39a3ee5e"),
 			RequestHeadersToAdd: envoy.RouteHeaders(),
 		}, {
-			Match:               envoy.PrefixMatch("/ws-1"),
+			Match:               envoy.RouteMatch("/ws-1"),
 			Action:              websocketroute("default/ws/80/da39a3ee5e"),
 			RequestHeadersToAdd: envoy.RouteHeaders(),
 		}, {
-			Match:               envoy.PrefixMatch("/"), // match all
+			Match:               envoy.RouteMatch("/"), // match all
 			Action:              routecluster("default/ws/80/da39a3ee5e"),
 			RequestHeadersToAdd: envoy.RouteHeaders(),
 		}},
@@ -1296,15 +1296,15 @@ func TestPrefixRewriteIngressRoute(t *testing.T) {
 		Name:    "prefixrewrite.hello.world",
 		Domains: domains("prefixrewrite.hello.world"),
 		Routes: []route.Route{{
-			Match:               envoy.PrefixMatch("/ws-2"),
+			Match:               envoy.RouteMatch("/ws-2"),
 			Action:              prefixrewriteroute("default/ws/80/da39a3ee5e"),
 			RequestHeadersToAdd: envoy.RouteHeaders(),
 		}, {
-			Match:               envoy.PrefixMatch("/ws-1"),
+			Match:               envoy.RouteMatch("/ws-1"),
 			Action:              prefixrewriteroute("default/ws/80/da39a3ee5e"),
 			RequestHeadersToAdd: envoy.RouteHeaders(),
 		}, {
-			Match:               envoy.PrefixMatch("/"), // match all
+			Match:               envoy.RouteMatch("/"), // match all
 			Action:              routecluster("default/ws/80/da39a3ee5e"),
 			RequestHeadersToAdd: envoy.RouteHeaders(),
 		}},
@@ -1400,11 +1400,11 @@ func TestDefaultBackendDoesNotOverwriteNamedHost(t *testing.T) {
 					Name:    "*",
 					Domains: []string{"*"},
 					Routes: []route.Route{{
-						Match:               envoy.PrefixMatch("/kuard"),
+						Match:               envoy.RouteMatch("/kuard"),
 						Action:              routecluster("default/kuard/8080/da39a3ee5e"),
 						RequestHeadersToAdd: envoy.RouteHeaders(),
 					}, {
-						Match:               envoy.PrefixMatch("/"),
+						Match:               envoy.RouteMatch("/"),
 						Action:              routecluster("default/kuard/80/da39a3ee5e"),
 						RequestHeadersToAdd: envoy.RouteHeaders(),
 					}},
@@ -1412,7 +1412,7 @@ func TestDefaultBackendDoesNotOverwriteNamedHost(t *testing.T) {
 					Name:    "test-gui",
 					Domains: domains("test-gui"),
 					Routes: []route.Route{{
-						Match:               envoy.PrefixMatch("/"),
+						Match:               envoy.RouteMatch("/"),
 						Action:              routecluster("default/test-gui/80/da39a3ee5e"),
 						RequestHeadersToAdd: envoy.RouteHeaders(),
 					}},
@@ -1477,7 +1477,7 @@ func TestRDSIngressRouteInsideRootNamespaces(t *testing.T) {
 					Name:    "example.com",
 					Domains: domains("example.com"),
 					Routes: []route.Route{{
-						Match:               envoy.PrefixMatch("/"),
+						Match:               envoy.RouteMatch("/"),
 						Action:              routecluster("roots/kuard/8080/da39a3ee5e"),
 						RequestHeadersToAdd: envoy.RouteHeaders(),
 					}},
@@ -1594,7 +1594,7 @@ func TestRDSIngressRouteClassAnnotation(t *testing.T) {
 		Name:    "www.example.com",
 		Domains: domains("www.example.com"),
 		Routes: []route.Route{{
-			Match:               envoy.PrefixMatch("/"),
+			Match:               envoy.RouteMatch("/"),
 			Action:              routecluster("default/kuard/8080/da39a3ee5e"),
 			RequestHeadersToAdd: envoy.RouteHeaders(),
 		}},
@@ -1680,7 +1680,7 @@ func TestRDSIngressRouteClassAnnotation(t *testing.T) {
 		Name:    "www.example.com",
 		Domains: domains("www.example.com"),
 		Routes: []route.Route{{
-			Match:               envoy.PrefixMatch("/"),
+			Match:               envoy.RouteMatch("/"),
 			Action:              routecluster("default/kuard/8080/da39a3ee5e"),
 			RequestHeadersToAdd: envoy.RouteHeaders(),
 		}},
@@ -1715,7 +1715,7 @@ func TestRDSIngressRouteClassAnnotation(t *testing.T) {
 		Name:    "www.example.com",
 		Domains: domains("www.example.com"),
 		Routes: []route.Route{{
-			Match:               envoy.PrefixMatch("/"),
+			Match:               envoy.RouteMatch("/"),
 			Action:              routecluster("default/kuard/8080/da39a3ee5e"),
 			RequestHeadersToAdd: envoy.RouteHeaders(),
 		}},
@@ -1765,7 +1765,7 @@ func TestRDSIngressClassAnnotation(t *testing.T) {
 		Name:    "*",
 		Domains: []string{"*"},
 		Routes: []route.Route{{
-			Match:               envoy.PrefixMatch("/"),
+			Match:               envoy.RouteMatch("/"),
 			Action:              routecluster("default/kuard/8080/da39a3ee5e"),
 			RequestHeadersToAdd: envoy.RouteHeaders(),
 		}},
@@ -1827,7 +1827,7 @@ func TestRDSIngressClassAnnotation(t *testing.T) {
 		Name:    "*",
 		Domains: []string{"*"},
 		Routes: []route.Route{{
-			Match:               envoy.PrefixMatch("/"),
+			Match:               envoy.RouteMatch("/"),
 			Action:              routecluster("default/kuard/8080/da39a3ee5e"),
 			RequestHeadersToAdd: envoy.RouteHeaders(),
 		}},
@@ -1853,7 +1853,7 @@ func TestRDSIngressClassAnnotation(t *testing.T) {
 		Name:    "*",
 		Domains: []string{"*"},
 		Routes: []route.Route{{
-			Match:               envoy.PrefixMatch("/"),
+			Match:               envoy.RouteMatch("/"),
 			Action:              routecluster("default/kuard/8080/da39a3ee5e"),
 			RequestHeadersToAdd: envoy.RouteHeaders(),
 		}},
@@ -1987,7 +1987,7 @@ func TestRDSIngressSpecMissingHTTPKey(t *testing.T) {
 		Name:    "test2.test.com",
 		Domains: domains("test2.test.com"),
 		Routes: []route.Route{{
-			Match:               envoy.PrefixMatch("/"), // match all
+			Match:               envoy.RouteMatch("/"), // match all
 			Action:              routecluster("default/network-test/9001/da39a3ee5e"),
 			RequestHeadersToAdd: envoy.RouteHeaders(),
 		}},
@@ -2035,7 +2035,7 @@ func TestRouteWithAServiceWeight(t *testing.T) {
 		Name:    "test2.test.com",
 		Domains: domains("test2.test.com"),
 		Routes: []route.Route{{
-			Match:               envoy.PrefixMatch("/a"), // match all
+			Match:               envoy.RouteMatch("/a"), // match all
 			Action:              routecluster("default/kuard/80/da39a3ee5e"),
 			RequestHeadersToAdd: envoy.RouteHeaders(),
 		}},
@@ -2068,7 +2068,7 @@ func TestRouteWithAServiceWeight(t *testing.T) {
 		Name:    "test2.test.com",
 		Domains: domains("test2.test.com"),
 		Routes: []route.Route{{
-			Match: envoy.PrefixMatch("/a"), // match all
+			Match: envoy.RouteMatch("/a"), // match all
 			Action: routeweightedcluster(
 				weightedcluster{"default/kuard/80/da39a3ee5e", 60},
 				weightedcluster{"default/kuard/80/da39a3ee5e", 90},
@@ -2142,7 +2142,7 @@ func TestRouteWithTLS(t *testing.T) {
 					Name:    "test2.test.com",
 					Domains: domains("test2.test.com"),
 					Routes: []route.Route{{
-						Match:  envoy.PrefixMatch("/a"),
+						Match:  envoy.RouteMatch("/a"),
 						Action: envoy.UpgradeHTTPS(),
 					}},
 				}}}),
@@ -2152,7 +2152,7 @@ func TestRouteWithTLS(t *testing.T) {
 					Name:    "test2.test.com",
 					Domains: domains("test2.test.com"),
 					Routes: []route.Route{{
-						Match:               envoy.PrefixMatch("/a"),
+						Match:               envoy.RouteMatch("/a"),
 						Action:              routecluster("default/kuard/80/da39a3ee5e"),
 						RequestHeadersToAdd: envoy.RouteHeaders(),
 					}},
@@ -2248,10 +2248,10 @@ func TestRouteWithTLS_InsecurePaths(t *testing.T) {
 					Domains: domains("test2.test.com"),
 					Routes: []route.Route{
 						{
-							Match:  envoy.PrefixMatch("/secure"),
+							Match:  envoy.RouteMatch("/secure"),
 							Action: envoy.UpgradeHTTPS(),
 						}, {
-							Match:               envoy.PrefixMatch("/insecure"),
+							Match:               envoy.RouteMatch("/insecure"),
 							Action:              routecluster("default/kuard/80/da39a3ee5e"),
 							RequestHeadersToAdd: envoy.RouteHeaders(),
 						},
@@ -2264,11 +2264,11 @@ func TestRouteWithTLS_InsecurePaths(t *testing.T) {
 					Domains: domains("test2.test.com"),
 					Routes: []route.Route{
 						{
-							Match:               envoy.PrefixMatch("/secure"),
+							Match:               envoy.RouteMatch("/secure"),
 							Action:              routecluster("default/svc2/80/da39a3ee5e"),
 							RequestHeadersToAdd: envoy.RouteHeaders(),
 						}, {
-							Match:               envoy.PrefixMatch("/insecure"),
+							Match:               envoy.RouteMatch("/insecure"),
 							Action:              routecluster("default/kuard/80/da39a3ee5e"),
 							RequestHeadersToAdd: envoy.RouteHeaders(),
 						},
@@ -2318,7 +2318,7 @@ func TestRouteRetryAnnotations(t *testing.T) {
 		Name:    "*",
 		Domains: []string{"*"},
 		Routes: []route.Route{{
-			Match:               envoy.PrefixMatch("/"), // match all
+			Match:               envoy.RouteMatch("/"), // match all
 			Action:              routeretry("default/backend/80/da39a3ee5e", "5xx,gateway-error", 7, 120*time.Millisecond),
 			RequestHeadersToAdd: envoy.RouteHeaders(),
 		}},
@@ -2371,7 +2371,7 @@ func TestRouteRetryIngressRoute(t *testing.T) {
 		Name:    "test2.test.com",
 		Domains: domains("test2.test.com"),
 		Routes: []route.Route{{
-			Match:               envoy.PrefixMatch("/"), // match all
+			Match:               envoy.RouteMatch("/"), // match all
 			Action:              routeretry("default/backend/80/da39a3ee5e", "5xx", 7, 120*time.Millisecond),
 			RequestHeadersToAdd: envoy.RouteHeaders(),
 		}},
@@ -2425,7 +2425,7 @@ func TestRouteTimeoutPolicyIngressRoute(t *testing.T) {
 		Name:    "test2.test.com",
 		Domains: domains("test2.test.com"),
 		Routes: []route.Route{{
-			Match:               envoy.PrefixMatch("/"), // match all
+			Match:               envoy.RouteMatch("/"), // match all
 			Action:              routecluster("default/backend/80/da39a3ee5e"),
 			RequestHeadersToAdd: envoy.RouteHeaders(),
 		}},
@@ -2456,7 +2456,7 @@ func TestRouteTimeoutPolicyIngressRoute(t *testing.T) {
 		Name:    "test2.test.com",
 		Domains: domains("test2.test.com"),
 		Routes: []route.Route{{
-			Match:               envoy.PrefixMatch("/"), // match all
+			Match:               envoy.RouteMatch("/"), // match all
 			Action:              clustertimeout("default/backend/80/da39a3ee5e", durationInfinite),
 			RequestHeadersToAdd: envoy.RouteHeaders(),
 		}},
@@ -2486,7 +2486,7 @@ func TestRouteTimeoutPolicyIngressRoute(t *testing.T) {
 		Name:    "test2.test.com",
 		Domains: domains("test2.test.com"),
 		Routes: []route.Route{{
-			Match:               envoy.PrefixMatch("/"), // match all
+			Match:               envoy.RouteMatch("/"), // match all
 			Action:              clustertimeout("default/backend/80/da39a3ee5e", duration10Minutes),
 			RequestHeadersToAdd: envoy.RouteHeaders(),
 		}},
@@ -2516,7 +2516,7 @@ func TestRouteTimeoutPolicyIngressRoute(t *testing.T) {
 		Name:    "test2.test.com",
 		Domains: domains("test2.test.com"),
 		Routes: []route.Route{{
-			Match:               envoy.PrefixMatch("/"), // match all
+			Match:               envoy.RouteMatch("/"), // match all
 			Action:              clustertimeout("default/backend/80/da39a3ee5e", durationInfinite),
 			RequestHeadersToAdd: envoy.RouteHeaders(),
 		}},
@@ -2569,7 +2569,7 @@ func TestRouteWithSessionAffinity(t *testing.T) {
 		Name:    "www.example.com",
 		Domains: domains("www.example.com"),
 		Routes: []route.Route{{
-			Match:               envoy.PrefixMatch("/cart"),
+			Match:               envoy.RouteMatch("/cart"),
 			Action:              withSessionAffinity(routecluster("default/app/80/e4f81994fe")),
 			RequestHeadersToAdd: envoy.RouteHeaders(),
 		}},
@@ -2602,7 +2602,7 @@ func TestRouteWithSessionAffinity(t *testing.T) {
 		Name:    "www.example.com",
 		Domains: domains("www.example.com"),
 		Routes: []route.Route{{
-			Match: envoy.PrefixMatch("/cart"),
+			Match: envoy.RouteMatch("/cart"),
 			Action: withSessionAffinity(
 				routeweightedcluster(
 					weightedcluster{"default/app/80/e4f81994fe", 1},
@@ -2645,7 +2645,7 @@ func TestRouteWithSessionAffinity(t *testing.T) {
 		Name:    "www.example.com",
 		Domains: domains("www.example.com"),
 		Routes: []route.Route{{
-			Match: envoy.PrefixMatch("/cart"),
+			Match: envoy.RouteMatch("/cart"),
 			Action: withSessionAffinity(
 				routeweightedcluster(
 					weightedcluster{"default/app/80/e4f81994fe", 1},
@@ -2654,7 +2654,7 @@ func TestRouteWithSessionAffinity(t *testing.T) {
 			),
 			RequestHeadersToAdd: envoy.RouteHeaders(),
 		}, {
-			Match:               envoy.PrefixMatch("/"),
+			Match:               envoy.RouteMatch("/"),
 			Action:              routecluster("default/app/80/da39a3ee5e"),
 			RequestHeadersToAdd: envoy.RouteHeaders(),
 		}},
@@ -2726,7 +2726,7 @@ func TestLoadBalancingStrategies(t *testing.T) {
 		Domains: domains("test2.test.com"),
 		Routes: []route.Route{
 			{
-				Match:               envoy.PrefixMatch("/a"),
+				Match:               envoy.RouteMatch("/a"),
 				Action:              routeweightedcluster(wc...),
 				RequestHeadersToAdd: envoy.RouteHeaders(),
 			},

--- a/internal/envoy/route.go
+++ b/internal/envoy/route.go
@@ -14,6 +14,7 @@ package envoy
 
 import (
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
@@ -157,11 +158,19 @@ func weightedClusters(clusters []*dag.Cluster) *route.WeightedCluster {
 	return &wc
 }
 
-// PrefixMatch creates a RouteMatch for the supplied prefix.
-func PrefixMatch(prefix string) route.RouteMatch {
+// RouteMatch creates a RouteMatch for the supplied prefix/regex.
+func RouteMatch(path string) route.RouteMatch {
+	// Check if path contains a regex
+	if strings.ContainsAny(path, "^+*[]%") {
+		return route.RouteMatch{
+			PathSpecifier: &route.RouteMatch_Regex{
+				Regex: path,
+			},
+		}
+	}
 	return route.RouteMatch{
 		PathSpecifier: &route.RouteMatch_Prefix{
-			Prefix: prefix,
+			Prefix: path,
 		},
 	}
 }

--- a/internal/envoy/route_test.go
+++ b/internal/envoy/route_test.go
@@ -487,10 +487,24 @@ func TestVirtualHost(t *testing.T) {
 
 func TestPrefixMatch(t *testing.T) {
 	const prefix = "/kang"
-	got := PrefixMatch(prefix)
+	got := RouteMatch(prefix)
 	want := route.RouteMatch{
 		PathSpecifier: &route.RouteMatch_Prefix{
 			Prefix: prefix,
+		},
+	}
+
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Fatal(diff)
+	}
+}
+
+func TestRegexMatch(t *testing.T) {
+	const prefix = "/[^/]+/media(/.*|/?)"
+	got := RouteMatch(prefix)
+	want := route.RouteMatch{
+		PathSpecifier: &route.RouteMatch_Regex{
+			Regex: prefix,
 		},
 	}
 


### PR DESCRIPTION
Fixes #1243 by implementing a routematch_regex for any Ingress route containing a regex. 

Signed-off-by: Steve Sloka <slokas@vmware.com>