### PR TITLE
contour: sort prefix routes after regex routes

### DIFF
--- a/internal/e2e/rds_test.go
+++ b/internal/e2e/rds_test.go
@@ -2793,8 +2793,7 @@ func TestRoutePrefixRouteRegex(t *testing.T) {
 					Name:    "*",
 					Domains: []string{"*"},
 					Routes: []route.Route{{
-						Match: envoy.RouteRegex("/[^/]+/invoices(/.*|/?)"),
-
+						Match:               envoy.RouteRegex("/[^/]+/invoices(/.*|/?)"),
 						Action:              routecluster("default/kuard/80/da39a3ee5e"),
 						RequestHeadersToAdd: envoy.RouteHeaders(),
 					}, {


### PR DESCRIPTION
Fix build by stabilising the sorting of routes. Now regexes sort before
prefixes, withing regexes and prefixes, they sorted by length.

Signed-off-by: Dave Cheney <dave@cheney.net>