### PR TITLE
internal/dag: move validity check to VirtualHost/SecureVirtualHost

### DIFF
--- a/internal/dag/builder.go
+++ b/internal/dag/builder.go
@@ -448,13 +448,11 @@ func (b *Builder) dag() *DAG {
 		for k, vh := range l.VirtualHosts {
 			switch vh := vh.(type) {
 			case *VirtualHost:
-				// suppress virtual hosts without routes.
-				if len(vh.routes) < 1 {
+				if !vh.Valid() {
 					delete(l.VirtualHosts, k)
 				}
 			case *SecureVirtualHost:
-				// suppress secure virtual hosts without secrets or tcpproxy.
-				if vh.Secret == nil && vh.TCPProxy == nil {
+				if !vh.Valid() {
 					delete(l.VirtualHosts, k)
 				}
 			}

--- a/internal/dag/dag.go
+++ b/internal/dag/dag.go
@@ -161,6 +161,12 @@ func (v *VirtualHost) Visit(f func(Vertex)) {
 	}
 }
 
+func (v *VirtualHost) Valid() bool {
+	// A VirtualHost is valid if it has at least one route,
+	// or tcp proxy is not nil.
+	return len(v.routes) > 0 || v.TCPProxy != nil
+}
+
 // A SecureVirtualHost represents a HTTP host protected by TLS.
 type SecureVirtualHost struct {
 	VirtualHost
@@ -177,6 +183,11 @@ func (s *SecureVirtualHost) Visit(f func(Vertex)) {
 	if s.Secret != nil {
 		f(s.Secret) // secret is not required if vhost is using tls passthrough
 	}
+}
+
+func (s *SecureVirtualHost) Valid() bool {
+	// A SecureVirtualHost is valid if it as a Secret or a TCPProxy.
+	return s.Secret != nil || s.TCPProxy != nil
 }
 
 type Visitable interface {

--- a/internal/dag/dag_test.go
+++ b/internal/dag/dag_test.go
@@ -1,0 +1,101 @@
+// Copyright © 2019 Heptio
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dag
+
+import (
+	"testing"
+)
+
+func TestVirtualHostValid(t *testing.T) {
+	assert := Assert{t}
+
+	vh := VirtualHost{}
+	assert.False(vh.Valid())
+
+	vh = VirtualHost{
+		routes: map[string]Vertex{
+			"/": &Route{},
+		},
+	}
+	assert.True(vh.Valid())
+
+	vh = VirtualHost{
+		TCPProxy: new(TCPProxy),
+	}
+	assert.True(vh.Valid())
+}
+
+func TestSecureVirtualHostValid(t *testing.T) {
+	assert := Assert{t}
+
+	vh := SecureVirtualHost{}
+	assert.False(vh.Valid())
+
+	vh = SecureVirtualHost{
+		Secret: new(Secret),
+	}
+	assert.True(vh.Valid())
+
+	vh = SecureVirtualHost{
+		VirtualHost: VirtualHost{
+			routes: map[string]Vertex{
+				"/": &Route{},
+			},
+		},
+	}
+	assert.False(vh.Valid())
+
+	vh = SecureVirtualHost{
+		Secret: new(Secret),
+		VirtualHost: VirtualHost{
+			routes: map[string]Vertex{
+				"/": &Route{},
+			},
+		},
+	}
+	assert.True(vh.Valid())
+
+	vh = SecureVirtualHost{
+		VirtualHost: VirtualHost{
+			TCPProxy: new(TCPProxy),
+		},
+	}
+	assert.True(vh.Valid())
+
+	vh = SecureVirtualHost{
+		Secret: new(Secret),
+		VirtualHost: VirtualHost{
+			TCPProxy: new(TCPProxy),
+		},
+	}
+	assert.True(vh.Valid())
+}
+
+type Assert struct {
+	*testing.T
+}
+
+func (a Assert) True(t bool) {
+	a.Helper()
+	if !t {
+		a.Error("expected true, got false")
+	}
+}
+
+func (a Assert) False(t bool) {
+	a.Helper()
+	if t {
+		a.Error("expected false, got true")
+	}
+}


### PR DESCRIPTION
Updates #1165

The rules for determining if a SecureVirtualHost is valid are subtle as
they must take into account the workarounds for TLS passthrough to a
proxy. Move those into methods on VirtualHost/SecureVirtualHost and add
tests to assert them.

Signed-off-by: Dave Cheney <dave@cheney.net>