### PR TITLE
Fix leader election config and TLS config loading of partial values.

### DIFF
--- a/cmd/contour/servecontext.go
+++ b/cmd/contour/servecontext.go
@@ -1,0 +1,225 @@
+// Copyright © 2019 Heptio
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"errors"
+	"io/ioutil"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/heptio/contour/internal/contour"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+)
+
+type serveContext struct {
+	// contour's kubernetes client parameters
+	InCluster  bool   `yaml:"incluster,omitempty"`
+	Kubeconfig string `yaml:"kubeconfig,omitempty"`
+
+	// contour's xds service parameters
+	xdsAddr                         string
+	xdsPort                         int
+	caFile, contourCert, contourKey string
+
+	// contour's debug handler parameters
+	debugAddr string
+	debugPort int
+
+	// contour's metrics handler parameters
+	metricsAddr string
+	metricsPort int
+
+	// ingressroute root namespaces
+	rootNamespaces string
+
+	// ingress class
+	ingressClass string
+
+	// envoy's stats listener parameters
+	statsAddr string
+	statsPort int
+
+	// envoy's listener parameters
+	useProxyProto bool
+
+	// envoy's http listener parameters
+	httpAddr      string
+	httpPort      int
+	httpAccessLog string
+
+	// envoy's https listener parameters
+	httpsAddr      string
+	httpsPort      int
+	httpsAccessLog string
+
+	// PermitInsecureGRPC disables TLS on Contour's gRPC listener.
+	PermitInsecureGRPC bool `yaml:"-"`
+
+	TLSConfig `yaml:"tls,omitempty"`
+
+	// DisablePermitInsecure disables the use of the
+	// permitInsecure field in IngressRoute.
+	DisablePermitInsecure bool `yaml:"disablePermitInsecure,omitempty"`
+
+	EnableLeaderElection bool
+	LeaderElectionConfig `yaml:"leaderelection,omitempty"`
+}
+
+// newServeContext returns a serveContext initialized to defaults.
+// Supply one or more functions to modify the defaults.
+func newServeContext(options ...func(*serveContext)) *serveContext {
+	// Set defaults for parameters which are then overridden via flags, ENV, or ConfigFile
+	ctx := serveContext{
+		Kubeconfig:            filepath.Join(os.Getenv("HOME"), ".kube", "config"),
+		xdsAddr:               "127.0.0.1",
+		xdsPort:               8001,
+		statsAddr:             "0.0.0.0",
+		statsPort:             8002,
+		debugAddr:             "127.0.0.1",
+		debugPort:             6060,
+		metricsAddr:           "0.0.0.0",
+		metricsPort:           8000,
+		httpAccessLog:         contour.DEFAULT_HTTP_ACCESS_LOG,
+		httpsAccessLog:        contour.DEFAULT_HTTPS_ACCESS_LOG,
+		httpAddr:              "0.0.0.0",
+		httpsAddr:             "0.0.0.0",
+		httpPort:              8080,
+		httpsPort:             8443,
+		PermitInsecureGRPC:    false,
+		DisablePermitInsecure: false,
+		EnableLeaderElection:  false,
+		LeaderElectionConfig:  *newLeaderElectionConfig(),
+	}
+
+	for _, option := range options {
+		option(&ctx)
+	}
+
+	return &ctx
+}
+
+// TLSConfig holds configuration file TLS configuration details.
+type TLSConfig struct {
+	MinimumProtocolVersion string `yaml:"minimum-protocol-version"`
+}
+
+// LeaderElectionConfig holds the config bits for leader election inside the
+// configuration file.
+type LeaderElectionConfig struct {
+	LeaseDuration time.Duration `yaml:"lease-duration,omitempty"`
+	RenewDeadline time.Duration `yaml:"renew-deadline,omitempty"`
+	RetryPeriod   time.Duration `yaml:"retry-period,omitempty"`
+	Namespace     string        `yaml:"configmap-namespace,omitempty"`
+	Name          string        `yaml:"configmap-name,omitempty"`
+}
+
+// newLeaderElectionConfig returns a defaulted LeaderElectionConfig. Pass option
+// functions to modify the defaults.
+func newLeaderElectionConfig(options ...func(*LeaderElectionConfig)) *LeaderElectionConfig {
+	lec := LeaderElectionConfig{
+		LeaseDuration: time.Second * 15,
+		RenewDeadline: time.Second * 10,
+		RetryPeriod:   time.Second * 2,
+		Namespace:     "heptio-contour",
+		Name:          "contour",
+	}
+
+	for _, option := range options {
+		option(&lec)
+	}
+
+	return &lec
+}
+
+// grpcOptions returns a slice of grpc.ServerOptions.
+// if ctx.PermitInsecureGRPC is false, the option set will
+// include TLS configuration.
+func (ctx *serveContext) grpcOptions() []grpc.ServerOption {
+	opts := []grpc.ServerOption{
+		// By default the Go grpc library defaults to a value of ~100 streams per
+		// connection. This number is likely derived from the HTTP/2 spec:
+		// https://http2.github.io/http2-spec/#SettingValues
+		// We need to raise this value because Envoy will open one EDS stream per
+		// CDS entry. There doesn't seem to be a penalty for increasing this value,
+		// so set it the limit similar to envoyproxy/go-control-plane#70.
+		//
+		// Somewhat arbitrary limit to handle many, many, EDS streams.
+		grpc.MaxConcurrentStreams(1 << 20),
+	}
+	if !ctx.PermitInsecureGRPC {
+		tlsconfig := ctx.tlsconfig()
+		creds := credentials.NewTLS(tlsconfig)
+		opts = append(opts, grpc.Creds(creds))
+	}
+	return opts
+}
+
+// tlsconfig returns a new *tls.Config. If the context is not properly configured
+// for tls communication, tlsconfig returns nil.
+func (ctx *serveContext) tlsconfig() *tls.Config {
+
+	err := ctx.verifyTLSFlags()
+	check(err)
+
+	cert, err := tls.LoadX509KeyPair(ctx.contourCert, ctx.contourKey)
+	check(err)
+
+	ca, err := ioutil.ReadFile(ctx.caFile)
+	check(err)
+
+	certPool := x509.NewCertPool()
+	if ok := certPool.AppendCertsFromPEM(ca); !ok {
+		log.Fatalf("unable to append certificate in %s to CA pool", ctx.caFile)
+	}
+
+	return &tls.Config{
+		Certificates: []tls.Certificate{cert},
+		ClientAuth:   tls.RequireAndVerifyClientCert,
+		ClientCAs:    certPool,
+		Rand:         rand.Reader,
+	}
+}
+
+// verifyTLSFlags indicates if the TLS flags are set up correctly.
+func (ctx *serveContext) verifyTLSFlags() error {
+	if ctx.caFile == "" && ctx.contourCert == "" && ctx.contourKey == "" {
+		return errors.New("no TLS parameters and --insecure not supplied. You must supply one or the other")
+	}
+	// If one of the three TLS commands is not empty, they all must be not empty
+	if !(ctx.caFile != "" && ctx.contourCert != "" && ctx.contourKey != "") {
+		return errors.New("you must supply all three TLS parameters - --contour-cafile, --contour-cert-file, --contour-key-file, or none of them")
+	}
+	return nil
+}
+
+// ingressRouteRootNamespaces returns a slice of namespaces restricting where
+// contour should look for ingressroute roots.
+func (ctx *serveContext) ingressRouteRootNamespaces() []string {
+	if strings.TrimSpace(ctx.rootNamespaces) == "" {
+		return nil
+	}
+	var ns []string
+	for _, s := range strings.Split(ctx.rootNamespaces, ",") {
+		ns = append(ns, strings.TrimSpace(s))
+	}
+	return ns
+}

