### PR TITLE
internal/builder: cleanup buildDAG

### DIFF
--- a/internal/contour/cluster_test.go
+++ b/internal/contour/cluster_test.go
@@ -196,10 +196,7 @@ func TestClusterVisit(t *testing.T) {
 						Namespace: "default",
 					},
 					Spec: v1beta1.IngressSpec{
-						Backend: &v1beta1.IngressBackend{
-							ServiceName: "kuard",
-							ServicePort: intstr.FromInt(443),
-						},
+						Backend: backend("kuard", 443),
 					},
 				},
 				service("default", "kuard",
@@ -312,10 +309,7 @@ func TestClusterVisit(t *testing.T) {
 						Namespace: "beurocratic-company-test-domain-1",
 					},
 					Spec: v1beta1.IngressSpec{
-						Backend: &v1beta1.IngressBackend{
-							ServiceName: "tiny-cog-department-test-instance",
-							ServicePort: intstr.FromInt(443),
-						},
+						Backend: backend("tiny-cog-department-test-instance", 443),
 					},
 				},
 				service("beurocratic-company-test-domain-1", "tiny-cog-department-test-instance",

--- a/internal/contour/listener_test.go
+++ b/internal/contour/listener_test.go
@@ -26,7 +26,6 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/api/extensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
 func TestListenerCacheContents(t *testing.T) {
@@ -143,10 +142,7 @@ func TestListenerVisit(t *testing.T) {
 						Namespace: "default",
 					},
 					Spec: v1beta1.IngressSpec{
-						Backend: &v1beta1.IngressBackend{
-							ServiceName: "kuard",
-							ServicePort: intstr.FromInt(8080),
-						},
+						Backend: backend("kuard", 8080),
 					},
 				},
 				&v1.Service{
@@ -222,10 +218,7 @@ func TestListenerVisit(t *testing.T) {
 							Hosts:      []string{"whatever.example.com"},
 							SecretName: "secret",
 						}},
-						Backend: &v1beta1.IngressBackend{
-							ServiceName: "kuard",
-							ServicePort: intstr.FromInt(8080),
-						},
+						Backend: backend("kuard", 8080),
 					},
 				},
 				&v1.Secret{
@@ -281,10 +274,7 @@ func TestListenerVisit(t *testing.T) {
 							Hosts:      []string{"sortedsecond.example.com"},
 							SecretName: "secret",
 						}},
-						Backend: &v1beta1.IngressBackend{
-							ServiceName: "kuard",
-							ServicePort: intstr.FromInt(8080),
-						},
+						Backend: backend("kuard", 8080),
 					},
 				},
 				&v1beta1.Ingress{
@@ -297,10 +287,7 @@ func TestListenerVisit(t *testing.T) {
 							Hosts:      []string{"sortedfirst.example.com"},
 							SecretName: "secret",
 						}},
-						Backend: &v1beta1.IngressBackend{
-							ServiceName: "kuard",
-							ServicePort: intstr.FromInt(8080),
-						},
+						Backend: backend("kuard", 8080),
 					},
 				},
 				&v1.Secret{
@@ -362,10 +349,7 @@ func TestListenerVisit(t *testing.T) {
 							Hosts:      []string{"whatever.example.com"},
 							SecretName: "missing",
 						}},
-						Backend: &v1beta1.IngressBackend{
-							ServiceName: "kuard",
-							ServicePort: intstr.FromInt(8080),
-						},
+						Backend: backend("kuard", 8080),
 					},
 				},
 				&v1.Secret{
@@ -474,10 +458,7 @@ func TestListenerVisit(t *testing.T) {
 						},
 					},
 					Spec: v1beta1.IngressSpec{
-						Backend: &v1beta1.IngressBackend{
-							ServiceName: "kuard",
-							ServicePort: intstr.FromInt(8080),
-						},
+						Backend: backend("kuard", 8080),
 					},
 				},
 			},
@@ -498,10 +479,7 @@ func TestListenerVisit(t *testing.T) {
 							Hosts:      []string{"www.example.com"},
 							SecretName: "secret",
 						}},
