### PR TITLE
Add leader election

### DIFF
--- a/cmd/contour/certgen.go
+++ b/cmd/contour/certgen.go
@@ -128,6 +128,6 @@ func OutputCerts(config *certgenConfig,
 func doCertgen(config *certgenConfig) {
 	generatedCerts, err := GenerateCerts(config)
 	check(err)
-	kubeclient, _ := newClient(config.KubeConfig, config.InCluster)
+	kubeclient, _, _ := newClient(config.KubeConfig, config.InCluster)
 	OutputCerts(config, kubeclient, generatedCerts)
 }

--- a/cmd/contour/contour.go
+++ b/cmd/contour/contour.go
@@ -22,6 +22,7 @@ import (
 	"github.com/sirupsen/logrus"
 	kingpin "gopkg.in/alecthomas/kingpin.v2"
 	"k8s.io/client-go/kubernetes"
+	coordinationv1 "k8s.io/client-go/kubernetes/typed/coordination/v1"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/klog"
@@ -98,7 +99,7 @@ func main() {
 	}
 }
 
-func newClient(kubeconfig string, inCluster bool) (*kubernetes.Clientset, *clientset.Clientset) {
+func newClient(kubeconfig string, inCluster bool) (*kubernetes.Clientset, *clientset.Clientset, *coordinationv1.CoordinationV1Client) {
 	var err error
 	var config *rest.Config
 	if kubeconfig != "" && !inCluster {
@@ -113,7 +114,10 @@ func newClient(kubeconfig string, inCluster bool) (*kubernetes.Clientset, *clien
 	check(err)
 	contourClient, err := clientset.NewForConfig(config)
 	check(err)
-	return client, contourClient
+	coordinationClient, err := coordinationv1.NewForConfig(config)
+	check(err)
+
+	return client, contourClient, coordinationClient
 }
 
 func check(err error) {

--- a/cmd/contour/serve.go
+++ b/cmd/contour/serve.go
@@ -397,7 +397,6 @@ func doServe(log logrus.FieldLogger, ctx *serveContext) error {
 	// Generate the event recorder to send election events to the logs.
 	// Set up the event bits
 	eventBroadcaster := record.NewBroadcaster()
-	eventBroadcaster.StartLogging(log.Infof)
 	// Broadcast election events to the config map
 	eventBroadcaster.StartRecordingToSink(&clientcorev1.EventSinkImpl{Interface: clientcorev1.New(client.CoreV1().RESTClient()).Events("")})
 	eventsScheme := runtime.NewScheme()

--- a/cmd/contour/serve.go
+++ b/cmd/contour/serve.go
@@ -452,7 +452,7 @@ func doServe(log logrus.FieldLogger, ctx *serveContext) error {
 	// AddContext will generate its own context.Context and pass it in,
 	// managing the close process when the other goroutines are closed.
 	g.AddContext(func(electionCtx context.Context) {
-		log := log.WithField("context", "leaderelect")
+		log := log.WithField("context", "leaderelection")
 		if !ctx.EnableLeaderElection {
 			log.Info("Leader election disabled")
 			// if leader election is disabled, signal the gRPC goroutine
@@ -466,10 +466,10 @@ func doServe(log logrus.FieldLogger, ctx *serveContext) error {
 		log.WithFields(logrus.Fields{
 			"configmapname":      ctx.LeaderElectionConfig.Name,
 			"configmapnamespace": ctx.LeaderElectionConfig.Namespace,
-		}).Info("Started leader election")
+		}).Info("started")
 
 		le.Run(electionCtx)
-		log.Info("Finishing leader election")
+		log.Info("stopped")
 	})
 
 	g.Add(func(stop <-chan struct{}) error {

--- a/examples/common/rbac.yaml
+++ b/examples/common/rbac.yaml
@@ -59,3 +59,41 @@ rules:
   - post
   - patch
 ---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: Role
+metadata:
+  name: contour-leaderelection
+  namespace: heptio-contour
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - update
+  - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  name: contour-leaderelection
+  namespace: heptio-contour
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: contour-leaderelection
+subjects:
+- kind: ServiceAccount
+  name: contour
+  namespace: heptio-contour

--- a/examples/common/service.yaml
+++ b/examples/common/service.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: Service
 metadata:

--- a/examples/ds-hostnet-split/03-contour.yaml
+++ b/examples/ds-hostnet-split/03-contour.yaml
@@ -42,7 +42,6 @@ spec:
         - --contour-key-file=/certs/tls.key
         - --config-path=/config/contour.yaml
         command: ["contour"]
-        # image: gcr.io/heptio-images/contour:master
         image: docker.io/youngnick/contour:latest
         imagePullPolicy: Always
         name: contour

--- a/examples/ds-hostnet-split/03-contour.yaml
+++ b/examples/ds-hostnet-split/03-contour.yaml
@@ -7,6 +7,8 @@ metadata:
   namespace: heptio-contour
 spec:
   replicas: 2
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       app: contour
@@ -40,7 +42,8 @@ spec:
         - --contour-key-file=/certs/tls.key
         - --config-path=/config/contour.yaml
         command: ["contour"]
-        image: gcr.io/heptio-images/contour:master
+        # image: gcr.io/heptio-images/contour:master
+        image: docker.io/youngnick/contour:latest
         imagePullPolicy: Always
         name: contour
         ports:
@@ -55,9 +58,10 @@ spec:
             path: /healthz
             port: 8000
         readinessProbe:
-          httpGet:
-            path: /healthz
-            port: 8000
+          tcpSocket:
+            port: 8001
+          initialDelaySeconds: 15
+          periodSeconds: 10
         volumeMounts:
           - name: contourcert
             mountPath: /certs
@@ -68,6 +72,12 @@ spec:
           - name: contour-config
             mountPath: /config
             readOnly: true
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.name
       dnsPolicy: ClusterFirst
       serviceAccountName: contour
       volumes:

--- a/examples/ds-hostnet-split/03-contour.yaml
+++ b/examples/ds-hostnet-split/03-contour.yaml
@@ -33,6 +33,7 @@ spec:
       - args:
         - serve
         - --incluster
+        - --enable-leader-election
         - --xds-address=0.0.0.0
         - --xds-port=8001
         - --envoy-service-http-port=80
@@ -42,7 +43,7 @@ spec:
         - --contour-key-file=/certs/tls.key
         - --config-path=/config/contour.yaml
         command: ["contour"]
-        image: docker.io/youngnick/contour:latest
+        image: gcr.io/heptio-images/contour:master
         imagePullPolicy: Always
         name: contour
         ports:

--- a/examples/render/daemonset-rbac.yaml
+++ b/examples/render/daemonset-rbac.yaml
@@ -440,6 +440,44 @@ rules:
   - post
   - patch
 ---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: Role
+metadata:
+  name: contour-leaderelection
+  namespace: heptio-contour
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - update
+  - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  name: contour-leaderelection
+  namespace: heptio-contour
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: contour-leaderelection
+subjects:
+- kind: ServiceAccount
+  name: contour
+  namespace: heptio-contour---
 apiVersion: v1
 kind: Service
 metadata:

--- a/examples/render/deployment-rbac.yaml
+++ b/examples/render/deployment-rbac.yaml
@@ -450,6 +450,44 @@ rules:
   - post
   - patch
 ---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: Role
+metadata:
+  name: contour-leaderelection
+  namespace: heptio-contour
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - update
+  - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  name: contour-leaderelection
+  namespace: heptio-contour
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: contour-leaderelection
+subjects:
+- kind: ServiceAccount
+  name: contour
+  namespace: heptio-contour---
 apiVersion: v1
 kind: Service
 metadata:

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/gogo/protobuf v1.2.1
 	github.com/golang/groupcache v0.0.0-20190129154638-5b532d6fd5ef // indirect
 	github.com/google/go-cmp v0.3.0
+	github.com/google/uuid v1.0.0
 	github.com/googleapis/gnostic v0.2.0 // indirect
 	github.com/gordonklaus/ineffassign v0.0.0-20180909121442-1003c8bd00dc
 	github.com/hashicorp/golang-lru v0.5.1 // indirect


### PR DESCRIPTION
- add `--disable-leader-election` command line flag.
- Leader election parameters, including ConfigMap name and namespace, are not tunable yet.

Updates #1204 
`serve.go` needs cleanup, but this establishes baseline functionality.

Signed-off-by: Nick Young <ynick@vmware.com>