### PR TITLE
internal/dag: do not trigger update for unreferenced service

### DIFF
--- a/internal/e2e/cds_test.go
+++ b/internal/e2e/cds_test.go
@@ -626,12 +626,12 @@ func TestClusterPerServiceParameters(t *testing.T) {
 	})
 
 	assertEqual(t, &v2.DiscoveryResponse{
-		VersionInfo: "2",
+		VersionInfo: "1",
 		Resources: []types.Any{
 			any(t, cluster("default/kuard/80/da39a3ee5e", "default/kuard", "default_kuard_80")),
 		},
 		TypeUrl: clusterType,
-		Nonce:   "2",
+		Nonce:   "1",
 	}, streamCDS(t, cc))
 }
 
@@ -681,7 +681,7 @@ func TestClusterLoadBalancerStrategyPerRoute(t *testing.T) {
 	})
 
 	assertEqual(t, &v2.DiscoveryResponse{
-		VersionInfo: "2",
+		VersionInfo: "1",
 		Resources: []types.Any{
 			any(t, &v2.Cluster{
 				Name:                 "default/kuard/80/58d888c08a",
@@ -709,7 +709,7 @@ func TestClusterLoadBalancerStrategyPerRoute(t *testing.T) {
 			}),
 		},
 		TypeUrl: clusterType,
-		Nonce:   "2",
+		Nonce:   "1",
 	}, streamCDS(t, cc))
 }
 
@@ -753,12 +753,12 @@ func TestClusterWithHealthChecks(t *testing.T) {
 	})
 
 	assertEqual(t, &v2.DiscoveryResponse{
-		VersionInfo: "2",
+		VersionInfo: "1",
 		Resources: []types.Any{
 			any(t, clusterWithHealthCheck("default/kuard/80/bc862a33ca", "default/kuard", "default_kuard_80", "/healthz", true)),
 		},
 		TypeUrl: clusterType,
-		Nonce:   "2",
+		Nonce:   "1",
 	}, streamCDS(t, cc))
 }
 
