### PR TITLE
internal/dag: refactor Builder

### DIFF
--- a/internal/contour/cachehandler_test.go
+++ b/internal/contour/cachehandler_test.go
@@ -570,7 +570,11 @@ func TestIngressRouteMetrics(t *testing.T) {
 			for _, o := range tc.objs {
 				kc.Insert(o)
 			}
-			dag := dag.BuildDAG(kc, false)
+			builder := dag.Builder{
+				Source: kc,
+			}
+			dag := builder.Build()
+
 			got := calculateIngressRouteMetric(dag.Statuses())
 			if diff := cmp.Diff(tc.want, got); diff != "" {
 				t.Fatal(diff)

--- a/internal/contour/k8s.go
+++ b/internal/contour/k8s.go
@@ -131,7 +131,11 @@ func (reh *ResourceEventHandler) update() {
 
 func (reh *ResourceEventHandler) notify() {
 	reh.KubernetesCache.RLock()
-	dag := dag.BuildDAG(&reh.KubernetesCache, reh.DisablePermitInsecure)
+	builder := &dag.Builder{
+		Source:                &reh.KubernetesCache,
+		DisablePermitInsecure: reh.DisablePermitInsecure,
+	}
+	dag := builder.Build()
 	reh.KubernetesCache.RUnlock()
 
 	reh.CacheHandler.OnChange(dag)

--- a/internal/contour/secret_test.go
+++ b/internal/contour/secret_test.go
@@ -360,7 +360,10 @@ func buildDAG(objs ...interface{}) *dag.DAG {
 	for _, o := range objs {
 		cache.Insert(o)
 	}
-	return dag.BuildDAG(&cache, false)
+	builder := dag.Builder{
+		Source: &cache,
+	}
+	return builder.Build()
 }
 
 func secretmap(secrets ...*auth.Secret) map[string]*auth.Secret {

--- a/internal/dag/cache.go
+++ b/internal/dag/cache.go
@@ -11,8 +11,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package dag provides a data model, in the form of a directed acyclic graph,
-// of the relationship between Kubernetes Ingress, Service, and Secret objects.
 package dag
 
 import (

--- a/internal/debug/dot.go
+++ b/internal/debug/dot.go
@@ -93,7 +93,11 @@ func (dw *dotWriter) writeDot(w io.Writer) {
 		})
 	}
 
-	dag.BuildDAG(dw.kc, dw.disablePermitInsecure).Visit(visit)
+	builder := &dag.Builder{
+		Source:                dw.kc,
+		DisablePermitInsecure: dw.disablePermitInsecure,
+	}
+	builder.Build().Visit(visit)
 
 	fmt.Fprintln(w, "}")
 }


### PR DESCRIPTION
Updates #1166
Updates #1172

Refactor builder to a public type, retire the dag.BuildDAG() method in
favor of constructing a dag.Builder and calling Build(). Build() is safe
to be called multple times -- but not concurrently -- so it doesn't need
to be hidden behind a BuildDAG() helper.

Signed-off-by: Dave Cheney <dave@cheney.net>