### PR TITLE
go.mod: upgrade to grpc v1.23.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	golang.org/x/sys v0.0.0-20190804053845-51ab0e2deafa // indirect
 	golang.org/x/tools v0.0.0-20190802220118-1d1727260058 // indirect
 	google.golang.org/genproto v0.0.0-20190801165951-fa694d86fc64 // indirect
-	google.golang.org/grpc v1.22.0
+	google.golang.org/grpc v1.23.0
 	gopkg.in/alecthomas/kingpin.v2 v2.2.6
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.2.2 // indirect


### PR DESCRIPTION
Update to grpc v1.23.0 to address the HTTP/2 issues that Netflix have
disclosed. There is no requirement to backport this to 0.14 as we don't
expose HTTP/2 to the world; it's either over localhost to Envoy running
in the same pod, or over TLS to a trusted Envoy.

Signed-off-by: Dave Cheney <dave@cheney.net>