@@ -867,7 +867,7 @@ func TestClusterServiceTLSBackendCAValidation(t *testing.T) {
 	rh.OnAdd(ir1)
 
 	assertEqual(t, &v2.DiscoveryResponse{
-		VersionInfo: "3",
+		VersionInfo: "2",
 		Resources: []types.Any{
 			any(t, tlscluster(
 				"default/kuard/443/da39a3ee5e",
@@ -877,7 +877,7 @@ func TestClusterServiceTLSBackendCAValidation(t *testing.T) {
 				"")),
 		},
 		TypeUrl: clusterType,
-		Nonce:   "3",
+		Nonce:   "2",
 	}, streamCDS(t, cc))
 
 	ir2 := &ingressroutev1.IngressRoute{
@@ -904,7 +904,7 @@ func TestClusterServiceTLSBackendCAValidation(t *testing.T) {
 	rh.OnUpdate(ir1, ir2)
 
 	assertEqual(t, &v2.DiscoveryResponse{
-		VersionInfo: "4",
+		VersionInfo: "3",
 		Resources: []types.Any{
 			any(t, tlscluster(
 				"default/kuard/443/98c0f31c72",
@@ -914,7 +914,7 @@ func TestClusterServiceTLSBackendCAValidation(t *testing.T) {
 				"subjname")),
 		},
 		TypeUrl: clusterType,
-		Nonce:   "4",
+		Nonce:   "3",
 	}, streamCDS(t, cc))
 }
 

--- a/internal/e2e/lds_test.go
+++ b/internal/e2e/lds_test.go
@@ -364,7 +364,7 @@ func TestIngressRouteTLSListener(t *testing.T) {
 	rh.OnAdd(i1)
 
 	assertEqual(t, &v2.DiscoveryResponse{
-		VersionInfo: "3",
+		VersionInfo: "2",
 		Resources: []types.Any{
 			any(t, &v2.Listener{
 				Name:         "ingress_http",
@@ -375,13 +375,13 @@ func TestIngressRouteTLSListener(t *testing.T) {
 			any(t, staticListener()),
 		},
 		TypeUrl: listenerType,
-		Nonce:   "3",
+		Nonce:   "2",
 	}, streamLDS(t, cc))
 
 	// delete secret and assert that ingress_https is removed
 	rh.OnDelete(secret1)
 	assertEqual(t, &v2.DiscoveryResponse{
-		VersionInfo: "4",
+		VersionInfo: "3",
 		Resources: []types.Any{
 			any(t, &v2.Listener{
 				Name:         "ingress_http",
@@ -391,7 +391,7 @@ func TestIngressRouteTLSListener(t *testing.T) {
 			any(t, staticListener()),
 		},
 		TypeUrl: listenerType,
-		Nonce:   "4",
+		Nonce:   "3",
 	}, streamLDS(t, cc))
 
 	rh.OnDelete(i1)
@@ -411,7 +411,7 @@ func TestIngressRouteTLSListener(t *testing.T) {
 	// add ingress and assert the existence of ingress_http and ingres_https
 	rh.OnAdd(i2)
 	assertEqual(t, &v2.DiscoveryResponse{
-		VersionInfo: "7",
+		VersionInfo: "6",
 		Resources: []types.Any{
 			any(t, &v2.Listener{
 				Name:         "ingress_http",
@@ -422,7 +422,7 @@ func TestIngressRouteTLSListener(t *testing.T) {
 			any(t, staticListener()),
 		},
 		TypeUrl: listenerType,
-		Nonce:   "7",
+		Nonce:   "6",
 	}, streamLDS(t, cc))
 }
 
@@ -943,7 +943,7 @@ func TestLDSIngressRouteInsideRootNamespaces(t *testing.T) {
 
 	// assert there is an active listener
 	assertEqual(t, &v2.DiscoveryResponse{
-		VersionInfo: "2",
+		VersionInfo: "1",
 		Resources: []types.Any{
 			any(t, &v2.Listener{
 				Name:         "ingress_http",
@@ -953,7 +953,7 @@ func TestLDSIngressRouteInsideRootNamespaces(t *testing.T) {
 			any(t, staticListener()),
 		},
 		TypeUrl: listenerType,
-		Nonce:   "2",
+		Nonce:   "1",
 	}, streamLDS(t, cc))
 }
 
@@ -1093,14 +1093,14 @@ func TestIngressRouteHTTPS(t *testing.T) {
 		FilterChains: filterchaintls("example.com", s1, envoy.HTTPConnectionManager("ingress_https", "/dev/stdout"), "h2", "http/1.1"),
 	}
 	assertEqual(t, &v2.DiscoveryResponse{
-		VersionInfo: "3",
+		VersionInfo: "2",
 		Resources: []types.Any{
 			any(t, ingressHTTP),
 			any(t, ingressHTTPS),
 			any(t, staticListener()),
 		},
 		TypeUrl: listenerType,
-		Nonce:   "3",
+		Nonce:   "2",
 	}, streamLDS(t, cc))
 }
 
@@ -1163,13 +1163,13 @@ func TestLDSIngressRouteTCPProxyTLSPassthrough(t *testing.T) {
 	}
 
 	assertEqual(t, &v2.DiscoveryResponse{
-		VersionInfo: "2",
+		VersionInfo: "1",
 		Resources: []types.Any{
 			any(t, ingressHTTPS),
 			any(t, staticListener()),
 		},
 		TypeUrl: listenerType,
-		Nonce:   "2",
+		Nonce:   "1",
 	}, streamLDS(t, cc))
 }
 
@@ -1236,13 +1236,13 @@ func TestLDSIngressRouteTCPForward(t *testing.T) {
 	}
 
 	assertEqual(t, &v2.DiscoveryResponse{
-		VersionInfo: "3",
+		VersionInfo: "2",
 		Resources: []types.Any{
 			any(t, ingressHTTPS),
 			any(t, staticListener()),
 		},
 		TypeUrl: listenerType,
-		Nonce:   "3",
+		Nonce:   "2",
 	}, streamLDS(t, cc))
 }
 
@@ -1321,13 +1321,13 @@ func TestIngressRouteTLSCertificateDelegation(t *testing.T) {
 
 	// assert there is no ingress_https because there is no matching secret.
 	assertEqual(t, &v2.DiscoveryResponse{
-		VersionInfo: "3",
+		VersionInfo: "2",
 		Resources: []types.Any{
 			any(t, ingress_http),
 			any(t, staticListener()),
 		},
 		TypeUrl: listenerType,
-		Nonce:   "3",
+		Nonce:   "2",
 	}, streamLDS(t, cc))
 
 	// t1 is a TLSCertificateDelegation that permits default to access secret/wildcard
@@ -1357,14 +1357,14 @@ func TestIngressRouteTLSCertificateDelegation(t *testing.T) {
 	}
 
 	assertEqual(t, &v2.DiscoveryResponse{
-		VersionInfo: "4",
+		VersionInfo: "3",
 		Resources: []types.Any{
 			any(t, ingress_http),
 			any(t, ingress_https),
 			any(t, staticListener()),
 		},
 		TypeUrl: listenerType,
-		Nonce:   "4",
+		Nonce:   "3",
 	}, streamLDS(t, cc))
 
 	// t2 is a TLSCertificateDelegation that permits access to secret/wildcard from all namespaces.
@@ -1385,14 +1385,14 @@ func TestIngressRouteTLSCertificateDelegation(t *testing.T) {
 	rh.OnUpdate(t1, t2)
 
 	assertEqual(t, &v2.DiscoveryResponse{
-		VersionInfo: "5",
+		VersionInfo: "4",
 		Resources: []types.Any{
 			any(t, ingress_http),
 			any(t, ingress_https),
 			any(t, staticListener()),
 		},
 		TypeUrl: listenerType,
-		Nonce:   "5",
+		Nonce:   "4",
 	}, streamLDS(t, cc))
 
 	// t3 is a TLSCertificateDelegation that permits access to secret/different all namespaces.
@@ -1413,13 +1413,13 @@ func TestIngressRouteTLSCertificateDelegation(t *testing.T) {
 	rh.OnUpdate(t2, t3)
 
 	assertEqual(t, &v2.DiscoveryResponse{
-		VersionInfo: "6",
+		VersionInfo: "5",
 		Resources: []types.Any{
 			any(t, ingress_http),
 			any(t, staticListener()),
 		},
 		TypeUrl: listenerType,
-		Nonce:   "6",
+		Nonce:   "5",
 	}, streamLDS(t, cc))
 
 	// t4 is a TLSCertificateDelegation that permits access to secret/wildcard from the kube-secret namespace.
@@ -1440,13 +1440,13 @@ func TestIngressRouteTLSCertificateDelegation(t *testing.T) {
 	rh.OnUpdate(t3, t4)
 
 	assertEqual(t, &v2.DiscoveryResponse{
-		VersionInfo: "7",
+		VersionInfo: "6",
 		Resources: []types.Any{
 			any(t, ingress_http),
 			any(t, staticListener()),
 		},
 		TypeUrl: listenerType,
-		Nonce:   "7",
+		Nonce:   "6",
 	}, streamLDS(t, cc))
 
 }
@@ -1524,7 +1524,7 @@ func TestIngressRouteMinimumTLSVersion(t *testing.T) {
 
 	// verify that i1's TLS 1.1 minimum has been upgraded to 1.2
 	assertEqual(t, &v2.DiscoveryResponse{
-		VersionInfo: "3",
+		VersionInfo: "2",
 		Resources: []types.Any{
 			any(t, &v2.Listener{
 				Name:         "ingress_http",
@@ -1535,7 +1535,7 @@ func TestIngressRouteMinimumTLSVersion(t *testing.T) {
 			any(t, staticListener()),
 		},
 		TypeUrl: listenerType,
-		Nonce:   "3",
+		Nonce:   "2",
 	}, streamLDS(t, cc))
 
 	// i2 is a tls ingressroute
@@ -1575,7 +1575,7 @@ func TestIngressRouteMinimumTLSVersion(t *testing.T) {
 
 	// verify that i2's TLS 1.3 minimum has NOT been downgraded to 1.2
 	assertEqual(t, &v2.DiscoveryResponse{
-		VersionInfo: "4",
+		VersionInfo: "3",
 		Resources: []types.Any{
 			any(t, &v2.Listener{
 				Name:         "ingress_http",
@@ -1586,7 +1586,7 @@ func TestIngressRouteMinimumTLSVersion(t *testing.T) {
 			any(t, staticListener()),
 		},
 		TypeUrl: listenerType,
-		Nonce:   "4",
+		Nonce:   "3",
 	}, streamLDS(t, cc))
 }
 

--- a/internal/e2e/rds_test.go
+++ b/internal/e2e/rds_test.go
@@ -96,7 +96,7 @@ func TestEditIngress(t *testing.T) {
 
 	// check that it's been translated correctly.
 	assertEqual(t, &v2.DiscoveryResponse{
-		VersionInfo: "2",
+		VersionInfo: "1",
 		Resources: []types.Any{
 			any(t, &v2.RouteConfiguration{
 				Name: "ingress_http",
@@ -115,7 +115,7 @@ func TestEditIngress(t *testing.T) {
 			}),
 		},
 		TypeUrl: routeType,
-		Nonce:   "2",
+		Nonce:   "1",
 	}, streamRDS(t, cc))
 
 	// update old to new
@@ -140,7 +140,7 @@ func TestEditIngress(t *testing.T) {
 
 	// check that ingress_http has been updated.
 	assertEqual(t, &v2.DiscoveryResponse{
-		VersionInfo: "3",
+		VersionInfo: "2",
 		Resources: []types.Any{
 			any(t, &v2.RouteConfiguration{
 				Name: "ingress_http",
@@ -159,7 +159,7 @@ func TestEditIngress(t *testing.T) {
 			}),
 		},
 		TypeUrl: routeType,
-		Nonce:   "3",
+		Nonce:   "2",
 	}, streamRDS(t, cc))
 }
 
@@ -301,7 +301,7 @@ func TestEditIngressInPlace(t *testing.T) {
 	rh.OnAdd(s2)
 
 	assertEqual(t, &v2.DiscoveryResponse{
-		VersionInfo: "3",
+		VersionInfo: "2",
 		Resources: []types.Any{
 			any(t, &v2.RouteConfiguration{
 				Name: "ingress_http",
@@ -320,7 +320,7 @@ func TestEditIngressInPlace(t *testing.T) {
 			}),
 		},
 		TypeUrl: routeType,
-		Nonce:   "3",
+		Nonce:   "2",
 	}, streamRDS(t, cc))
 
 	// i2 is like i1 but adds a second route
@@ -351,7 +351,7 @@ func TestEditIngressInPlace(t *testing.T) {
 	}
 	rh.OnUpdate(i1, i2)
 	assertEqual(t, &v2.DiscoveryResponse{
-		VersionInfo: "4",
+		VersionInfo: "3",
 		Resources: []types.Any{
 			any(t, &v2.RouteConfiguration{
 				Name: "ingress_http",
@@ -374,7 +374,7 @@ func TestEditIngressInPlace(t *testing.T) {
 			}),
 		},
 		TypeUrl: routeType,
-		Nonce:   "4",
+		Nonce:   "3",
 	}, streamRDS(t, cc))
 
 	// i3 is like i2, but adds the ingress.kubernetes.io/force-ssl-redirect: "true" annotation
@@ -410,7 +410,7 @@ func TestEditIngressInPlace(t *testing.T) {
 	}
 	rh.OnUpdate(i2, i3)
 	assertEqual(t, &v2.DiscoveryResponse{
-		VersionInfo: "5",
+		VersionInfo: "4",
 		Resources: []types.Any{
 			any(t, &v2.RouteConfiguration{
 				Name: "ingress_http",
@@ -428,7 +428,7 @@ func TestEditIngressInPlace(t *testing.T) {
 			any(t, &v2.RouteConfiguration{Name: "ingress_https"}),
 		},
 		TypeUrl: routeType,
-		Nonce:   "5",
+		Nonce:   "4",
 	}, streamRDS(t, cc))
 
 	rh.OnAdd(&v1.Secret{
@@ -481,7 +481,7 @@ func TestEditIngressInPlace(t *testing.T) {
 	}
 	rh.OnUpdate(i3, i4)
 	assertEqual(t, &v2.DiscoveryResponse{
-		VersionInfo: "7",
+		VersionInfo: "6",
 		Resources: []types.Any{
 			any(t, &v2.RouteConfiguration{
 				Name: "ingress_http",
@@ -513,7 +513,7 @@ func TestEditIngressInPlace(t *testing.T) {
 				}}}),
 		},
 		TypeUrl: routeType,
-		Nonce:   "7",
+		Nonce:   "6",
 	}, streamRDS(t, cc))
 }
 
@@ -550,7 +550,7 @@ func TestRequestTimeout(t *testing.T) {
 		},
 	}
 	rh.OnAdd(i1)
-	assertRDS(t, cc, "2", []route.VirtualHost{{
+	assertRDS(t, cc, "1", []route.VirtualHost{{
 		Name:    "*",
 		Domains: []string{"*"},
 		Routes: []route.Route{{
@@ -572,7 +572,7 @@ func TestRequestTimeout(t *testing.T) {
 		},
 	}
 	rh.OnUpdate(i1, i2)
-	assertRDS(t, cc, "3", []route.VirtualHost{{
+	assertRDS(t, cc, "2", []route.VirtualHost{{
 		Name:    "*",
 		Domains: []string{"*"},
 		Routes: []route.Route{{
@@ -594,7 +594,7 @@ func TestRequestTimeout(t *testing.T) {
 		},
 	}
 	rh.OnUpdate(i2, i3)
-	assertRDS(t, cc, "4", []route.VirtualHost{{
+	assertRDS(t, cc, "3", []route.VirtualHost{{
 		Name:    "*",
 		Domains: []string{"*"},
 		Routes: []route.Route{{
@@ -616,7 +616,7 @@ func TestRequestTimeout(t *testing.T) {
 		},
 	}
 	rh.OnUpdate(i3, i4)
-	assertRDS(t, cc, "5", []route.VirtualHost{{
+	assertRDS(t, cc, "4", []route.VirtualHost{{
 		Name:    "*",
 		Domains: []string{"*"},
 		Routes: []route.Route{{
@@ -812,7 +812,7 @@ func TestInvalidCertInIngress(t *testing.T) {
 		},
 	})
 
-	assertRDS(t, cc, "3", []route.VirtualHost{{ // ingress_http
+	assertRDS(t, cc, "2", []route.VirtualHost{{ // ingress_http
 		Name:    "kuard.io",
 		Domains: domains("kuard.io"),
 		Routes: []route.Route{{
@@ -835,7 +835,7 @@ func TestInvalidCertInIngress(t *testing.T) {
 		},
 	})
 
-	assertRDS(t, cc, "4", []route.VirtualHost{{ // ingress_http
+	assertRDS(t, cc, "3", []route.VirtualHost{{ // ingress_http
 		Name:    "kuard.io",
 		Domains: domains("kuard.io"),
 		Routes: []route.Route{{
@@ -1163,7 +1163,7 @@ func TestWebsocketIngress(t *testing.T) {
 		},
 	})
 
-	assertRDS(t, cc, "2", []route.VirtualHost{{
+	assertRDS(t, cc, "1", []route.VirtualHost{{
 		Name:    "websocket.hello.world",
 		Domains: domains("websocket.hello.world"),
 		Routes: []route.Route{{
@@ -1223,7 +1223,7 @@ func TestWebsocketIngressRoute(t *testing.T) {
 		},
 	})
 
-	assertRDS(t, cc, "2", []route.VirtualHost{{
+	assertRDS(t, cc, "1", []route.VirtualHost{{
 		Name:    "websocket.hello.world",
 		Domains: domains("websocket.hello.world"),
 		Routes: []route.Route{{
@@ -1309,7 +1309,7 @@ func TestWebsocketIngressRoute_MultipleUpstreams(t *testing.T) {
 		},
 	})
 
-	assertRDS(t, cc, "3", []route.VirtualHost{{
+	assertRDS(t, cc, "1", []route.VirtualHost{{
 		Name:    "websocket.hello.world",
 		Domains: domains("websocket.hello.world"),
 		Routes: []route.Route{{
@@ -1369,7 +1369,7 @@ func TestPrefixRewriteIngressRoute(t *testing.T) {
 		},
 	})
 
-	assertRDS(t, cc, "2", []route.VirtualHost{{
+	assertRDS(t, cc, "1", []route.VirtualHost{{
 		Name:    "prefixrewrite.hello.world",
 		Domains: domains("prefixrewrite.hello.world"),
 		Routes: []route.Route{{
@@ -1469,7 +1469,7 @@ func TestDefaultBackendDoesNotOverwriteNamedHost(t *testing.T) {
 	})
 
 	assertEqual(t, &v2.DiscoveryResponse{
-		VersionInfo: "3",
+		VersionInfo: "1",
 		Resources: []types.Any{
 			any(t, &v2.RouteConfiguration{
 				Name: "ingress_http",
@@ -1497,7 +1497,7 @@ func TestDefaultBackendDoesNotOverwriteNamedHost(t *testing.T) {
 			}),
 		},
 		TypeUrl: routeType,
-		Nonce:   "3",
+		Nonce:   "1",
 	}, streamRDS(t, cc, "ingress_http"))
 }
 
@@ -1543,7 +1543,7 @@ func TestRDSIngressRouteInsideRootNamespaces(t *testing.T) {
 	rh.OnAdd(ir1)
 
 	assertEqual(t, &v2.DiscoveryResponse{
-		VersionInfo: "2",
+		VersionInfo: "1",
 		Resources: []types.Any{
 			any(t, &v2.RouteConfiguration{
 				Name: "ingress_http",
@@ -1559,7 +1559,7 @@ func TestRDSIngressRouteInsideRootNamespaces(t *testing.T) {
 			}),
 		},
 		TypeUrl: routeType,
-		Nonce:   "2",
+		Nonce:   "1",
 	}, streamRDS(t, cc, "ingress_http"))
 }
 
@@ -1605,14 +1605,14 @@ func TestRDSIngressRouteOutsideRootNamespaces(t *testing.T) {
 	rh.OnAdd(ir1)
 
 	assertEqual(t, &v2.DiscoveryResponse{
-		VersionInfo: "2",
+		VersionInfo: "1",
 		Resources: []types.Any{
 			any(t, &v2.RouteConfiguration{
 				Name: "ingress_http",
 			}),
 		},
 		TypeUrl: routeType,
-		Nonce:   "2",
+		Nonce:   "1",
 	}, streamRDS(t, cc, "ingress_http"))
 }
 
@@ -1661,7 +1661,7 @@ func TestRDSIngressRouteClassAnnotation(t *testing.T) {
 	}
 
 	rh.OnAdd(ir1)
-	assertRDS(t, cc, "2", []route.VirtualHost{{
+	assertRDS(t, cc, "1", []route.VirtualHost{{
 		Name:    "www.example.com",
 		Domains: domains("www.example.com"),
 		Routes: []route.Route{{
@@ -1695,7 +1695,7 @@ func TestRDSIngressRouteClassAnnotation(t *testing.T) {
 		},
 	}
 	rh.OnUpdate(ir1, ir2)
-	assertRDS(t, cc, "3", nil, nil)
+	assertRDS(t, cc, "2", nil, nil)
 
 	ir3 := &ingressroutev1.IngressRoute{
 		ObjectMeta: metav1.ObjectMeta{
@@ -1721,7 +1721,7 @@ func TestRDSIngressRouteClassAnnotation(t *testing.T) {
 		},
 	}
 	rh.OnUpdate(ir2, ir3)
-	assertRDS(t, cc, "3", nil, nil)
+	assertRDS(t, cc, "2", nil, nil)
 
 	ir4 := &ingressroutev1.IngressRoute{
 		ObjectMeta: metav1.ObjectMeta{
@@ -1747,7 +1747,7 @@ func TestRDSIngressRouteClassAnnotation(t *testing.T) {
 		},
 	}
 	rh.OnUpdate(ir3, ir4)
-	assertRDS(t, cc, "4", []route.VirtualHost{{
+	assertRDS(t, cc, "3", []route.VirtualHost{{
 		Name:    "www.example.com",
 		Domains: domains("www.example.com"),
 		Routes: []route.Route{{
@@ -1782,7 +1782,7 @@ func TestRDSIngressRouteClassAnnotation(t *testing.T) {
 	}
 	rh.OnUpdate(ir4, ir5)
 
-	assertRDS(t, cc, "5", []route.VirtualHost{{
+	assertRDS(t, cc, "4", []route.VirtualHost{{
 		Name:    "www.example.com",
 		Domains: domains("www.example.com"),
 		Routes: []route.Route{{
@@ -1793,7 +1793,7 @@ func TestRDSIngressRouteClassAnnotation(t *testing.T) {
 	}}, nil)
 
 	rh.OnUpdate(ir5, ir3)
-	assertRDS(t, cc, "6", nil, nil)
+	assertRDS(t, cc, "5", nil, nil)
 }
 
 // Test DAGAdapter.IngressClass setting works, this could be done
@@ -1832,7 +1832,7 @@ func TestRDSIngressClassAnnotation(t *testing.T) {
 		},
 	}
 	rh.OnAdd(i1)
-	assertRDS(t, cc, "2", []route.VirtualHost{{
+	assertRDS(t, cc, "1", []route.VirtualHost{{
 		Name:    "*",
 		Domains: []string{"*"},
 		Routes: []route.Route{{
@@ -1858,7 +1858,7 @@ func TestRDSIngressClassAnnotation(t *testing.T) {
 		},
 	}
 	rh.OnUpdate(i1, i2)
-	assertRDS(t, cc, "3", nil, nil)
+	assertRDS(t, cc, "2", nil, nil)
 
 	i3 := &v1beta1.Ingress{
 		ObjectMeta: metav1.ObjectMeta{
@@ -1876,7 +1876,7 @@ func TestRDSIngressClassAnnotation(t *testing.T) {
 		},
 	}
 	rh.OnUpdate(i2, i3)
-	assertRDS(t, cc, "3", nil, nil)
+	assertRDS(t, cc, "2", nil, nil)
 
 	i4 := &v1beta1.Ingress{
 		ObjectMeta: metav1.ObjectMeta{
@@ -1894,7 +1894,7 @@ func TestRDSIngressClassAnnotation(t *testing.T) {
 		},
 	}
 	rh.OnUpdate(i3, i4)
-	assertRDS(t, cc, "4", []route.VirtualHost{{
+	assertRDS(t, cc, "3", []route.VirtualHost{{
 		Name:    "*",
 		Domains: []string{"*"},
 		Routes: []route.Route{{
@@ -1920,7 +1920,7 @@ func TestRDSIngressClassAnnotation(t *testing.T) {
 		},
 	}
 	rh.OnUpdate(i4, i5)
-	assertRDS(t, cc, "5", []route.VirtualHost{{
+	assertRDS(t, cc, "4", []route.VirtualHost{{
 		Name:    "*",
 		Domains: []string{"*"},
 		Routes: []route.Route{{
@@ -1931,7 +1931,7 @@ func TestRDSIngressClassAnnotation(t *testing.T) {
 	}}, nil)
 
 	rh.OnUpdate(i5, i3)
-	assertRDS(t, cc, "6", nil, nil)
+	assertRDS(t, cc, "5", nil, nil)
 }
 
 // issue 523, check for data races caused by accidentally
@@ -2102,7 +2102,7 @@ func TestRouteWithAServiceWeight(t *testing.T) {
 	}
 
 	rh.OnAdd(ir1)
-	assertRDS(t, cc, "2", []route.VirtualHost{{
+	assertRDS(t, cc, "1", []route.VirtualHost{{
 		Name:    "test2.test.com",
 		Domains: domains("test2.test.com"),
 		Routes: []route.Route{{
@@ -2135,7 +2135,7 @@ func TestRouteWithAServiceWeight(t *testing.T) {
 	}
 
 	rh.OnUpdate(ir1, ir2)
-	assertRDS(t, cc, "3", []route.VirtualHost{{
+	assertRDS(t, cc, "2", []route.VirtualHost{{
 		Name:    "test2.test.com",
 		Domains: domains("test2.test.com"),
 		Routes: []route.Route{{
@@ -2205,7 +2205,7 @@ func TestRouteWithTLS(t *testing.T) {
 
 	// check that ingress_http has been updated.
 	assertEqual(t, &v2.DiscoveryResponse{
-		VersionInfo: "3",
+		VersionInfo: "2",
 		Resources: []types.Any{
 			any(t, &v2.RouteConfiguration{
 				Name: "ingress_http",
@@ -2230,7 +2230,7 @@ func TestRouteWithTLS(t *testing.T) {
 				}}}),
 		},
 		TypeUrl: routeType,
-		Nonce:   "3",
+		Nonce:   "2",
 	}, streamRDS(t, cc))
 }
 func TestRouteWithTLS_InsecurePaths(t *testing.T) {
@@ -2310,7 +2310,7 @@ func TestRouteWithTLS_InsecurePaths(t *testing.T) {
 
 	// check that ingress_http has been updated.
 	assertEqual(t, &v2.DiscoveryResponse{
-		VersionInfo: "4",
+		VersionInfo: "2",
 		Resources: []types.Any{
 			any(t, &v2.RouteConfiguration{
 				Name: "ingress_http",
@@ -2347,7 +2347,7 @@ func TestRouteWithTLS_InsecurePaths(t *testing.T) {
 				}}}),
 		},
 		TypeUrl: routeType,
-		Nonce:   "4",
+		Nonce:   "2",
 	}, streamRDS(t, cc))
 }
 
@@ -2431,7 +2431,7 @@ func TestRouteWithTLS_InsecurePaths_DisablePermitInsecureTrue(t *testing.T) {
 
 	// check that ingress_http has been updated.
 	assertEqual(t, &v2.DiscoveryResponse{
-		VersionInfo: "4",
+		VersionInfo: "2",
 		Resources: []types.Any{
 			any(t, &v2.RouteConfiguration{
 				Name: "ingress_http",
@@ -2467,7 +2467,7 @@ func TestRouteWithTLS_InsecurePaths_DisablePermitInsecureTrue(t *testing.T) {
 				}}}),
 		},
 		TypeUrl: routeType,
-		Nonce:   "4",
+		Nonce:   "2",
 	}, streamRDS(t, cc))
 }
 
@@ -2505,7 +2505,7 @@ func TestRouteRetryAnnotations(t *testing.T) {
 		},
 	}
 	rh.OnAdd(i1)
-	assertRDS(t, cc, "2", []route.VirtualHost{{
+	assertRDS(t, cc, "1", []route.VirtualHost{{
 		Name:    "*",
 		Domains: []string{"*"},
 		Routes: []route.Route{{
@@ -2558,7 +2558,7 @@ func TestRouteRetryIngressRoute(t *testing.T) {
 	}
 
 	rh.OnAdd(i1)
-	assertRDS(t, cc, "2", []route.VirtualHost{{
+	assertRDS(t, cc, "1", []route.VirtualHost{{
 		Name:    "test2.test.com",
 		Domains: domains("test2.test.com"),
 		Routes: []route.Route{{
@@ -2612,7 +2612,7 @@ func TestRouteTimeoutPolicyIngressRoute(t *testing.T) {
 		},
 	}
 	rh.OnAdd(i1)
-	assertRDS(t, cc, "2", []route.VirtualHost{{
+	assertRDS(t, cc, "1", []route.VirtualHost{{
 		Name:    "test2.test.com",
 		Domains: domains("test2.test.com"),
 		Routes: []route.Route{{
@@ -2643,7 +2643,7 @@ func TestRouteTimeoutPolicyIngressRoute(t *testing.T) {
 		},
 	}
 	rh.OnUpdate(i1, i2)
-	assertRDS(t, cc, "3", []route.VirtualHost{{
+	assertRDS(t, cc, "2", []route.VirtualHost{{
 		Name:    "test2.test.com",
 		Domains: domains("test2.test.com"),
 		Routes: []route.Route{{
@@ -2673,7 +2673,7 @@ func TestRouteTimeoutPolicyIngressRoute(t *testing.T) {
 		},
 	}
 	rh.OnUpdate(i2, i3)
-	assertRDS(t, cc, "4", []route.VirtualHost{{
+	assertRDS(t, cc, "3", []route.VirtualHost{{
 		Name:    "test2.test.com",
 		Domains: domains("test2.test.com"),
 		Routes: []route.Route{{
@@ -2703,7 +2703,7 @@ func TestRouteTimeoutPolicyIngressRoute(t *testing.T) {
 		},
 	}
 	rh.OnUpdate(i3, i4)
-	assertRDS(t, cc, "5", []route.VirtualHost{{
+	assertRDS(t, cc, "4", []route.VirtualHost{{
 		Name:    "test2.test.com",
 		Domains: domains("test2.test.com"),
 		Routes: []route.Route{{
@@ -2756,7 +2756,7 @@ func TestRouteWithSessionAffinity(t *testing.T) {
 	}
 
 	rh.OnAdd(ir1)
-	assertRDS(t, cc, "2", []route.VirtualHost{{
+	assertRDS(t, cc, "1", []route.VirtualHost{{
 		Name:    "www.example.com",
 		Domains: domains("www.example.com"),
 		Routes: []route.Route{{
@@ -2789,7 +2789,7 @@ func TestRouteWithSessionAffinity(t *testing.T) {
 		},
 	}
 	rh.OnUpdate(ir1, ir2)
-	assertRDS(t, cc, "3", []route.VirtualHost{{
+	assertRDS(t, cc, "2", []route.VirtualHost{{
 		Name:    "www.example.com",
 		Domains: domains("www.example.com"),
 		Routes: []route.Route{{
@@ -2832,7 +2832,7 @@ func TestRouteWithSessionAffinity(t *testing.T) {
 		},
 	}
 	rh.OnUpdate(ir2, ir3)
-	assertRDS(t, cc, "4", []route.VirtualHost{{
+	assertRDS(t, cc, "3", []route.VirtualHost{{
 		Name:    "www.example.com",
 		Domains: domains("www.example.com"),
 		Routes: []route.Route{{
@@ -2923,7 +2923,7 @@ func TestLoadBalancingStrategies(t *testing.T) {
 			},
 		},
 	}}
-	assertRDS(t, cc, "5", want, nil)
+	assertRDS(t, cc, "1", want, nil)
 }
 
 // issue 1234, assert that RoutePrefix and RouteRegex work as expected
@@ -2976,7 +2976,7 @@ func TestRoutePrefixRouteRegex(t *testing.T) {
 
 	// check that it's been translated correctly.
 	assertEqual(t, &v2.DiscoveryResponse{
-		VersionInfo: "2",
+		VersionInfo: "1",
 		Resources: []types.Any{
 			any(t, &v2.RouteConfiguration{
 				Name: "ingress_http",
@@ -2999,7 +2999,7 @@ func TestRoutePrefixRouteRegex(t *testing.T) {
 			}),
 		},
 		TypeUrl: routeType,
-		Nonce:   "2",
+		Nonce:   "1",
 	}, streamRDS(t, cc))
 }
 


### PR DESCRIPTION
Fixes #1172

Teach dag.Cache.Insert to return false if the Service being inserted is
not referenced by an Ingress or IngressRoute object in the cache.

The implementation is O(N(ingress)+N(ingressroutes)) this can be
improved later with caching if required.

Signed-off-by: Dave Cheney <dave@cheney.net>