### PR TITLE
cmd/contour: rework how we configure TLS required auth

### DIFF
--- a/internal/grpc/server.go
+++ b/internal/grpc/server.go
@@ -19,28 +19,14 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
-	"github.com/envoyproxy/go-control-plane/envoy/api/v2"
+	v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v2"
 	loadstats "github.com/envoyproxy/go-control-plane/envoy/service/load_stats/v2"
 	"github.com/sirupsen/logrus"
 )
 
-const (
-	// somewhat arbitrary limit to handle many, many, EDS streams
-	grpcMaxConcurrentStreams = 1 << 20
-)
-
 // NewAPI returns a *grpc.Server which responds to the Envoy v2 xDS gRPC API.
-func NewAPI(log logrus.FieldLogger, resources map[string]Resource) *grpc.Server {
-	opts := []grpc.ServerOption{
-		// By default the Go grpc library defaults to a value of ~100 streams per
-		// connection. This number is likely derived from the HTTP/2 spec:
-		// https://http2.github.io/http2-spec/#SettingValues
-		// We need to raise this value because Envoy will open one EDS stream per
-		// CDS entry. There doesn't seem to be a penalty for increasing this value,
-		// so set it the limit similar to envoyproxy/go-control-plane#70.
-		grpc.MaxConcurrentStreams(grpcMaxConcurrentStreams),
-	}
+func NewAPI(log logrus.FieldLogger, resources map[string]Resource, opts ...grpc.ServerOption) *grpc.Server {
 	g := grpc.NewServer(opts...)
 	s := &grpcServer{
 		xdsHandler{


### PR DESCRIPTION
Use grpc.Creds option to ask the gRPC server to create the TLS listener
rather than creating our own. This lets us do more setup work before
entering leader election. Once we are elected leader all there is to do
is to open the socker and serve.

Signed-off-by: Dave Cheney <dave@cheney.net>