### PR TITLE
travis.yml: fix travis build caching

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,14 +7,11 @@ sudo: false
 
 cache:
   directories:
-  - $HOME/.cache/go-build
-  - $HOME/gopath/pkg/mod
+  - /home/travis/.cache/go-build
+  - /home/travis/gopath/pkg/mod
 
 env:
-  - GOPROXY=https://gocenter.io
-
-install:
-  - make download
+  - GOPROXY=HTTPS://gocenter.io
 
 script:
   - make check


### PR DESCRIPTION
gocenter.io seems to be having problems today. Also build caching
doesn't seem to be working.

Signed-off-by: Dave Cheney <dave@cheney.net>