-						Backend: &v1beta1.IngressBackend{
-							ServiceName: "kuard",
-							ServicePort: intstr.FromInt(8080),
-						},
+						Backend: backend("kuard", 8080),
 					},
 				},
 				&v1.Secret{
@@ -546,10 +524,7 @@ func TestListenerVisit(t *testing.T) {
 							Hosts:      []string{"whatever.example.com"},
 							SecretName: "secret",
 						}},
-						Backend: &v1beta1.IngressBackend{
-							ServiceName: "kuard",
-							ServicePort: intstr.FromInt(8080),
-						},
+						Backend: backend("kuard", 8080),
 					},
 				},
 				&v1.Secret{
@@ -608,10 +583,7 @@ func TestListenerVisit(t *testing.T) {
 							Hosts:      []string{"whatever.example.com"},
 							SecretName: "secret",
 						}},
-						Backend: &v1beta1.IngressBackend{
-							ServiceName: "kuard",
-							ServicePort: intstr.FromInt(8080),
-						},
+						Backend: backend("kuard", 8080),
 					},
 				},
 				&v1.Secret{
@@ -675,10 +647,7 @@ func TestListenerVisit(t *testing.T) {
 							Hosts:      []string{"whatever.example.com"},
 							SecretName: "secret",
 						}},
-						Backend: &v1beta1.IngressBackend{
-							ServiceName: "kuard",
-							ServicePort: intstr.FromInt(8080),
-						},
+						Backend: backend("kuard", 8080),
 					},
 				},
 				&v1.Secret{
@@ -737,10 +706,7 @@ func TestListenerVisit(t *testing.T) {
 							Hosts:      []string{"whatever.example.com"},
 							SecretName: "secret",
 						}},
-						Backend: &v1beta1.IngressBackend{
-							ServiceName: "kuard",
-							ServicePort: intstr.FromInt(8080),
-						},
+						Backend: backend("kuard", 8080),
 					},
 				},
 				&v1.Secret{
@@ -802,10 +768,7 @@ func TestListenerVisit(t *testing.T) {
 							Hosts:      []string{"whatever.example.com"},
 							SecretName: "secret",
 						}},
-						Backend: &v1beta1.IngressBackend{
-							ServiceName: "kuard",
-							ServicePort: intstr.FromInt(8080),
-						},
+						Backend: backend("kuard", 8080),
 					},
 				},
 				&v1.Secret{

--- a/internal/contour/route_test.go
+++ b/internal/contour/route_test.go
@@ -157,10 +157,7 @@ func TestRouteVisit(t *testing.T) {
 						Namespace: "default",
 					},
 					Spec: v1beta1.IngressSpec{
-						Backend: &v1beta1.IngressBackend{
-							ServiceName: "kuard",
-							ServicePort: intstr.FromInt(8080),
-						},
+						Backend: backend("kuard", 8080),
 					},
 				},
 				&v1.Service{
@@ -316,10 +313,7 @@ func TestRouteVisit(t *testing.T) {
 							Hosts:      []string{"whatever.example.com"},
 							SecretName: "secret",
 						}},
