### PR TITLE
internal/contour: embed builder into contour.EventHandler

### DIFF
--- a/cmd/contour/serve.go
+++ b/cmd/contour/serve.go
@@ -265,13 +265,15 @@ func doServe(log logrus.FieldLogger, ctx *serveContext) error {
 
 	// step 4. wrap the cache handler in a k8s event handler.
 	eh := &contour.EventHandler{
-		CacheHandler:          &ch,
-		HoldoffDelay:          100 * time.Millisecond,
-		HoldoffMaxDelay:       500 * time.Millisecond,
-		DisablePermitInsecure: ctx.DisablePermitInsecure,
-		KubernetesCache: dag.KubernetesCache{
-			IngressRouteRootNamespaces: ctx.ingressRouteRootNamespaces(),
-			IngressClass:               ctx.ingressClass,
+		CacheHandler:    &ch,
+		HoldoffDelay:    100 * time.Millisecond,
+		HoldoffMaxDelay: 500 * time.Millisecond,
+		Builder: dag.Builder{
+			Source: &dag.KubernetesCache{
+				IngressRouteRootNamespaces: ctx.ingressRouteRootNamespaces(),
+				IngressClass:               ctx.ingressClass,
+			},
+			DisablePermitInsecure: ctx.DisablePermitInsecure,
 		},
 		FieldLogger: log.WithField("context", "contourEventHandler"),
 	}
@@ -332,7 +334,7 @@ func doServe(log logrus.FieldLogger, ctx *serveContext) error {
 			Port:        ctx.debugPort,
 			FieldLogger: log.WithField("context", "debugsvc"),
 		},
-		KubernetesCache: &eh.KubernetesCache,
+		KubernetesCache: eh.Builder.Source,
 	}
 	g.Add(debugsvc.Start)
 

--- a/cmd/contour/serve.go
+++ b/cmd/contour/serve.go
@@ -269,7 +269,7 @@ func doServe(log logrus.FieldLogger, ctx *serveContext) error {
 		HoldoffDelay:    100 * time.Millisecond,
 		HoldoffMaxDelay: 500 * time.Millisecond,
 		Builder: dag.Builder{
-			Source: &dag.KubernetesCache{
+			Source: dag.KubernetesCache{
 				IngressRouteRootNamespaces: ctx.ingressRouteRootNamespaces(),
 				IngressClass:               ctx.ingressClass,
 			},
@@ -334,7 +334,7 @@ func doServe(log logrus.FieldLogger, ctx *serveContext) error {
 			Port:        ctx.debugPort,
 			FieldLogger: log.WithField("context", "debugsvc"),
 		},
-		KubernetesCache: eh.Builder.Source,
+		Builder: &eh.Builder,
 	}
 	g.Add(debugsvc.Start)
 

--- a/internal/contour/metrics_test.go
+++ b/internal/contour/metrics_test.go
@@ -564,14 +564,13 @@ func TestIngressRouteMetrics(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			kc := &dag.KubernetesCache{
-				IngressRouteRootNamespaces: tc.rootNamespaces,
+			builder := dag.Builder{
+				Source: dag.KubernetesCache{
+					IngressRouteRootNamespaces: tc.rootNamespaces,
+				},
 			}
 			for _, o := range tc.objs {
-				kc.Insert(o)
-			}
-			builder := dag.Builder{
-				Source: kc,
+				builder.Source.Insert(o)
 			}
 			dag := builder.Build()
 

--- a/internal/contour/secret_test.go
+++ b/internal/contour/secret_test.go
@@ -356,12 +356,9 @@ func TestSecretVisit(t *testing.T) {
 
 // buildDAG produces a dag.DAG from the supplied objects.
 func buildDAG(objs ...interface{}) *dag.DAG {
-	var cache dag.KubernetesCache
+	var builder dag.Builder
 	for _, o := range objs {
-		cache.Insert(o)
-	}
-	builder := dag.Builder{
-		Source: &cache,
+		builder.Source.Insert(o)
 	}
 	return builder.Build()
 }

--- a/internal/dag/builder.go
+++ b/internal/dag/builder.go
@@ -38,7 +38,7 @@ type Builder struct {
 
 	// Source is the source of Kuberenetes objects
 	// from which to build a DAG.
-	Source *KubernetesCache
+	Source KubernetesCache
 
 	// DisablePermitInsecure disables the use of the
 	// permitInsecure field in IngressRoute.

--- a/internal/dag/builder_test.go
+++ b/internal/dag/builder_test.go
@@ -2994,13 +2994,11 @@ func TestDAGInsert(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			var kc KubernetesCache
-			for _, o := range tc.objs {
-				kc.Insert(o)
-			}
 			builder := Builder{
-				Source:                &kc,
 				DisablePermitInsecure: tc.disablePermitInsecure,
+			}
+			for _, o := range tc.objs {
+				builder.Source.Insert(o)
 			}
 			dag := builder.Build()
 
@@ -3105,7 +3103,7 @@ func TestBuilderLookupHTTPService(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			b := Builder{
-				Source: &KubernetesCache{
+				Source: KubernetesCache{
 					services: services,
 				},
 			}
@@ -3233,14 +3231,14 @@ func TestDAGRootNamespaces(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			kc := &KubernetesCache{
-				IngressRouteRootNamespaces: tc.rootNamespaces,
-			}
-			for _, o := range tc.objs {
-				kc.Insert(o)
-			}
 			builder := Builder{
-				Source: kc,
+				Source: KubernetesCache{
+					IngressRouteRootNamespaces: tc.rootNamespaces,
+				},
+			}
+
+			for _, o := range tc.objs {
+				builder.Source.Insert(o)
 			}
 			dag := builder.Build()
 
@@ -3801,14 +3799,13 @@ func TestDAGIngressRouteStatus(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			kc := &KubernetesCache{
-				IngressRouteRootNamespaces: []string{"roots"},
+			builder := Builder{
+				Source: KubernetesCache{
+					IngressRouteRootNamespaces: []string{"roots"},
+				},
 			}
 			for _, o := range tc.objs {
-				kc.Insert(o)
-			}
-			builder := Builder{
-				Source: kc,
+				builder.Source.Insert(o)
 			}
 			dag := builder.Build()
 
@@ -3943,12 +3940,9 @@ func TestDAGIngressRouteUniqueFQDNs(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			var kc KubernetesCache
+			var builder Builder
 			for _, o := range tc.objs {
-				kc.Insert(o)
-			}
-			builder := Builder{
-				Source: &kc,
+				builder.Source.Insert(o)
 			}
 			dag := builder.Build()
 

--- a/internal/debug/debug.go
+++ b/internal/debug/debug.go
@@ -27,14 +27,14 @@ import (
 type Service struct {
 	httpsvc.Service
 
-	KubernetesCache *dag.KubernetesCache
+	Builder *dag.Builder
 }
 
 // Start fulfills the g.Start contract.
 // When stop is closed the http server will shutdown.
 func (svc *Service) Start(stop <-chan struct{}) error {
 	registerProfile(&svc.ServeMux)
-	registerDotWriter(&svc.ServeMux, svc.KubernetesCache)
+	registerDotWriter(&svc.ServeMux, svc.Builder)
 	return svc.Service.Start(stop)
 }
 
@@ -50,10 +50,10 @@ func registerProfile(mux *http.ServeMux) {
 	mux.Handle("/debug/pprof/threadcreate", pprof.Handler("threadcreate"))
 }
 
-func registerDotWriter(mux *http.ServeMux, kc *dag.KubernetesCache) {
+func registerDotWriter(mux *http.ServeMux, builder *dag.Builder) {
 	mux.HandleFunc("/debug/dag", func(w http.ResponseWriter, r *http.Request) {
 		dw := &dotWriter{
-			kc: kc,
+			Builder: builder,
 		}
 		dw.writeDot(w)
 	})

--- a/internal/debug/dot.go
+++ b/internal/debug/dot.go
@@ -24,8 +24,7 @@ import (
 // quick and dirty dot debugging package
 
 type dotWriter struct {
-	kc                    *dag.KubernetesCache
-	disablePermitInsecure bool
+	*dag.Builder
 }
 
 type pair struct {
@@ -93,11 +92,7 @@ func (dw *dotWriter) writeDot(w io.Writer) {
 		})
 	}
 
-	builder := &dag.Builder{
-		Source:                dw.kc,
-		DisablePermitInsecure: dw.disablePermitInsecure,
-	}
-	builder.Build().Visit(visit)
+	dw.Builder.Build().Visit(visit)
 
 	fmt.Fprintln(w, "}")
 }

--- a/internal/e2e/e2e.go
+++ b/internal/e2e/e2e.go
@@ -28,6 +28,7 @@ import (
 	"github.com/gogo/protobuf/types"
 	"github.com/heptio/contour/apis/generated/clientset/versioned/fake"
 	"github.com/heptio/contour/internal/contour"
+	"github.com/heptio/contour/internal/dag"
 	cgrpc "github.com/heptio/contour/internal/grpc"
 	"github.com/heptio/contour/internal/k8s"
 	"github.com/heptio/contour/internal/metrics"
@@ -88,6 +89,9 @@ func setup(t *testing.T, opts ...func(*contour.EventHandler)) (cache.ResourceEve
 	rand.Seed(time.Now().Unix())
 
 	eh := &contour.EventHandler{
+		Builder: dag.Builder{
+			Source: new(dag.KubernetesCache),
+		},
 		CacheHandler:    ch,
 		Metrics:         ch.Metrics,
 		FieldLogger:     log,

--- a/internal/e2e/e2e.go
+++ b/internal/e2e/e2e.go
@@ -28,7 +28,6 @@ import (
 	"github.com/gogo/protobuf/types"
 	"github.com/heptio/contour/apis/generated/clientset/versioned/fake"
 	"github.com/heptio/contour/internal/contour"
-	"github.com/heptio/contour/internal/dag"
 	cgrpc "github.com/heptio/contour/internal/grpc"
 	"github.com/heptio/contour/internal/k8s"
 	"github.com/heptio/contour/internal/metrics"
@@ -89,9 +88,6 @@ func setup(t *testing.T, opts ...func(*contour.EventHandler)) (cache.ResourceEve
 	rand.Seed(time.Now().Unix())
 
 	eh := &contour.EventHandler{
-		Builder: dag.Builder{
-			Source: new(dag.KubernetesCache),
-		},
 		CacheHandler:    ch,
 		Metrics:         ch.Metrics,
 		FieldLogger:     log,

--- a/internal/e2e/lds_test.go
+++ b/internal/e2e/lds_test.go
@@ -891,7 +891,7 @@ func TestLDSCustomAccessLogPaths(t *testing.T) {
 
 func TestLDSIngressRouteInsideRootNamespaces(t *testing.T) {
 	rh, cc, done := setup(t, func(reh *contour.EventHandler) {
-		reh.IngressRouteRootNamespaces = []string{"roots"}
+		reh.Builder.Source.IngressRouteRootNamespaces = []string{"roots"}
 	})
 	defer done()
 
@@ -959,7 +959,7 @@ func TestLDSIngressRouteInsideRootNamespaces(t *testing.T) {
 
 func TestLDSIngressRouteOutsideRootNamespaces(t *testing.T) {
 	rh, cc, done := setup(t, func(reh *contour.EventHandler) {
-		reh.IngressRouteRootNamespaces = []string{"roots"}
+		reh.Builder.Source.IngressRouteRootNamespaces = []string{"roots"}
 	})
 	defer done()
 
@@ -1006,9 +1006,7 @@ func TestLDSIngressRouteOutsideRootNamespaces(t *testing.T) {
 }
 
 func TestIngressRouteHTTPS(t *testing.T) {
-	rh, cc, done := setup(t, func(reh *contour.EventHandler) {
-		reh.IngressRouteRootNamespaces = []string{}
-	})
+	rh, cc, done := setup(t)
 	defer done()
 
 	// assert that there is only a static listener

--- a/internal/e2e/rds_test.go
+++ b/internal/e2e/rds_test.go
@@ -1424,7 +1424,7 @@ func TestDefaultBackendDoesNotOverwriteNamedHost(t *testing.T) {
 
 func TestRDSIngressRouteInsideRootNamespaces(t *testing.T) {
 	rh, cc, done := setup(t, func(reh *contour.EventHandler) {
-		reh.IngressRouteRootNamespaces = []string{"roots"}
+		reh.Builder.Source.IngressRouteRootNamespaces = []string{"roots"}
 	})
 	defer done()
 
@@ -1486,7 +1486,7 @@ func TestRDSIngressRouteInsideRootNamespaces(t *testing.T) {
 
 func TestRDSIngressRouteOutsideRootNamespaces(t *testing.T) {
 	rh, cc, done := setup(t, func(reh *contour.EventHandler) {
-		reh.IngressRouteRootNamespaces = []string{"roots"}
+		reh.Builder.Source.IngressRouteRootNamespaces = []string{"roots"}
 	})
 	defer done()
 
@@ -1542,7 +1542,7 @@ func TestRDSIngressRouteOutsideRootNamespaces(t *testing.T) {
 // tested in internal/contour/route_test.go
 func TestRDSIngressRouteClassAnnotation(t *testing.T) {
 	rh, cc, done := setup(t, func(reh *contour.EventHandler) {
-		reh.IngressClass = "linkerd"
+		reh.Builder.Source.IngressClass = "linkerd"
 	})
 	defer done()
 
@@ -1722,7 +1722,7 @@ func TestRDSIngressRouteClassAnnotation(t *testing.T) {
 // tested in internal/contour/route_test.go
 func TestRDSIngressClassAnnotation(t *testing.T) {
 	rh, cc, done := setup(t, func(reh *contour.EventHandler) {
-		reh.IngressClass = "linkerd"
+		reh.Builder.Source.IngressClass = "linkerd"
 	})
 	defer done()
 

--- a/internal/grpc/server_test.go
+++ b/internal/grpc/server_test.go
@@ -20,17 +20,18 @@ import (
 	"testing"
 	"time"
 
-	"github.com/envoyproxy/go-control-plane/envoy/api/v2"
+	v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v2"
 	"github.com/envoyproxy/go-control-plane/pkg/cache"
 	"github.com/heptio/contour/internal/contour"
+	"github.com/heptio/contour/internal/dag"
 	"github.com/heptio/contour/internal/metrics"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/api/extensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -195,6 +196,9 @@ func TestGRPC(t *testing.T) {
 				Metrics: metrics.NewMetrics(prometheus.NewRegistry()),
 			}
 			eh = &contour.EventHandler{
+				Builder: dag.Builder{
+					Source: new(dag.KubernetesCache),
+				},
 				CacheHandler: &ch,
 				Metrics:      ch.Metrics,
 				FieldLogger:  log,

--- a/internal/grpc/server_test.go
+++ b/internal/grpc/server_test.go
@@ -24,7 +24,6 @@ import (
 	discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v2"
 	"github.com/envoyproxy/go-control-plane/pkg/cache"
 	"github.com/heptio/contour/internal/contour"
-	"github.com/heptio/contour/internal/dag"
 	"github.com/heptio/contour/internal/metrics"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
@@ -196,9 +195,6 @@ func TestGRPC(t *testing.T) {
 				Metrics: metrics.NewMetrics(prometheus.NewRegistry()),
 			}
 			eh = &contour.EventHandler{
-				Builder: dag.Builder{
-					Source: new(dag.KubernetesCache),
-				},
 				CacheHandler: &ch,
 				Metrics:      ch.Metrics,
 				FieldLogger:  log,


### PR DESCRIPTION
Rather than building a new dag.Builder each time, reuse the same one.
This is safe to do as Builder.Build resets its internal state each time.
This also means the canonical setting for DisablePermitInsecure lives on
the builder and is set directly during startup.

Signed-off-by: Dave Cheney <dave@cheney.net>