--- a/cmd/contour/servecontext.go
+++ b/cmd/contour/servecontext.go
@@ -80,15 +80,17 @@ type serveContext struct {
 	// permitInsecure field in IngressRoute.
 	DisablePermitInsecure bool `yaml:"disablePermitInsecure,omitempty"`
 
-	EnableLeaderElection bool
+	// EnableLeaderElection should only be set by command line flag.
+	EnableLeaderElection bool `yaml:"-"`
+
+	// LeaderElectionConfig can be set in the config file.
 	LeaderElectionConfig `yaml:"leaderelection,omitempty"`
 }
 
 // newServeContext returns a serveContext initialized to defaults.
-// Supply one or more functions to modify the defaults.
-func newServeContext(options ...func(*serveContext)) *serveContext {
+func newServeContext() *serveContext {
 	// Set defaults for parameters which are then overridden via flags, ENV, or ConfigFile
-	ctx := serveContext{
+	return &serveContext{
 		Kubeconfig:            filepath.Join(os.Getenv("HOME"), ".kube", "config"),
 		xdsAddr:               "127.0.0.1",
 		xdsPort:               8001,
@@ -109,12 +111,6 @@ func newServeContext(options ...func(*serveContext)) *serveContext {
 		EnableLeaderElection:  false,
 		LeaderElectionConfig:  *newLeaderElectionConfig(),
 	}
-
-	for _, option := range options {
-		option(&ctx)
-	}
-
-	return &ctx
 }
 
 // TLSConfig holds configuration file TLS configuration details.
@@ -132,22 +128,15 @@ type LeaderElectionConfig struct {
 	Name          string        `yaml:"configmap-name,omitempty"`
 }
 
-// newLeaderElectionConfig returns a defaulted LeaderElectionConfig. Pass option
-// functions to modify the defaults.
-func newLeaderElectionConfig(options ...func(*LeaderElectionConfig)) *LeaderElectionConfig {
-	lec := LeaderElectionConfig{
+// newLeaderElectionConfig returns a defaulted LeaderElectionConfig.
+func newLeaderElectionConfig() *LeaderElectionConfig {
+	return &LeaderElectionConfig{
 		LeaseDuration: time.Second * 15,
 		RenewDeadline: time.Second * 10,
 		RetryPeriod:   time.Second * 2,
 		Namespace:     "heptio-contour",
 		Name:          "contour",
 	}
-
-	for _, option := range options {
-		option(&lec)
-	}
-
-	return &lec
 }
 
 // grpcOptions returns a slice of grpc.ServerOptions.

--- a/cmd/contour/servecontext.go
+++ b/cmd/contour/servecontext.go
@@ -109,7 +109,13 @@ func newServeContext() *serveContext {
 		PermitInsecureGRPC:    false,
 		DisablePermitInsecure: false,
 		EnableLeaderElection:  false,
-		LeaderElectionConfig:  *newLeaderElectionConfig(),
+		LeaderElectionConfig: LeaderElectionConfig{
+			LeaseDuration: time.Second * 15,
+			RenewDeadline: time.Second * 10,
+			RetryPeriod:   time.Second * 2,
+			Namespace:     "heptio-contour",
+			Name:          "contour",
+		},
 	}
 }
 
@@ -126,17 +132,6 @@ type LeaderElectionConfig struct {
 	RetryPeriod   time.Duration `yaml:"retry-period,omitempty"`
 	Namespace     string        `yaml:"configmap-namespace,omitempty"`
 	Name          string        `yaml:"configmap-name,omitempty"`
-}
-
-// newLeaderElectionConfig returns a defaulted LeaderElectionConfig.
-func newLeaderElectionConfig() *LeaderElectionConfig {
-	return &LeaderElectionConfig{
-		LeaseDuration: time.Second * 15,
-		RenewDeadline: time.Second * 10,
-		RetryPeriod:   time.Second * 2,
-		Namespace:     "heptio-contour",
-		Name:          "contour",
-	}
 }
 
 // grpcOptions returns a slice of grpc.ServerOptions.

--- a/cmd/contour/servecontext_test.go
+++ b/cmd/contour/servecontext_test.go
@@ -107,15 +107,15 @@ func TestServeContextTLSParams(t *testing.T) {
 
 func TestConfigFileDefaultOverrideImport(t *testing.T) {
 	tests := map[string]struct {
-		yamlIn []byte
+		yamlIn string
 		want   func() *serveContext
 	}{
 		"empty configuration": {
-			yamlIn: []byte(``),
+			yamlIn: ``,
 			want:   newServeContext,
 		},
 		"defaults in yaml": {
-			yamlIn: []byte(`
+			yamlIn: `
 incluster: false
 disablePermitInsecure: false
 leaderelection:
@@ -124,34 +124,32 @@ leaderelection:
   lease-duration: 15s
   renew-deadline: 10s
   retry-period: 2s
-`),
+`,
 			want: newServeContext,
 		},
 		"blank tls configuration": {
-			yamlIn: []byte(`
+			yamlIn: `
 tls:
-`),
+`,
 			want: newServeContext,
 		},
 		"tls configuration only": {
-			yamlIn: []byte(`
+			yamlIn: `
 tls:
   minimum-protocol-version: 1.2
-`),
+`,
 			want: func() *serveContext {
 				ctx := newServeContext()
-				ctx.TLSConfig = TLSConfig{
-					MinimumProtocolVersion: "1.2",
-				}
+				ctx.TLSConfig.MinimumProtocolVersion = "1.2"
 				return ctx
 			},
 		},
 		"leader election namespace and configmap only": {
-			yamlIn: []byte(`
+			yamlIn: `
 leaderelection:
   configmap-name: foo
   configmap-namespace: bar
-`),
+`,
 			want: func() *serveContext {
 				ctx := newServeContext()
 				ctx.LeaderElectionConfig.Name = "foo"
@@ -160,14 +158,14 @@ leaderelection:
 			},
 		},
 		"leader election all fields set": {
-			yamlIn: []byte(`
+			yamlIn: `
 leaderelection:
   configmap-name: foo
   configmap-namespace: bar
   lease-duration: 600s
   renew-deadline: 500s
   retry-period: 60s
-`),
+`,
 			want: func() *serveContext {
 				ctx := newServeContext()
 				ctx.LeaderElectionConfig.Name = "foo"
@@ -182,7 +180,7 @@ leaderelection:
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			got := newServeContext()
-			err := yaml.Unmarshal(tc.yamlIn, got)
+			err := yaml.Unmarshal([]byte(tc.yamlIn), got)
 			checkErr(t, err)
 			want := tc.want()
 

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/envoyproxy/go-control-plane v0.8.3
 	github.com/envoyproxy/protoc-gen-validate v0.0.14 // indirect
 	github.com/evanphx/json-patch v4.1.0+incompatible
+	github.com/go-test/deep v1.0.3
 	github.com/gogo/protobuf v1.2.1
 	github.com/golang/groupcache v0.0.0-20190129154638-5b532d6fd5ef // indirect
 	github.com/google/go-cmp v0.3.1

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,6 @@ require (
 	github.com/envoyproxy/go-control-plane v0.8.3
 	github.com/envoyproxy/protoc-gen-validate v0.0.14 // indirect
 	github.com/evanphx/json-patch v4.1.0+incompatible
-	github.com/go-test/deep v1.0.3
 	github.com/gogo/protobuf v1.2.1
 	github.com/golang/groupcache v0.0.0-20190129154638-5b532d6fd5ef // indirect
 	github.com/google/go-cmp v0.3.1


### PR DESCRIPTION
Fixes #1367

Also add some tests for the YAML parsing of the config file.

Changed those tests to use `github.com/go-test/deep` so I could actually find the errors.

Signed-off-by: Nick Young <ynick@vmware.com>