-						Backend: &v1beta1.IngressBackend{
-							ServiceName: "kuard",
-							ServicePort: intstr.FromInt(8080),
-						},
+						Backend: backend("kuard", 8080),
 					},
 				},
 				&v1.Secret{
@@ -755,10 +749,7 @@ func TestRouteVisit(t *testing.T) {
 						},
 					},
 					Spec: v1beta1.IngressSpec{
-						Backend: &v1beta1.IngressBackend{
-							ServiceName: "kuard",
-							ServicePort: intstr.FromInt(8080),
-						},
+						Backend: backend("kuard", 8080),
 					},
 				},
 				&v1.Service{
@@ -804,10 +795,7 @@ func TestRouteVisit(t *testing.T) {
 						},
 					},
 					Spec: v1beta1.IngressSpec{
-						Backend: &v1beta1.IngressBackend{
-							ServiceName: "kuard",
-							ServicePort: intstr.FromInt(8080),
-						},
+						Backend: backend("kuard", 8080),
 					},
 				},
 				&v1.Service{
@@ -853,10 +841,7 @@ func TestRouteVisit(t *testing.T) {
 						},
 					},
 					Spec: v1beta1.IngressSpec{
-						Backend: &v1beta1.IngressBackend{
-							ServiceName: "kuard",
-							ServicePort: intstr.FromInt(8080),
-						},
+						Backend: backend("kuard", 8080),
 					},
 				},
 				&v1.Service{
@@ -959,10 +944,7 @@ func TestRouteVisit(t *testing.T) {
 						},
 					},
 					Spec: v1beta1.IngressSpec{
-						Backend: &v1beta1.IngressBackend{
-							ServiceName: "kuard",
-							ServicePort: intstr.FromInt(8080),
-						},
+						Backend: backend("kuard", 8080),
 					},
 				},
 				&v1.Service{
@@ -1009,10 +991,7 @@ func TestRouteVisit(t *testing.T) {
 						},
 					},
 					Spec: v1beta1.IngressSpec{
-						Backend: &v1beta1.IngressBackend{
-							ServiceName: "kuard",
-							ServicePort: intstr.FromInt(8080),
-						},
+						Backend: backend("kuard", 8080),
 					},
 				},
 				&v1.Service{
@@ -1059,10 +1038,7 @@ func TestRouteVisit(t *testing.T) {
 						},
 					},
 					Spec: v1beta1.IngressSpec{
-						Backend: &v1beta1.IngressBackend{
-							ServiceName: "kuard",
-							ServicePort: intstr.FromInt(8080),
-						},
+						Backend: backend("kuard", 8080),
 					},
 				},
 				&v1.Service{

--- a/internal/contour/secret_test.go
+++ b/internal/contour/secret_test.go
@@ -135,10 +135,7 @@ func TestSecretVisit(t *testing.T) {
 							Hosts:      []string{"whatever.example.com"},
 							SecretName: "secret",
 						}},
-						Backend: &v1beta1.IngressBackend{
-							ServiceName: "kuard",
-							ServicePort: intstr.FromInt(8080),
-						},
+						Backend: backend("kuard", 8080),
 					},
 				},
 				tlssecret("default", "secret", secretdata("cert", "key")),
@@ -173,10 +170,7 @@ func TestSecretVisit(t *testing.T) {
 							Hosts:      []string{"whatever.example.com"},
 							SecretName: "secret",
 						}},
-						Backend: &v1beta1.IngressBackend{
-							ServiceName: "kuard",
-							ServicePort: intstr.FromInt(8080),
-						},
+						Backend: backend("kuard", 8080),
 					},
 				},
 				&v1beta1.Ingress{
@@ -189,10 +183,7 @@ func TestSecretVisit(t *testing.T) {
 							Hosts:      []string{"omg.example.com"},
 							SecretName: "secret",
 						}},
-						Backend: &v1beta1.IngressBackend{
-							ServiceName: "kuard",
-							ServicePort: intstr.FromInt(8080),
-						},
+						Backend: backend("kuard", 8080),
 					},
 				},
 				tlssecret("default", "secret", secretdata("cert", "key")),
@@ -227,10 +218,7 @@ func TestSecretVisit(t *testing.T) {
 							Hosts:      []string{"whatever.example.com"},
 							SecretName: "secret-a",
 						}},
-						Backend: &v1beta1.IngressBackend{
-							ServiceName: "kuard",
-							ServicePort: intstr.FromInt(8080),
-						},
+						Backend: backend("kuard", 8080),
 					},
 				},
 				&v1beta1.Ingress{
@@ -243,10 +231,7 @@ func TestSecretVisit(t *testing.T) {
 							Hosts:      []string{"omg.example.com"},
 							SecretName: "secret-b",
 						}},
-						Backend: &v1beta1.IngressBackend{
-							ServiceName: "kuard",
-							ServicePort: intstr.FromInt(8080),
-						},
+						Backend: backend("kuard", 8080),
 					},
 				},
 				tlssecret("default", "secret-a", secretdata("cert-a", "key-a")),
@@ -484,5 +469,12 @@ func tlssecret(namespace, name string, data map[string][]byte) *v1.Secret {
 		},
 		Type: v1.SecretTypeTLS,
 		Data: data,
+	}
+}
+
+func backend(name string, port int) *v1beta1.IngressBackend {
+	return &v1beta1.IngressBackend{
+		ServiceName: name,
+		ServicePort: intstr.FromInt(port),
 	}
 }


### PR DESCRIPTION
Updates #1165

Clean up buildDAG, also add a helper to reduce the size of the
internal/contour unit tests.

Signed-off-by: Dave Cheney <dave@cheney.net>