### PR TITLE
cmd/contour: cleanly shutdown grpc server

### DIFF
--- a/cmd/contour/serve.go
+++ b/cmd/contour/serve.go
@@ -383,6 +383,12 @@ func doServe(log logrus.FieldLogger, ctx *serveContext) error {
 		})
 		log.WithField("address", addr).Info("started")
 		defer log.Info("stopped")
+
+		go func() {
+			<-stop
+			s.Stop()
+		}()
+
 		return s.Serve(l)
 	})
 
@@ -401,7 +407,7 @@ func startInformer(inf informer, log logrus.FieldLogger) func(stop <-chan struct
 		inf.WaitForCacheSync(stop)
 
 		log.Println("started")
-		defer log.Println("stopping")
+		defer log.Println("stopped")
 		inf.Start(stop)
 		<-stop
 		return nil


### PR DESCRIPTION
Fixes #1361

The stop channel was not wired into the grpc server stop signal. This
meant unless the grpc server was the instigator contour serve would hang
on group shutdown.

This PR fixes this by wiring stop into grpc.Server.Stop. It also adjusts
the stopping message in startInformer to be stopped so it is the same as
the other workers. This is important because we don't issue a "stopped"
message thus the reader could be confused that what was stopping had not
yet stopped.

Signed-off-by: Dave Cheney <dave@cheney.net>