### PR TITLE
cmd/contour: switch to yaml for contour config

### DIFF
--- a/examples/common/common.yaml
+++ b/examples/common/common.yaml
@@ -237,12 +237,3 @@ spec:
                   targetNamespaces:
                     type: array
 ---
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: contour
-  namespace: heptio-contour
-data:
-  contour.json: |
-    {}
----

--- a/examples/common/contour-config.yaml
+++ b/examples/common/contour-config.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: contour
+  namespace: heptio-contour
+data:
+  contour.yaml: |
+    # should contour expect to be running inside a k8s cluster
+    # incluster: true
+    #
+    # path to kubeconfig (if not running inside a k8s cluster)
+    # kubeconfig: /path/to/.kube/config
+    #
+    # disable ingressroute permitInsecure field
+    # disablePermitInsecure: false
+    tls:
+      # minimum TLS version that Contour will negotiate
+      # minimumProtocolVersion: "1.1"
+---

--- a/examples/deployment-grpc-v2/01-contour-config.yaml
+++ b/examples/deployment-grpc-v2/01-contour-config.yaml
@@ -1,0 +1,1 @@
+../common/contour-config.yaml

--- a/examples/deployment-grpc-v2/02-contour.yaml
+++ b/examples/deployment-grpc-v2/02-contour.yaml
@@ -30,7 +30,7 @@ spec:
         - --insecure
         - --envoy-service-http-port=8080
         - --envoy-service-https-port=8443
-        - --config-path=/config/contour.json
+        - --config-path=/config/contour.yaml
         livenessProbe:
           httpGet:
             path: /healthz
@@ -111,8 +111,8 @@ spec:
           name: contour
           defaultMode: 0643
           items:
-          - key: contour.json
-            path: contour.json
+          - key: contour.yaml
+            path: contour.yaml
       dnsPolicy: ClusterFirst
       serviceAccountName: contour
       terminationGracePeriodSeconds: 30

--- a/examples/ds-grpc-v2/01-contour-config.yaml
+++ b/examples/ds-grpc-v2/01-contour-config.yaml
@@ -1,0 +1,1 @@
+../common/contour-config.yaml

--- a/examples/ds-grpc-v2/02-contour.yaml
+++ b/examples/ds-grpc-v2/02-contour.yaml
@@ -31,7 +31,7 @@ spec:
         - --insecure
         - --envoy-service-http-port=8080
         - --envoy-service-https-port=8443
-        - --config-path=/config/contour.json
+        - --config-path=/config/contour.yaml
         livenessProbe:
           httpGet:
             path: /healthz
@@ -112,8 +112,8 @@ spec:
           name: contour
           defaultMode: 0644
           items:
-          - key: contour.json
-            path: contour.json
+          - key: contour.yaml
+            path: contour.yaml
       dnsPolicy: ClusterFirst
       serviceAccountName: contour
       terminationGracePeriodSeconds: 30

--- a/examples/ds-hostnet-split/01-contour-config.yaml
+++ b/examples/ds-hostnet-split/01-contour-config.yaml
@@ -1,0 +1,1 @@
+../common/contour-config.yaml

--- a/examples/ds-hostnet-split/03-contour.yaml
+++ b/examples/ds-hostnet-split/03-contour.yaml
@@ -38,7 +38,7 @@ spec:
         - --contour-cafile=/ca/cacert.pem
         - --contour-cert-file=/certs/tls.crt
         - --contour-key-file=/certs/tls.key
-        - --config-path=/config/contour.json
+        - --config-path=/config/contour.yaml
         command: ["contour"]
         image: gcr.io/heptio-images/contour:master
         imagePullPolicy: Always
@@ -82,5 +82,5 @@ spec:
             name: contour
             defaultMode: 0644
             items:
-            - key: contour.json
-              path: contour.json
+            - key: contour.yaml
+              path: contour.yaml

--- a/examples/ds-hostnet/01-contour-config.yaml
+++ b/examples/ds-hostnet/01-contour-config.yaml
@@ -1,0 +1,1 @@
+../common/contour-config.yaml

