### PR TITLE
internal/dag: move IngressClass filtering to dag.KubernetesCache

### DIFF
--- a/cmd/contour/serve.go
+++ b/cmd/contour/serve.go
@@ -267,9 +267,9 @@ func doServe(log logrus.FieldLogger, ctx *serveContext) error {
 		},
 		KubernetesCache: dag.KubernetesCache{
 			IngressRouteRootNamespaces: ctx.ingressRouteRootNamespaces(),
+			IngressClass:               ctx.ingressClass,
 		},
-		IngressClass: ctx.ingressClass,
-		FieldLogger:  log.WithField("context", "resourceEventHandler"),
+		FieldLogger: log.WithField("context", "resourceEventHandler"),
 	}
 
 	// step 5. register out resource event handler with the k8s informers.

--- a/internal/contour/cluster_test.go
+++ b/internal/contour/cluster_test.go
@@ -23,10 +23,7 @@ import (
 	"github.com/gogo/protobuf/proto"
 	"github.com/google/go-cmp/cmp"
 	ingressroutev1 "github.com/heptio/contour/apis/contour/v1beta1"
-	"github.com/heptio/contour/internal/dag"
 	"github.com/heptio/contour/internal/envoy"
-	"github.com/heptio/contour/internal/metrics"
-	"github.com/prometheus/client_golang/prometheus"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/api/extensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -859,15 +856,7 @@ func TestClusterVisit(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			reh := ResourceEventHandler{
-				FieldLogger: testLogger(t),
-				Notifier:    new(nullNotifier),
-				Metrics:     metrics.NewMetrics(prometheus.NewRegistry()),
-			}
-			for _, o := range tc.objs {
-				reh.OnAdd(o)
-			}
-			root := dag.BuildDAG(&reh.KubernetesCache)
+			root := buildDAG(tc.objs...)
 			got := visitClusters(root)
 			if diff := cmp.Diff(tc.want, got); diff != "" {
 				t.Fatal(diff)

--- a/internal/contour/contour_test.go
+++ b/internal/contour/contour_test.go
@@ -16,7 +16,6 @@ package contour
 import (
 	"testing"
 
-	"github.com/heptio/contour/internal/dag"
 	"github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -62,7 +61,3 @@ func ports(ps ...int32) []v1.EndpointPort {
 	}
 	return ports
 }
-
-type nullNotifier int
-
-func (nn *nullNotifier) OnChange(kc *dag.KubernetesCache) {}

--- a/internal/contour/listener_test.go
+++ b/internal/contour/listener_test.go
@@ -22,10 +22,7 @@ import (
 	"github.com/gogo/protobuf/proto"
 	"github.com/google/go-cmp/cmp"
 	ingressroutev1 "github.com/heptio/contour/apis/contour/v1beta1"
-	"github.com/heptio/contour/internal/dag"
 	"github.com/heptio/contour/internal/envoy"
-	"github.com/heptio/contour/internal/metrics"
-	"github.com/prometheus/client_golang/prometheus"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/api/extensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -815,15 +812,7 @@ func TestListenerVisit(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			reh := ResourceEventHandler{
-				FieldLogger: testLogger(t),
-				Notifier:    new(nullNotifier),
-				Metrics:     metrics.NewMetrics(prometheus.NewRegistry()),
-			}
-			for _, o := range tc.objs {
-				reh.OnAdd(o)
-			}
-			root := dag.BuildDAG(&reh.KubernetesCache)
+			root := buildDAG(tc.objs...)
 			got := visitListeners(root, &tc.ListenerVisitorConfig)
 			if !cmp.Equal(tc.want, got) {
 				t.Fatalf("expected:\n%+v\ngot:\n%+v", tc.want, got)

--- a/internal/dag/annotations.go
+++ b/internal/dag/annotations.go
@@ -83,3 +83,22 @@ func websocketRoutes(i *v1beta1.Ingress) map[string]bool {
 	}
 	return routes
 }
+
+// getIngressClassAnnotation checks for the acceptable ingress class annotations
+// 1. contour.heptio.com/ingress.class
+// 2. kubernetes.io/ingress.class
+//
+// it returns the first matching ingress annotation (in the above order) with test
+func getIngressClassAnnotation(annotations map[string]string) string {
+	class, ok := annotations["contour.heptio.com/ingress.class"]
+	if ok {
+		return class
+	}
+
+	class, ok = annotations["kubernetes.io/ingress.class"]
+	if ok {
+		return class
+	}
+
+	return ""
+}

--- a/internal/dag/cache.go
+++ b/internal/dag/cache.go
@@ -25,6 +25,8 @@ import (
 	ingressroutev1 "github.com/heptio/contour/apis/contour/v1beta1"
 )
 
+const DEFAULT_INGRESS_CLASS = "contour"
+
 // A KubernetesCache holds Kubernetes objects and associated configuration and produces
 // DAG values.
 type KubernetesCache struct {
@@ -32,6 +34,10 @@ type KubernetesCache struct {
 	// IngressRoutes can be defined. If empty, roots can be defined in any
 	// namespace.
 	IngressRouteRootNamespaces []string
+
+	// Contour's IngressClass.
+	// If not set, defaults to DEFAULT_INGRESS_CLASS.
+	IngressClass string
 
 	mu sync.RWMutex
 
@@ -48,8 +54,10 @@ type Meta struct {
 }
 
 // Insert inserts obj into the KubernetesCache.
-// If an object with a matching type, name, and namespace exists, it will be overwritten.
-func (kc *KubernetesCache) Insert(obj interface{}) {
+// Insert returns true if the cache accepted the object, or false if the value
+// is not interesting to the cache. If an object with a matching type, name,
+// and namespace exists, it will be overwritten.
+func (kc *KubernetesCache) Insert(obj interface{}) bool {
 	kc.mu.Lock()
 	defer kc.mu.Unlock()
 	switch obj := obj.(type) {
@@ -59,67 +67,97 @@ func (kc *KubernetesCache) Insert(obj interface{}) {
 			kc.secrets = make(map[Meta]*v1.Secret)
 		}
 		kc.secrets[m] = obj
+		return true
 	case *v1.Service:
 		m := Meta{name: obj.Name, namespace: obj.Namespace}
 		if kc.services == nil {
 			kc.services = make(map[Meta]*v1.Service)
 		}
 		kc.services[m] = obj
+		return true
 	case *v1beta1.Ingress:
+		class := getIngressClassAnnotation(obj.Annotations)
+		if class != "" && class != kc.ingressClass() {
+			return false
+		}
 		m := Meta{name: obj.Name, namespace: obj.Namespace}
 		if kc.ingresses == nil {
 			kc.ingresses = make(map[Meta]*v1beta1.Ingress)
 		}
 		kc.ingresses[m] = obj
+		return true
 	case *ingressroutev1.IngressRoute:
+		class := getIngressClassAnnotation(obj.Annotations)
+		if class != "" && class != kc.ingressClass() {
+			return false
+		}
 		m := Meta{name: obj.Name, namespace: obj.Namespace}
 		if kc.ingressroutes == nil {
 			kc.ingressroutes = make(map[Meta]*ingressroutev1.IngressRoute)
 		}
 		kc.ingressroutes[m] = obj
+		return true
 	case *ingressroutev1.TLSCertificateDelegation:
 		m := Meta{name: obj.Name, namespace: obj.Namespace}
 		if kc.delegations == nil {
 			kc.delegations = make(map[Meta]*ingressroutev1.TLSCertificateDelegation)
 		}
 		kc.delegations[m] = obj
-
+		return true
 	default:
 		// not an interesting object
+		return false
 	}
+}
+
+// ingressClass returns the IngressClass
+// or DEFAULT_INGRESS_CLASS if not configured.
+func (kc *KubernetesCache) ingressClass() string {
+	return stringOrDefault(kc.IngressClass, DEFAULT_INGRESS_CLASS)
 }
 
 // Remove removes obj from the KubernetesCache.
-// If no object with a matching type, name, and namespace exists in the DAG, no action is taken.
-func (kc *KubernetesCache) Remove(obj interface{}) {
+// Remove returns a boolean indiciating if the cache changed after the remove operation.
+func (kc *KubernetesCache) Remove(obj interface{}) bool {
 	switch obj := obj.(type) {
 	default:
-		kc.remove(obj)
+		return kc.remove(obj)
 	case cache.DeletedFinalStateUnknown:
-		kc.Remove(obj.Obj) // recurse into ourselves with the tombstoned value
+		return kc.Remove(obj.Obj) // recurse into ourselves with the tombstoned value
 	}
 }
 
-func (kc *KubernetesCache) remove(obj interface{}) {
+func (kc *KubernetesCache) remove(obj interface{}) bool {
 	kc.mu.Lock()
 	defer kc.mu.Unlock()
 	switch obj := obj.(type) {
 	case *v1.Secret:
 		m := Meta{name: obj.Name, namespace: obj.Namespace}
+		_, ok := kc.secrets[m]
 		delete(kc.secrets, m)
+		return ok
 	case *v1.Service:
 		m := Meta{name: obj.Name, namespace: obj.Namespace}
+		_, ok := kc.services[m]
 		delete(kc.services, m)
+		return ok
 	case *v1beta1.Ingress:
 		m := Meta{name: obj.Name, namespace: obj.Namespace}
+		_, ok := kc.ingresses[m]
 		delete(kc.ingresses, m)
+		return ok
 	case *ingressroutev1.IngressRoute:
 		m := Meta{name: obj.Name, namespace: obj.Namespace}
+		_, ok := kc.ingressroutes[m]
 		delete(kc.ingressroutes, m)
+		return ok
 	case *ingressroutev1.TLSCertificateDelegation:
 		m := Meta{name: obj.Name, namespace: obj.Namespace}
+		_, ok := kc.delegations[m]
 		delete(kc.delegations, m)
+		return ok
 	default:
 		// not interesting
+		return false
 	}
 }

--- a/internal/dag/cache_test.go
+++ b/internal/dag/cache_test.go
@@ -1,0 +1,310 @@
+// Copyright © 2019 Heptio
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dag
+
+import (
+	"testing"
+
+	ingressroutev1 "github.com/heptio/contour/apis/contour/v1beta1"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/api/extensions/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestKubernetesCacheInsert(t *testing.T) {
+	tests := map[string]struct {
+		obj  interface{}
+		want bool
+	}{
+		"insert secret": {
+			obj: &v1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "secret",
+					Namespace: "default",
+				},
+			},
+			want: true,
+		},
+		"insert ingress empty ingress class": {
+			obj: &v1beta1.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "incorrect",
+					Namespace: "default",
+				},
+			},
+			want: true,
+		},
+		"insert ingress incorrect kubernetes.io/ingress.class": {
+			obj: &v1beta1.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "incorrect",
+					Namespace: "default",
+					Annotations: map[string]string{
+						"kubernetes.io/ingress.class": "nginx",
+					},
+				},
+			},
+			want: false,
+		},
+		"insert ingress incorrect contour.heptio.com/ingress.class": {
+			obj: &v1beta1.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "incorrect",
+					Namespace: "default",
+					Annotations: map[string]string{
+						"contour.heptio.com/ingress.class": "nginx",
+					},
+				},
+			},
+			want: false,
+		},
+		"insert ingress explicit kubernetes.io/ingress.class": {
+			obj: &v1beta1.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "incorrect",
+					Namespace: "default",
+					Annotations: map[string]string{
+						"kubernetes.io/ingress.class": new(KubernetesCache).ingressClass(),
+					},
+				},
+			},
+			want: true,
+		},
+		"insert ingress explicit contour.heptio.com/ingress.class": {
+			obj: &v1beta1.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "incorrect",
+					Namespace: "default",
+					Annotations: map[string]string{
+						"contour.heptio.com/ingress.class": new(KubernetesCache).ingressClass(),
+					},
+				},
+			},
+			want: true,
+		},
+		"insert ingressroute empty ingress annotation": {
+			obj: &ingressroutev1.IngressRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "kuard",
+					Namespace: "default",
+				},
+			},
+			want: true,
+		},
+		"insert ingressroute incorrect contour.heptio.com/ingress.class": {
+			obj: &ingressroutev1.IngressRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "simple",
+					Namespace: "default",
+					Annotations: map[string]string{
+						"contour.heptio.com/ingress.class": "nginx",
+					},
+				},
+			},
+			want: false,
+		},
+		"insert ingressroute incorrect kubernetes.io/ingress.class": {
+			obj: &ingressroutev1.IngressRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "simple",
+					Namespace: "default",
+					Annotations: map[string]string{
+						"kubernetes.io/ingress.class": "nginx",
+					},
+				},
+			},
+			want: false,
+		},
+		"insert ingressroute: explicit contour.heptio.com/ingress.class": {
+			obj: &ingressroutev1.IngressRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "kuard",
+					Namespace: "default",
+					Annotations: map[string]string{
+						"contour.heptio.com/ingress.class": new(KubernetesCache).ingressClass(),
+					},
+				},
+			},
+			want: true,
+		},
+		"insert ingressroute explicit kubernetes.io/ingress.class": {
+			obj: &ingressroutev1.IngressRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "kuard",
+					Namespace: "default",
+					Annotations: map[string]string{
+						"kubernetes.io/ingress.class": new(KubernetesCache).ingressClass(),
+					},
+				},
+			},
+			want: true,
+		},
+		"insert tls certificate delegation": {
+			obj: &ingressroutev1.TLSCertificateDelegation{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "delegate",
+					Namespace: "default",
+				},
+			},
+			want: true,
+		},
+		"insert unknown": {
+			obj:  "not an object",
+			want: false,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			var cache KubernetesCache
+			got := cache.Insert(tc.obj)
+			if tc.want != got {
+				t.Fatalf("Insert(%v): expected %v, got %v", tc.obj, tc.want, got)
+			}
+		})
+	}
+}
+
+func TestKubernetesCacheRemove(t *testing.T) {
+	cache := func(objs ...interface{}) *KubernetesCache {
+		var cache KubernetesCache
+		for _, o := range objs {
+			cache.Insert(o)
+		}
+		return &cache
+	}
+
+	tests := map[string]struct {
+		cache *KubernetesCache
+		obj   interface{}
+		want  bool
+	}{
+		"remove secret": {
+			cache: cache(&v1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "secret",
+					Namespace: "default",
+				},
+			}),
+			obj: &v1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "secret",
+					Namespace: "default",
+				},
+			},
+			want: true,
+		},
+		"remove service": {
+			cache: cache(&v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "service",
+					Namespace: "default",
+				},
+			}),
+			obj: &v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "service",
+					Namespace: "default",
+				},
+			},
+			want: true,
+		},
+		"remove ingress": {
+			cache: cache(&v1beta1.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "ingress",
+					Namespace: "default",
+				},
+			}),
+			obj: &v1beta1.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "ingress",
+					Namespace: "default",
+				},
+			},
+			want: true,
+		},
+		"remove ingress incorrect ingressclass": {
+			cache: cache(&v1beta1.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "ingress",
+					Namespace: "default",
+					Annotations: map[string]string{
+						"kubernetes.io/ingress.class": "nginx",
+					},
+				},
+			}),
+			obj: &v1beta1.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "ingress",
+					Namespace: "default",
+					Annotations: map[string]string{
+						"kubernetes.io/ingress.class": "nginx",
+					},
+				},
+			},
+			want: false,
+		},
+		"remove ingressroute": {
+			cache: cache(&ingressroutev1.IngressRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "ingressroute",
+					Namespace: "default",
+				},
+			}),
+			obj: &ingressroutev1.IngressRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "ingressroute",
+					Namespace: "default",
+				},
+			},
+			want: true,
+		},
+		"remove ingressroute incorrect ingressclass": {
+			cache: cache(&ingressroutev1.IngressRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "ingressroute",
+					Namespace: "default",
+					Annotations: map[string]string{
+						"kubernetes.io/ingress.class": "nginx",
+					},
+				},
+			}),
+			obj: &ingressroutev1.IngressRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "ingressroute",
+					Namespace: "default",
+					Annotations: map[string]string{
+						"kubernetes.io/ingress.class": "nginx",
+					},
+				},
+			},
+			want: false,
+		},
+		"remove unknown": {
+			cache: cache("not an object"),
+			obj:   "not an object",
+			want:  false,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := tc.cache.Remove(tc.obj)
+			if tc.want != got {
+				t.Fatalf("Remove(%v): expected %v, got %v", tc.obj, tc.want, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Updates #1166
Updates #1172

Move the filtering of ingress class from the k8s resource event handler
to the dag KuberenetesCache. The cache now returns a boolean indicating
if the insert or remove operation caused the cache to change. This in
turn sets the ground rules for whether a dag update will take place in
the caller.

Signed-off-by: Dave Cheney <dave@cheney.net>