### PR TITLE
internal/dag: do not create routes if there is no matching service

### DIFF
--- a/internal/contour/listener_test.go
+++ b/internal/contour/listener_test.go
@@ -149,6 +149,19 @@ func TestListenerVisit(t *testing.T) {
 						},
 					},
 				},
+				&v1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "kuard",
+						Namespace: "default",
+					},
+					Spec: v1.ServiceSpec{
+						Ports: []v1.ServicePort{{
+							Name:     "http",
+							Protocol: "TCP",
+							Port:     8080,
+						}},
+					},
+				},
 			},
 			want: listenermap(&v2.Listener{
 				Name:         ENVOY_HTTP_LISTENER,
@@ -225,6 +238,19 @@ func TestListenerVisit(t *testing.T) {
 					Type: "kubernetes.io/tls",
 					Data: secretdata("certificate", "key"),
 				},
+				&v1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "kuard",
+						Namespace: "default",
+					},
+					Spec: v1.ServiceSpec{
+						Ports: []v1.ServicePort{{
+							Name:     "http",
+							Protocol: "TCP",
+							Port:     8080,
+						}},
+					},
+				},
 			},
 			want: listenermap(&v2.Listener{
 				Name:         ENVOY_HTTP_LISTENER,
@@ -287,6 +313,19 @@ func TestListenerVisit(t *testing.T) {
 					Type: "kubernetes.io/tls",
 					Data: secretdata("certificate", "key"),
 				},
+				&v1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "kuard",
+						Namespace: "default",
+					},
+					Spec: v1.ServiceSpec{
+						Ports: []v1.ServicePort{{
+							Name:     "http",
+							Protocol: "TCP",
+							Port:     8080,
+						}},
+					},
+				},
 			},
 			want: listenermap(&v2.Listener{
 				Name:         ENVOY_HTTP_LISTENER,
@@ -341,6 +380,19 @@ func TestListenerVisit(t *testing.T) {
 					},
 					Type: "kubernetes.io/tls",
 					Data: secretdata("certificate", "key"),
+				},
+				&v1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "kuard",
+						Namespace: "default",
+					},
+					Spec: v1.ServiceSpec{
+						Ports: []v1.ServicePort{{
+							Name:     "http",
+							Protocol: "TCP",
+							Port:     8080,
+						}},
+					},
 				},
 			},
 			want: listenermap(&v2.Listener{
@@ -513,6 +565,19 @@ func TestListenerVisit(t *testing.T) {
 					Type: "kubernetes.io/tls",
 					Data: secretdata("certificate", "key"),
 				},
+				&v1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "kuard",
+						Namespace: "default",
+					},
+					Spec: v1.ServiceSpec{
+						Ports: []v1.ServicePort{{
+							Name:     "http",
+							Protocol: "TCP",
+							Port:     8080,
+						}},
+					},
+				},
 			},
 			want: listenermap(&v2.Listener{
 				Name:         ENVOY_HTTP_LISTENER,
@@ -561,6 +626,19 @@ func TestListenerVisit(t *testing.T) {
 					},
 					Type: "kubernetes.io/tls",
 					Data: secretdata("certificate", "key"),
+				},
+				&v1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "kuard",
+						Namespace: "default",
+					},
+					Spec: v1.ServiceSpec{
+						Ports: []v1.ServicePort{{
+							Name:     "http",
+							Protocol: "TCP",
+							Port:     8080,
+						}},
+					},
 				},
 			},
 			want: listenermap(&v2.Listener{
@@ -616,6 +694,19 @@ func TestListenerVisit(t *testing.T) {
 					Type: "kubernetes.io/tls",
 					Data: secretdata("certificate", "key"),
 				},
+				&v1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "kuard",
+						Namespace: "default",
+					},
+					Spec: v1.ServiceSpec{
+						Ports: []v1.ServicePort{{
+							Name:     "http",
+							Protocol: "TCP",
+							Port:     8080,
+						}},
+					},
+				},
 			},
 			want: listenermap(&v2.Listener{
 				Name:         ENVOY_HTTP_LISTENER,
@@ -664,6 +755,19 @@ func TestListenerVisit(t *testing.T) {
 					},
 					Type: "kubernetes.io/tls",
 					Data: secretdata("certificate", "key"),
+				},
+				&v1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "kuard",
+						Namespace: "default",
+					},
+					Spec: v1.ServiceSpec{
+						Ports: []v1.ServicePort{{
+							Name:     "http",
+							Protocol: "TCP",
+							Port:     8080,
+						}},
+					},
 				},
 			},
 			want: listenermap(&v2.Listener{
@@ -716,6 +820,19 @@ func TestListenerVisit(t *testing.T) {
 					},
 					Type: "kubernetes.io/tls",
 					Data: secretdata("certificate", "key"),
+				},
+				&v1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "kuard",
+						Namespace: "default",
+					},
+					Spec: v1.ServiceSpec{
+						Ports: []v1.ServicePort{{
+							Name:     "http",
+							Protocol: "TCP",
+							Port:     8080,
+						}},
+					},
 				},
 			},
 			want: listenermap(&v2.Listener{

--- a/internal/contour/route.go
+++ b/internal/contour/route.go
@@ -144,10 +144,6 @@ func (v *routeVisitor) visit(vertex dag.Vertex) {
 				vh.Visit(func(v dag.Vertex) {
 					switch r := v.(type) {
 					case *dag.PrefixRoute:
-						if len(r.Clusters) < 1 {
-							// no services for this route, skip it.
-							return
-						}
 						rr := route.Route{
 							Match:               envoy.RoutePrefix(r.Prefix),
 							Action:              envoy.RouteRoute(&r.Route),
@@ -160,10 +156,6 @@ func (v *routeVisitor) visit(vertex dag.Vertex) {
 						}
 						vhost.Routes = append(vhost.Routes, rr)
 					case *dag.RegexRoute:
-						if len(r.Clusters) < 1 {
-							// no services for this route, skip it.
-							return
-						}
 						rr := route.Route{
 							Match:               envoy.RouteRegex(r.Regex),
 							Action:              envoy.RouteRoute(&r.Route),
@@ -187,20 +179,12 @@ func (v *routeVisitor) visit(vertex dag.Vertex) {
 				vh.Visit(func(v dag.Vertex) {
 					switch r := v.(type) {
 					case *dag.PrefixRoute:
-						if len(r.Clusters) < 1 {
-							// no services for this route, skip it.
-							return
-						}
 						vhost.Routes = append(vhost.Routes, route.Route{
 							Match:               envoy.RoutePrefix(r.Prefix),
 							Action:              envoy.RouteRoute(&r.Route),
 							RequestHeadersToAdd: envoy.RouteHeaders(),
 						})
 					case *dag.RegexRoute:
-						if len(r.Clusters) < 1 {
-							// no services for this route, skip it.
-							return
-						}
 						vhost.Routes = append(vhost.Routes, route.Route{
 							Match:               envoy.RouteRegex(r.Regex),
 							Action:              envoy.RouteRoute(&r.Route),

--- a/internal/contour/secret_test.go
+++ b/internal/contour/secret_test.go
@@ -111,6 +111,20 @@ func TestSecretVisit(t *testing.T) {
 		},
 		"simple ingress with secret": {
 			objs: []interface{}{
+				&v1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "kuard",
+						Namespace: "default",
+					},
+					Spec: v1.ServiceSpec{
+						Ports: []v1.ServicePort{{
+							Name:       "http",
+							Protocol:   "TCP",
+							Port:       8080,
+							TargetPort: intstr.FromInt(8080),
+						}},
+					},
+				},
 				&v1beta1.Ingress{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "simple",
@@ -135,6 +149,20 @@ func TestSecretVisit(t *testing.T) {
 		},
 		"multiple ingresses with shared secret": {
 			objs: []interface{}{
+				&v1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "kuard",
+						Namespace: "default",
+					},
+					Spec: v1.ServiceSpec{
+						Ports: []v1.ServicePort{{
+							Name:       "http",
+							Protocol:   "TCP",
+							Port:       8080,
+							TargetPort: intstr.FromInt(8080),
+						}},
+					},
+				},
 				&v1beta1.Ingress{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "simple-a",
@@ -175,6 +203,20 @@ func TestSecretVisit(t *testing.T) {
 		},
 		"multiple ingresses with different secrets": {
 			objs: []interface{}{
+				&v1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "kuard",
+						Namespace: "default",
+					},
+					Spec: v1.ServiceSpec{
+						Ports: []v1.ServicePort{{
+							Name:       "http",
+							Protocol:   "TCP",
+							Port:       80,
+							TargetPort: intstr.FromInt(8080),
+						}},
+					},
+				},
 				&v1beta1.Ingress{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "simple-a",
@@ -217,6 +259,20 @@ func TestSecretVisit(t *testing.T) {
 		},
 		"simple ingressroute with secret": {
 			objs: []interface{}{
+				&v1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "backend",
+						Namespace: "default",
+					},
+					Spec: v1.ServiceSpec{
+						Ports: []v1.ServicePort{{
+							Name:       "http",
+							Protocol:   "TCP",
+							Port:       80,
+							TargetPort: intstr.FromInt(8080),
+						}},
+					},
+				},
 				&ingressroutev1.IngressRoute{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "simple",
@@ -245,6 +301,20 @@ func TestSecretVisit(t *testing.T) {
 		},
 		"multiple ingressroutes with shared secret": {
 			objs: []interface{}{
+				&v1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "backend",
+						Namespace: "default",
+					},
+					Spec: v1.ServiceSpec{
+						Ports: []v1.ServicePort{{
+							Name:       "http",
+							Protocol:   "TCP",
+							Port:       80,
+							TargetPort: intstr.FromInt(8080),
+						}},
+					},
+				},
 				&ingressroutev1.IngressRoute{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "simple-a",
@@ -293,6 +363,20 @@ func TestSecretVisit(t *testing.T) {
 		},
 		"multiple ingressroutes with different secret": {
 			objs: []interface{}{
+				&v1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "backend",
+						Namespace: "default",
+					},
+					Spec: v1.ServiceSpec{
+						Ports: []v1.ServicePort{{
+							Name:       "http",
+							Protocol:   "TCP",
+							Port:       80,
+							TargetPort: intstr.FromInt(8080),
+						}},
+					},
+				},
 				&ingressroutev1.IngressRoute{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "simple-a",

--- a/internal/dag/dag.go
+++ b/internal/dag/dag.go
@@ -186,7 +186,7 @@ func (s *SecureVirtualHost) Visit(f func(Vertex)) {
 }
 
 func (s *SecureVirtualHost) Valid() bool {
-	// A SecureVirtualHost is valid if it as a Secret or a TCPProxy.
+	// A SecureVirtualHost is valid if it has a Secret or a TCPProxy.
 	return s.Secret != nil || s.TCPProxy != nil
 }
 

--- a/internal/e2e/lds_test.go
+++ b/internal/e2e/lds_test.go
@@ -63,6 +63,20 @@ func TestNonTLSListener(t *testing.T) {
 		},
 	}
 
+	rh.OnAdd(&v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "backend",
+			Namespace: "default",
+		},
+		Spec: v1.ServiceSpec{
+			Ports: []v1.ServicePort{{
+				Name:     "http",
+				Protocol: "TCP",
+				Port:     80,
+			}},
+		},
+	})
+
 	// add it and assert that we now have a ingress_http listener
 	rh.OnAdd(i1)
 	assertEqual(t, &v2.DiscoveryResponse{
@@ -167,6 +181,20 @@ func TestTLSListener(t *testing.T) {
 			}},
 		},
 	}
+
+	rh.OnAdd(&v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "backend",
+			Namespace: "default",
+		},
+		Spec: v1.ServiceSpec{
+			Ports: []v1.ServicePort{{
+				Name:     "http",
+				Protocol: "TCP",
+				Port:     80,
+			}},
+		},
+	})
 
 	// add secret
 	rh.OnAdd(s1)
@@ -458,6 +486,20 @@ func TestLDSFilter(t *testing.T) {
 		},
 	}
 
+	rh.OnAdd(&v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "backend",
+			Namespace: "default",
+		},
+		Spec: v1.ServiceSpec{
+			Ports: []v1.ServicePort{{
+				Name:     "http",
+				Protocol: "TCP",
+				Port:     80,
+			}},
+		},
+	})
+
 	// add secret
 	rh.OnAdd(s1)
 
@@ -634,6 +676,19 @@ func TestLDSIngressHTTPUseProxyProtocol(t *testing.T) {
 			Backend: backend("backend", intstr.FromInt(80)),
 		},
 	}
+	rh.OnAdd(&v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "backend",
+			Namespace: "default",
+		},
+		Spec: v1.ServiceSpec{
+			Ports: []v1.ServicePort{{
+				Name:     "http",
+				Protocol: "TCP",
+				Port:     80,
+			}},
+		},
+	})
 
 	// add it and assert that we now have a ingress_http listener using
 	// the proxy protocol (the true param to filterchain)
@@ -702,6 +757,20 @@ func TestLDSIngressHTTPSUseProxyProtocol(t *testing.T) {
 		TypeUrl: listenerType,
 		Nonce:   "0",
 	}, streamLDS(t, cc))
+
+	rh.OnAdd(&v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "backend",
+			Namespace: "default",
+		},
+		Spec: v1.ServiceSpec{
+			Ports: []v1.ServicePort{{
+				Name:     "http",
+				Protocol: "TCP",
+				Port:     80,
+			}},
+		},
+	})
 
 	// add ingress and assert the existence of ingress_http and ingres_https and both
 	// are using proxy protocol
@@ -785,6 +854,20 @@ func TestLDSCustomAddressAndPort(t *testing.T) {
 		Nonce:   "0",
 	}, streamLDS(t, cc))
 
+	rh.OnAdd(&v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "backend",
+			Namespace: "default",
+		},
+		Spec: v1.ServiceSpec{
+			Ports: []v1.ServicePort{{
+				Name:     "http",
+				Protocol: "TCP",
+				Port:     80,
+			}},
+		},
+	})
+
 	// add ingress and assert the existence of ingress_http and ingres_https and both
 	// are using proxy protocol
 	rh.OnAdd(i1)
@@ -848,6 +931,20 @@ func TestLDSCustomAccessLogPaths(t *testing.T) {
 			}},
 		},
 	}
+
+	rh.OnAdd(&v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "backend",
+			Namespace: "default",
+		},
+		Spec: v1.ServiceSpec{
+			Ports: []v1.ServicePort{{
+				Name:     "http",
+				Protocol: "TCP",
+				Port:     80,
+			}},
+		},
+	})
 
 	// add secret
 	rh.OnAdd(s1)


### PR DESCRIPTION
Updates #1165

When processing Ingress documents the dag.Builder would create routes
even if there was no matching Service available. These empty routes were
then filtered out in the contour.Route visitor.

After this change the empty routes are no longer created at the dag
level and don't need to be filtered out at the visitor level. It also
appears this filtering was not as good as it should have been and there
were cases where listeners were being created when there were routes
without any valid clusters backing them.

Signed-off-by: Dave Cheney <dave@cheney.net>