### PR TITLE
internal/contour: log details of failed to set status message

### DIFF
--- a/internal/contour/cachehandler.go
+++ b/internal/contour/cachehandler.go
@@ -61,7 +61,12 @@ func (ch *CacheHandler) setIngressRouteStatus(statuses map[dag.Meta]dag.Status) 
 	for _, st := range statuses {
 		err := ch.IngressRouteStatus.SetStatus(st.Status, st.Description, st.Object)
 		if err != nil {
-			ch.Errorf("Error Setting Status of IngressRoute: %v", err)
+			ch.WithError(err).
+				WithField("status", st.Status).
+				WithField("desc", st.Description).
+				WithField("name", st.Object.Name).
+				WithField("namespace", st.Object.Namespace).
+				Error("failed to set status")
 		}
 	}
 }


### PR DESCRIPTION
Spotted while working on #1166 / #1170 

Log more details of the failure to patch status message back to the API server.

Signed-off-by: Dave Cheney <dave@cheney.net>