### PR TITLE
internal\envoy: Update envoy to 1.11.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ secure-local: $(SECURE_LOCAL_BOOTSTRAP_CONFIG)
 		-it \
 		--mount type=bind,source=$(CURDIR),target=/config \
 		--net bridge \
-		docker.io/envoyproxy/envoy:v1.10.0 \
+		docker.io/envoyproxy/envoy:v1.11.1 \
 		envoy \
 		--config-path /config/$< \
 		--service-node node0 \
@@ -73,7 +73,7 @@ local: $(LOCAL_BOOTSTRAP_CONFIG)
 		-it \
 		--mount type=bind,source=$(CURDIR),target=/config \
 		--net bridge \
-		docker.io/envoyproxy/envoy:v1.10.0 \
+		docker.io/envoyproxy/envoy:v1.11.1 \
 		envoy \
 		--config-path /config/$< \
 		--service-node node0 \


### PR DESCRIPTION
Fixes: #1299

Security release of Envoy 1.11.1 is now available

https://groups.google.com/forum/#!topic/envoy-announce/ZLchtraPYVk

Addresses following CVE:

> * CVE-2019-9512 (HIGH severity; CVSS score 7.5 CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H): “Ping Flood”, the attacker sends continual pings to an HTTP/2 peer, causing the peer to build an internal queue of responses. Depending on how efficiently this data is queued, this can consume excess CPU, memory, or both, potentially leading to a denial of service.

> * CVE-2019-9513 (HIGH severity; CVSS score 7.5 CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H): “Resource Loop”, the attacker creates multiple request streams and continually shuffles the priority of the streams in a way that causes substantial churn to the priority tree. This can consume excess CPU, potentially leading to a denial of service.

> * CVE-2019-9514 (HIGH severity; CVSS score 7.5 CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H): “Reset Flood”, the attacker opens a number of streams and sends an invalid request over each stream that should solicit a stream of RST_STREAM frames from the peer. Depending on how the peer queues the RST_STREAM frames, this can consume excess memory, CPU, or both, potentially leading to a denial of service.

> * CVE-2019-9515 (HIGH severity; CVSS score 7.5 CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H): “Settings Flood”, the attacker sends a stream of SETTINGS frames to the peer. Since the RFC requires that the peer reply with one acknowledgement per SETTINGS frame, an empty SETTINGS frame is almost equivalent in behavior to a ping. Depending on how efficiently this data is queued, this can consume excess CPU, memory, or both, potentially leading to a denial of service.

> * CVE-2019-9518 (HIGH severity; CVSS score 7.5 CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H): “Empty Frames Flood”, the attacker sends a stream of frames with an empty payload and without the end-of-stream flag. These frames can be DATA, HEADERS, CONTINUATION and/or PUSH_PROMISE. The peer spends time processing each frame disproportionate to attack bandwidth. This can consume excess CPU, potentially leading to a denial of service.