### PR TITLE
internal/envoy: add Endpoints helper

### DIFF
--- a/internal/envoy/bootstrap.go
+++ b/internal/envoy/bootstrap.go
@@ -23,7 +23,6 @@ import (
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2/auth"
 	clusterv2 "github.com/envoyproxy/go-control-plane/envoy/api/v2/cluster"
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
-	"github.com/envoyproxy/go-control-plane/envoy/api/v2/endpoint"
 	bootstrap "github.com/envoyproxy/go-control-plane/envoy/config/bootstrap/v2"
 )
 
@@ -43,11 +42,9 @@ func Bootstrap(c *BootstrapConfig) *bootstrap.Bootstrap {
 				LbPolicy:             api.Cluster_ROUND_ROBIN,
 				LoadAssignment: &api.ClusterLoadAssignment{
 					ClusterName: "contour",
-					Endpoints: []endpoint.LocalityLbEndpoints{{
-						LbEndpoints: []endpoint.LbEndpoint{
-							LBEndpoint(c.xdsAddress(), c.xdsGRPCPort()),
-						},
-					}},
+					Endpoints: Endpoints(
+						SocketAddress(c.xdsAddress(), c.xdsGRPCPort()),
+					),
 				},
 				Http2ProtocolOptions: new(core.Http2ProtocolOptions), // enables http2
 				CircuitBreakers: &clusterv2.CircuitBreakers{
@@ -73,11 +70,9 @@ func Bootstrap(c *BootstrapConfig) *bootstrap.Bootstrap {
 				LbPolicy:             api.Cluster_ROUND_ROBIN,
 				LoadAssignment: &api.ClusterLoadAssignment{
 					ClusterName: "service-stats",
-					Endpoints: []endpoint.LocalityLbEndpoints{{
-						LbEndpoints: []endpoint.LbEndpoint{
-							LBEndpoint(c.adminAddress(), c.adminPort()),
-						},
-					}},
+					Endpoints: Endpoints(
+						SocketAddress(c.adminAddress(), c.adminPort()),
+					),
 				},
 			}},
 		},

--- a/internal/envoy/cluster.go
+++ b/internal/envoy/cluster.go
@@ -24,7 +24,6 @@ import (
 	v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	envoy_cluster "github.com/envoyproxy/go-control-plane/envoy/api/v2/cluster"
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
-	endpoint "github.com/envoyproxy/go-control-plane/envoy/api/v2/endpoint"
 	envoy_type "github.com/envoyproxy/go-control-plane/envoy/type"
 	"github.com/gogo/protobuf/types"
 	"github.com/heptio/contour/internal/dag"
@@ -124,26 +123,10 @@ func StaticClusterLoadAssignment(service *dag.TCPService) *v2.ClusterLoadAssignm
 		service.ServicePort.Name,
 	}
 
+	addr := SocketAddress(service.ExternalName, int(service.ServicePort.Port))
 	return &v2.ClusterLoadAssignment{
 		ClusterName: strings.Join(name, "/"),
-		Endpoints: []endpoint.LocalityLbEndpoints{{
-			LbEndpoints: []endpoint.LbEndpoint{{
-				HostIdentifier: &endpoint.LbEndpoint_Endpoint{
-					Endpoint: &endpoint.Endpoint{
-						Address: &core.Address{
-							Address: &core.Address_SocketAddress{
-								SocketAddress: &core.SocketAddress{
-									Address: service.ExternalName,
-									PortSpecifier: &core.SocketAddress_PortValue{
-										PortValue: uint32(service.ServicePort.Port),
-									},
-								},
-							},
-						},
-					},
-				},
-			}},
-		}},
+		Endpoints:   Endpoints(addr),
 	}
 }
 

--- a/internal/envoy/endpoint.go
+++ b/internal/envoy/endpoint.go
@@ -14,6 +14,7 @@
 package envoy
 
 import (
+	"github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2/endpoint"
 )
 
@@ -26,4 +27,23 @@ func LBEndpoint(addr string, port int) endpoint.LbEndpoint {
 			},
 		},
 	}
+}
+
+// Endpoints returns a slice of LocalityLbEndpoints.
+// The slice contains one entry, with one LbEndpoint per
+// *core.Address supplied.
+func Endpoints(addrs ...*core.Address) []endpoint.LocalityLbEndpoints {
+	lbendpoints := make([]endpoint.LbEndpoint, 0, len(addrs))
+	for _, addr := range addrs {
+		lbendpoints = append(lbendpoints, endpoint.LbEndpoint{
+			HostIdentifier: &endpoint.LbEndpoint_Endpoint{
+				Endpoint: &endpoint.Endpoint{
+					Address: addr,
+				},
+			},
+		})
+	}
+	return []endpoint.LocalityLbEndpoints{{
+		LbEndpoints: lbendpoints,
+	}}
 }

--- a/internal/envoy/endpoint_test.go
+++ b/internal/envoy/endpoint_test.go
@@ -49,3 +49,28 @@ func TestLBEndpoint(t *testing.T) {
 		t.Fatal(diff)
 	}
 }
+
+func TestEndpoints(t *testing.T) {
+	got := Endpoints(
+		SocketAddress("github.com", 443),
+		SocketAddress("microsoft.com", 80),
+	)
+	want := []endpoint.LocalityLbEndpoints{{
+		LbEndpoints: []endpoint.LbEndpoint{{
+			HostIdentifier: &endpoint.LbEndpoint_Endpoint{
+				Endpoint: &endpoint.Endpoint{
+					Address: SocketAddress("github.com", 443),
+				},
+			},
+		}, {
+			HostIdentifier: &endpoint.LbEndpoint_Endpoint{
+				Endpoint: &endpoint.Endpoint{
+					Address: SocketAddress("microsoft.com", 80),
+				},
+			},
+		}},
+	}}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Fatal(diff)
+	}
+}


### PR DESCRIPTION
Updates #1159

Turns out all the callers of LBEndpoint actually wanted a higher level
object. Who are we to complain?

Signed-off-by: Dave Cheney <dave@cheney.net>