--- a/examples/ds-hostnet/02-contour.yaml
+++ b/examples/ds-hostnet/02-contour.yaml
@@ -35,7 +35,7 @@ spec:
         - --insecure
         - --envoy-service-http-port=8080
         - --envoy-service-https-port=8443
-        - --config-path=/config/contour.json
+        - --config-path=/config/contour.yaml
         livenessProbe:
           httpGet:
             path: /healthz
@@ -116,8 +116,8 @@ spec:
           name: contour
           defaultMode: 0644
           items:
-          - key: contour.json
-            path: contour.json
+          - key: contour.yaml
+            path: contour.yaml
       dnsPolicy: ClusterFirst
       serviceAccountName: contour
       terminationGracePeriodSeconds: 30

--- a/examples/render/daemonset-rbac.yaml
+++ b/examples/render/daemonset-rbac.yaml
@@ -246,8 +246,18 @@ metadata:
   name: contour
   namespace: heptio-contour
 data:
-  contour.json: |
-    {}
+  contour.yaml: |
+    # should contour expect to be running inside a k8s cluster
+    # incluster: true
+    #
+    # path to kubeconfig (if not running inside a k8s cluster)
+    # kubeconfig: /path/to/.kube/config
+    #
+    # disable ingressroute permitInsecure field
+    # disablePermitInsecure: false
+    tls:
+      # minimum TLS version that Contour will negotiate
+      # minimumProtocolVersion: "1.1"
 ---
 apiVersion: apps/v1
 kind: DaemonSet
@@ -282,7 +292,7 @@ spec:
         - --insecure
         - --envoy-service-http-port=8080
         - --envoy-service-https-port=8443
-        - --config-path=/config/contour.json
+        - --config-path=/config/contour.yaml
         livenessProbe:
           httpGet:
             path: /healthz
@@ -363,8 +373,8 @@ spec:
           name: contour
           defaultMode: 0644
           items:
-          - key: contour.json
-            path: contour.json
+          - key: contour.yaml
+            path: contour.yaml
       dnsPolicy: ClusterFirst
       serviceAccountName: contour
       terminationGracePeriodSeconds: 30

--- a/examples/render/deployment-rbac.yaml
+++ b/examples/render/deployment-rbac.yaml
@@ -246,8 +246,18 @@ metadata:
   name: contour
   namespace: heptio-contour
 data:
-  contour.json: |
-    {}
+  contour.yaml: |
+    # should contour expect to be running inside a k8s cluster
+    # incluster: true
+    #
+    # path to kubeconfig (if not running inside a k8s cluster)
+    # kubeconfig: /path/to/.kube/config
+    #
+    # disable ingressroute permitInsecure field
+    # disablePermitInsecure: false
+    tls:
+      # minimum TLS version that Contour will negotiate
+      # minimumProtocolVersion: "1.1"
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -281,7 +291,7 @@ spec:
         - --insecure
         - --envoy-service-http-port=8080
         - --envoy-service-https-port=8443
-        - --config-path=/config/contour.json
+        - --config-path=/config/contour.yaml
         livenessProbe:
           httpGet:
             path: /healthz
@@ -362,8 +372,8 @@ spec:
           name: contour
           defaultMode: 0643
           items:
-          - key: contour.json
-            path: contour.json
+          - key: contour.yaml
+            path: contour.yaml
       dnsPolicy: ClusterFirst
       serviceAccountName: contour
       terminationGracePeriodSeconds: 30

--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,7 @@ require (
 	google.golang.org/grpc v1.23.0
 	gopkg.in/alecthomas/kingpin.v2 v2.2.6
 	gopkg.in/inf.v0 v0.9.1 // indirect
-	gopkg.in/yaml.v2 v2.2.2 // indirect
+	gopkg.in/yaml.v2 v2.2.2
 	honnef.co/go/tools v0.0.1-2019.2.2
 	k8s.io/api v0.0.0-20190620084959-7cf5895f2711
 	k8s.io/apimachinery v0.0.0-20190612205821-1799e75a0719


### PR DESCRIPTION
Fixes #1344

- Switch from json to yaml for --config-path.
- Update examples to match.
- Break out config map for easier editing.
- Add commentary to example config using default values.

Signed-off-by: Dave Cheney <dave@cheney.net>