### PR TITLE
cmd/contour: init klog flags to set logging to stderr

### DIFF
--- a/cmd/contour/contour.go
+++ b/cmd/contour/contour.go
@@ -24,9 +24,11 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/klog"
 )
 
 func main() {
+	klog.InitFlags(nil)
 	log := logrus.StandardLogger()
 	app := kingpin.New("contour", "Heptio Contour Kubernetes ingress controller.")
 

--- a/go.mod
+++ b/go.mod
@@ -36,6 +36,7 @@ require (
 	k8s.io/client-go v12.0.0+incompatible
 	k8s.io/code-generator v0.0.0-20190311093542-50b561225d70
 	k8s.io/gengo v0.0.0-20190116091435-f8a0810f38af // indirect
+	k8s.io/klog v0.3.1
 	k8s.io/utils v0.0.0-20190607212802-c55fbcfc754a // indirect
 	mvdan.cc/unparam v0.0.0-20190720180237-d51796306d8f
 )


### PR DESCRIPTION
The default behavior of klog will be to attempt to log to a file,
similar to glog, which will result in a container crash because the
filesystem is read-only.

closes #1279

Signed-off-by: Matt Alberts <malberts@cloudflare.com>