### PR TITLE
internal/contour: move dag.KubernetesCache logging to the caller

### DIFF
--- a/internal/contour/cachehandler.go
+++ b/internal/contour/cachehandler.go
@@ -42,7 +42,11 @@ type CacheHandler struct {
 func (ch *CacheHandler) OnChange(kc *dag.KubernetesCache) {
 	timer := prometheus.NewTimer(ch.CacheHandlerOnUpdateSummary)
 	defer timer.ObserveDuration()
+
+	kc.RLock()
 	dag := dag.BuildDAG(kc)
+	kc.RUnlock()
+
 	ch.updateSecrets(dag)
 	ch.updateListeners(dag)
 	ch.updateRoutes(dag)

--- a/internal/dag/builder.go
+++ b/internal/dag/builder.go
@@ -250,8 +250,6 @@ func (b *builder) listener(port int) *Listener {
 }
 
 func (b *builder) compute() *DAG {
-	b.source.mu.RLock() // blocks mutation of the underlying cache until compute is done.
-	defer b.source.mu.RUnlock()
 
 	// setup secure vhosts if there is a matching secret
 	// we do this first so that the set of active secure vhosts is stable

--- a/internal/dag/cache.go
+++ b/internal/dag/cache.go
@@ -39,7 +39,7 @@ type KubernetesCache struct {
 	// If not set, defaults to DEFAULT_INGRESS_CLASS.
 	IngressClass string
 
-	mu sync.RWMutex
+	sync.RWMutex
 
 	ingresses     map[Meta]*v1beta1.Ingress
 	ingressroutes map[Meta]*ingressroutev1.IngressRoute
@@ -58,8 +58,6 @@ type Meta struct {
 // is not interesting to the cache. If an object with a matching type, name,
 // and namespace exists, it will be overwritten.
 func (kc *KubernetesCache) Insert(obj interface{}) bool {
-	kc.mu.Lock()
-	defer kc.mu.Unlock()
 	switch obj := obj.(type) {
 	case *v1.Secret:
 		m := Meta{name: obj.Name, namespace: obj.Namespace}
@@ -128,8 +126,6 @@ func (kc *KubernetesCache) Remove(obj interface{}) bool {
 }
 
 func (kc *KubernetesCache) remove(obj interface{}) bool {
-	kc.mu.Lock()
-	defer kc.mu.Unlock()
 	switch obj := obj.(type) {
 	case *v1.Secret:
 		m := Meta{name: obj.Name, namespace: obj.Namespace}


### PR DESCRIPTION
Updates #1166
Updates #1172

This PR moves the lock that prevents the cache from being updated during
dag rebuild from the dag package to the caller. This is extremely poor
form, the lock of a thing shouldn't be mutated externally, but in this
case its a stepping stone to a better implementation that doesn't need a
lock.

Signed-off-by: Dave Cheney <dave@cheney.net>