### PR TITLE
Dockerfile: update to Go 1.12.8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.12.7 AS build
+FROM golang:1.12.8 AS build
 WORKDIR /contour
 
 ENV GOPROXY=https://proxy.golang.org


### PR DESCRIPTION
Fixes #1312

Merge once 1.12.8 base images are available, see https://groups.google.com/forum/#!topic/golang-announce/0uuMm1BwpHE

Signed-off-by: Dave Cheney <dave@cheney.net>