### PR TITLE
internal/dag: Add config file item `allowPermitInsecure`

### DIFF
--- a/cmd/contour/serve.go
+++ b/cmd/contour/serve.go
@@ -61,21 +61,22 @@ func registerServe(app *kingpin.Application) (*kingpin.CmdClause, *serveContext)
 	)
 	// Set defaults for parameters which are then overridden via flags, ENV, or ConfigFile
 	ctx = serveContext{
-		Kubeconfig:     filepath.Join(os.Getenv("HOME"), ".kube", "config"),
-		xdsAddr:        "127.0.0.1",
-		xdsPort:        8001,
-		statsAddr:      "0.0.0.0",
-		statsPort:      8002,
-		debugAddr:      "127.0.0.1",
-		debugPort:      6060,
-		metricsAddr:    "0.0.0.0",
-		metricsPort:    8000,
-		httpAccessLog:  contour.DEFAULT_HTTP_ACCESS_LOG,
-		httpsAccessLog: contour.DEFAULT_HTTPS_ACCESS_LOG,
-		httpAddr:       "0.0.0.0",
-		httpsAddr:      "0.0.0.0",
-		httpPort:       8080,
-		httpsPort:      8443,
+		Kubeconfig:            filepath.Join(os.Getenv("HOME"), ".kube", "config"),
+		xdsAddr:               "127.0.0.1",
+		xdsPort:               8001,
+		statsAddr:             "0.0.0.0",
+		statsPort:             8002,
+		debugAddr:             "127.0.0.1",
+		debugPort:             6060,
+		metricsAddr:           "0.0.0.0",
+		metricsPort:           8000,
+		httpAccessLog:         contour.DEFAULT_HTTP_ACCESS_LOG,
+		httpsAccessLog:        contour.DEFAULT_HTTPS_ACCESS_LOG,
+		httpAddr:              "0.0.0.0",
+		httpsAddr:             "0.0.0.0",
+		httpPort:              8080,
+		httpsPort:             8443,
+		DisablePermitInsecure: false,
 	}
 
 	parseConfig := func(_ *kingpin.ParseContext) error {
@@ -172,6 +173,8 @@ type serveContext struct {
 	httpsAccessLog string
 
 	tlsConfig `json:"tls"`
+
+	DisablePermitInsecure bool `json:"disablePermitInsecure"`
 }
 
 type tlsConfig struct {
@@ -257,6 +260,7 @@ func doServe(log logrus.FieldLogger, ctx *serveContext) error {
 		IngressRouteStatus: &k8s.IngressRouteStatus{
 			Client: contourClient,
 		},
+		DisablePermitInsecure: ctx.DisablePermitInsecure,
 	}
 
 	// step 4. wrap the gRPC cache handler in a k8s resource event handler.

--- a/internal/contour/cachehandler.go
+++ b/internal/contour/cachehandler.go
@@ -34,6 +34,8 @@ type CacheHandler struct {
 	ClusterCache
 	SecretCache
 
+	DisablePermitInsecure bool
+
 	IngressRouteStatus *k8s.IngressRouteStatus
 	logrus.FieldLogger
 	*metrics.Metrics
@@ -42,7 +44,7 @@ type CacheHandler struct {
 func (ch *CacheHandler) OnChange(kc *dag.KubernetesCache) {
 	timer := prometheus.NewTimer(ch.CacheHandlerOnUpdateSummary)
 	defer timer.ObserveDuration()
-	dag := dag.BuildDAG(kc)
+	dag := dag.BuildDAG(kc, ch.DisablePermitInsecure)
 	ch.updateSecrets(dag)
 	ch.updateListeners(dag)
 	ch.updateRoutes(dag)

--- a/internal/contour/cachehandler_test.go
+++ b/internal/contour/cachehandler_test.go
@@ -570,7 +570,7 @@ func TestIngressRouteMetrics(t *testing.T) {
 			for _, o := range tc.objs {
 				kc.Insert(o)
 			}
-			dag := dag.BuildDAG(kc)
+			dag := dag.BuildDAG(kc, false)
 			got := calculateIngressRouteMetric(dag.Statuses())
 			if diff := cmp.Diff(tc.want, got); diff != "" {
 				t.Fatal(diff)

--- a/internal/contour/secret_test.go
+++ b/internal/contour/secret_test.go
@@ -360,7 +360,7 @@ func buildDAG(objs ...interface{}) *dag.DAG {
 	for _, o := range objs {
 		cache.Insert(o)
 	}
-	return dag.BuildDAG(&cache)
+	return dag.BuildDAG(&cache, false)
 }
 
 func secretmap(secrets ...*auth.Secret) map[string]*auth.Secret {

--- a/internal/debug/dot.go
+++ b/internal/debug/dot.go
@@ -24,7 +24,8 @@ import (
 // quick and dirty dot debugging package
 
 type dotWriter struct {
-	kc *dag.KubernetesCache
+	kc                    *dag.KubernetesCache
+	disablePermitInsecure bool
 }
 
 type pair struct {
@@ -92,7 +93,7 @@ func (dw *dotWriter) writeDot(w io.Writer) {
 		})
 	}
 
-	dag.BuildDAG(dw.kc).Visit(visit)
+	dag.BuildDAG(dw.kc, dw.disablePermitInsecure).Visit(visit)
 
 	fmt.Fprintln(w, "}")
 }

--- a/internal/e2e/e2e.go
+++ b/internal/e2e/e2e.go
@@ -46,6 +46,8 @@ const (
 	statsPort    = 8002
 )
 
+var disablePermitInsecure = false
+
 type testWriter struct {
 	*testing.T
 }
@@ -75,9 +77,10 @@ func setup(t *testing.T, opts ...func(*contour.ResourceEventHandler)) (cache.Res
 		IngressRouteStatus: &k8s.IngressRouteStatus{
 			Client: fake.NewSimpleClientset(),
 		},
-		Metrics:       metrics.NewMetrics(r),
-		ListenerCache: contour.NewListenerCache(statsAddress, statsPort),
-		FieldLogger:   log,
+		Metrics:               metrics.NewMetrics(r),
+		ListenerCache:         contour.NewListenerCache(statsAddress, statsPort),
+		FieldLogger:           log,
+		DisablePermitInsecure: disablePermitInsecure,
 	}
 
 	reh := contour.ResourceEventHandler{


### PR DESCRIPTION
Fixes #864 by adding config items `allowPermitInsecure` which if set to false, disables the ability to use `permitInsecure` from an IngressRoute.

Signed-off-by: Steve Sloka <slokas@vmware.com>