### PR TITLE
internal/dag: simplify Builder's virtualhost map

### DIFF
--- a/internal/contour/visitor_test.go
+++ b/internal/contour/visitor_test.go
@@ -224,15 +224,6 @@ func TestVisitSecrets(t *testing.T) {
 	}
 }
 
-func virtualhosts(vx ...dag.Vertex) map[string]dag.Vertex {
-	m := make(map[string]dag.Vertex)
-	for _, v := range vx {
-		switch v := v.(type) {
-		case *dag.VirtualHost:
-			m[v.Name] = v
-		case *dag.SecureVirtualHost:
-			m[v.VirtualHost.Name] = v
-		}
-	}
-	return m
+func virtualhosts(vx ...dag.Vertex) []dag.Vertex {
+	return vx
 }

--- a/internal/dag/builder.go
+++ b/internal/dag/builder.go
@@ -439,6 +439,9 @@ func (b *Builder) dag() *DAG {
 		}
 	}
 	if len(http.VirtualHosts) > 0 {
+		sort.SliceStable(http.VirtualHosts, func(i, j int) bool {
+			return http.VirtualHosts[i].(*VirtualHost).Name < http.VirtualHosts[j].(*VirtualHost).Name
+		})
 		dag.roots = append(dag.roots, http)
 	}
 
@@ -451,6 +454,9 @@ func (b *Builder) dag() *DAG {
 		}
 	}
 	if len(https.VirtualHosts) > 0 {
+		sort.SliceStable(https.VirtualHosts, func(i, j int) bool {
+			return https.VirtualHosts[i].(*SecureVirtualHost).Name < https.VirtualHosts[j].(*SecureVirtualHost).Name
+		})
 		dag.roots = append(dag.roots, https)
 	}
 

--- a/internal/dag/builder_test.go
+++ b/internal/dag/builder_test.go
@@ -4224,19 +4224,8 @@ func secret(s *v1.Secret) *Secret {
 	}
 }
 
-func virtualhosts(vx ...Vertex) map[string]Vertex {
-	m := make(map[string]Vertex)
-	for _, v := range vx {
-		switch v := v.(type) {
-		case *VirtualHost:
-			m[v.Name] = v
-		case *SecureVirtualHost:
-			m[v.VirtualHost.Name] = v
-		default:
-			panic(fmt.Sprintf("unable to handle Vertex type %T", v))
-		}
-	}
-	return m
+func virtualhosts(vx ...Vertex) []Vertex {
+	return vx
 }
 
 func virtualhost(name string, v ...Vertex) *VirtualHost {

--- a/internal/dag/dag.go
+++ b/internal/dag/dag.go
@@ -175,7 +175,7 @@ type SecureVirtualHost struct {
 	MinProtoVersion auth.TlsParameters_TlsProtocol
 
 	// The cert and key for this host.
-	*Secret
+	Secret *Secret
 }
 
 func (s *SecureVirtualHost) Visit(f func(Vertex)) {

--- a/internal/dag/dag.go
+++ b/internal/dag/dag.go
@@ -214,7 +214,7 @@ type Listener struct {
 	// Port is the TCP port to listen on.
 	Port int
 
-	VirtualHosts map[string]Vertex
+	VirtualHosts []Vertex
 }
 
 func (l *Listener) Visit(f func(Vertex)) {


### PR DESCRIPTION
Fixes #1135

This PR removes the Builder's listeners map by storing two maps of
virtualhost and securevirtualhost objects directly in the builder. This
resolves #1135 by hard coding that there will only ever be a listener
for port 80 and a listener for port 443 -- this might not be the case
forever, but it will be for 1.0 and we can revisit that later.

In the mean time this significantly simplifies the handling of listeners
inside the builder. There is no more messy map storing two kinds of
objects which must be carefully identified every time we walk through
the map. It simplifies the dag.Listener object which no longer needs to
store things in a map when a slice will do. And it simplifies dag.dag()
because we no longer delete from a map while iterating through it, we
simply copy the value virtualhost objects into a fresh listener as part
of building the dag.Dag value.

Signed-off-by: Dave Cheney <dave@cheney.net>