### PR TITLE
internal/{contour,e2e}: fix invalid tls enable ingress fixtures

### DIFF
--- a/internal/contour/listener_test.go
+++ b/internal/contour/listener_test.go
@@ -218,7 +218,16 @@ func TestListenerVisit(t *testing.T) {
 							Hosts:      []string{"whatever.example.com"},
 							SecretName: "secret",
 						}},
-						Backend: backend("kuard", 8080),
+						Rules: []v1beta1.IngressRule{{
+							Host: "whatever.example.com",
+							IngressRuleValue: v1beta1.IngressRuleValue{
+								HTTP: &v1beta1.HTTPIngressRuleValue{
+									Paths: []v1beta1.HTTPIngressPath{{
+										Backend: *backend("kuard", 8080),
+									}},
+								},
+							},
+						}},
 					},
 				},
 				&v1.Secret{
@@ -274,7 +283,16 @@ func TestListenerVisit(t *testing.T) {
 							Hosts:      []string{"sortedsecond.example.com"},
 							SecretName: "secret",
 						}},
-						Backend: backend("kuard", 8080),
+						Rules: []v1beta1.IngressRule{{
+							Host: "sortedsecond.example.com",
+							IngressRuleValue: v1beta1.IngressRuleValue{
+								HTTP: &v1beta1.HTTPIngressRuleValue{
+									Paths: []v1beta1.HTTPIngressPath{{
+										Backend: *backend("kuard", 8080),
+									}},
+								},
+							},
+						}},
 					},
 				},
 				&v1beta1.Ingress{
@@ -287,7 +305,16 @@ func TestListenerVisit(t *testing.T) {
 							Hosts:      []string{"sortedfirst.example.com"},
 							SecretName: "secret",
 						}},
-						Backend: backend("kuard", 8080),
+						Rules: []v1beta1.IngressRule{{
+							Host: "sortedfirst.example.com",
+							IngressRuleValue: v1beta1.IngressRuleValue{
+								HTTP: &v1beta1.HTTPIngressRuleValue{
+									Paths: []v1beta1.HTTPIngressPath{{
+										Backend: *backend("kuard", 8080),
+									}},
+								},
+							},
+						}},
 					},
 				},
 				&v1.Secret{
@@ -349,7 +376,16 @@ func TestListenerVisit(t *testing.T) {
 							Hosts:      []string{"whatever.example.com"},
 							SecretName: "missing",
 						}},
-						Backend: backend("kuard", 8080),
+						Rules: []v1beta1.IngressRule{{
+							Host: "whatever.example.com",
+							IngressRuleValue: v1beta1.IngressRuleValue{
+								HTTP: &v1beta1.HTTPIngressRuleValue{
+									Paths: []v1beta1.HTTPIngressPath{{
+										Backend: *backend("kuard", 8080),
+									}},
+								},
+							},
+						}},
 					},
 				},
 				&v1.Secret{
@@ -479,7 +515,16 @@ func TestListenerVisit(t *testing.T) {
 							Hosts:      []string{"www.example.com"},
 							SecretName: "secret",
 						}},
-						Backend: backend("kuard", 8080),
+						Rules: []v1beta1.IngressRule{{
+							Host: "www.example.com",
+							IngressRuleValue: v1beta1.IngressRuleValue{
+								HTTP: &v1beta1.HTTPIngressRuleValue{
+									Paths: []v1beta1.HTTPIngressPath{{
+										Backend: *backend("kuard", 8080),
+									}},
+								},
+							},
+						}},
 					},
 				},
 				&v1.Secret{
@@ -489,6 +534,19 @@ func TestListenerVisit(t *testing.T) {
 					},
 					Type: "kubernetes.io/tls",
 					Data: secretdata("certificate", "key"),
+				},
+				&v1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "kuard",
+						Namespace: "default",
+					},
+					Spec: v1.ServiceSpec{
+						Ports: []v1.ServicePort{{
+							Name:     "http",
+							Protocol: "TCP",
+							Port:     8080,
+						}},
+					},
 				},
 			},
 			want: listenermap(&v2.Listener{
@@ -524,7 +582,16 @@ func TestListenerVisit(t *testing.T) {
 							Hosts:      []string{"whatever.example.com"},
 							SecretName: "secret",
 						}},
-						Backend: backend("kuard", 8080),
+						Rules: []v1beta1.IngressRule{{
+							Host: "whatever.example.com",
+							IngressRuleValue: v1beta1.IngressRuleValue{
+								HTTP: &v1beta1.HTTPIngressRuleValue{
+									Paths: []v1beta1.HTTPIngressPath{{
+										Backend: *backend("kuard", 8080),
+									}},
+								},
+							},
+						}},
 					},
 				},
 				&v1.Secret{
@@ -583,7 +650,16 @@ func TestListenerVisit(t *testing.T) {
 							Hosts:      []string{"whatever.example.com"},
 							SecretName: "secret",
 						}},
-						Backend: backend("kuard", 8080),
+						Rules: []v1beta1.IngressRule{{
+							Host: "whatever.example.com",
+							IngressRuleValue: v1beta1.IngressRuleValue{
+								HTTP: &v1beta1.HTTPIngressRuleValue{
+									Paths: []v1beta1.HTTPIngressPath{{
+										Backend: *backend("kuard", 8080),
+									}},
+								},
+							},
+						}},
 					},
 				},
 				&v1.Secret{
@@ -647,7 +723,16 @@ func TestListenerVisit(t *testing.T) {
 							Hosts:      []string{"whatever.example.com"},
 							SecretName: "secret",
 						}},
-						Backend: backend("kuard", 8080),
+						Rules: []v1beta1.IngressRule{{
+							Host: "whatever.example.com",
+							IngressRuleValue: v1beta1.IngressRuleValue{
+								HTTP: &v1beta1.HTTPIngressRuleValue{
+									Paths: []v1beta1.HTTPIngressPath{{
+										Backend: *backend("kuard", 8080),
+									}},
+								},
+							},
+						}},
 					},
 				},
 				&v1.Secret{
@@ -706,7 +791,16 @@ func TestListenerVisit(t *testing.T) {
 							Hosts:      []string{"whatever.example.com"},
 							SecretName: "secret",
 						}},
-						Backend: backend("kuard", 8080),
+						Rules: []v1beta1.IngressRule{{
+							Host: "whatever.example.com",
+							IngressRuleValue: v1beta1.IngressRuleValue{
+								HTTP: &v1beta1.HTTPIngressRuleValue{
+									Paths: []v1beta1.HTTPIngressPath{{
+										Backend: *backend("kuard", 8080),
+									}},
+								},
+							},
+						}},
 					},
 				},
 				&v1.Secret{
@@ -768,7 +862,16 @@ func TestListenerVisit(t *testing.T) {
 							Hosts:      []string{"whatever.example.com"},
 							SecretName: "secret",
 						}},
-						Backend: backend("kuard", 8080),
+						Rules: []v1beta1.IngressRule{{
+							Host: "whatever.example.com",
+							IngressRuleValue: v1beta1.IngressRuleValue{
+								HTTP: &v1beta1.HTTPIngressRuleValue{
+									Paths: []v1beta1.HTTPIngressPath{{
+										Backend: *backend("kuard", 8080),
+									}},
+								},
+							},
+						}},
 					},
 				},
 				&v1.Secret{

--- a/internal/contour/secret_test.go
+++ b/internal/contour/secret_test.go
@@ -135,7 +135,16 @@ func TestSecretVisit(t *testing.T) {
 							Hosts:      []string{"whatever.example.com"},
 							SecretName: "secret",
 						}},
-						Backend: backend("kuard", 8080),
+						Rules: []v1beta1.IngressRule{{
+							Host: "whatever.example.com",
+							IngressRuleValue: v1beta1.IngressRuleValue{
+								HTTP: &v1beta1.HTTPIngressRuleValue{
+									Paths: []v1beta1.HTTPIngressPath{{
+										Backend: *backend("kuard", 8080),
+									}},
+								},
+							},
+						}},
 					},
 				},
 				tlssecret("default", "secret", secretdata("cert", "key")),
@@ -170,7 +179,16 @@ func TestSecretVisit(t *testing.T) {
 							Hosts:      []string{"whatever.example.com"},
 							SecretName: "secret",
 						}},
-						Backend: backend("kuard", 8080),
+						Rules: []v1beta1.IngressRule{{
+							Host: "whatever.example.com",
+							IngressRuleValue: v1beta1.IngressRuleValue{
+								HTTP: &v1beta1.HTTPIngressRuleValue{
+									Paths: []v1beta1.HTTPIngressPath{{
+										Backend: *backend("kuard", 8080),
+									}},
+								},
+							},
+						}},
 					},
 				},
 				&v1beta1.Ingress{
@@ -183,7 +201,16 @@ func TestSecretVisit(t *testing.T) {
 							Hosts:      []string{"omg.example.com"},
 							SecretName: "secret",
 						}},
-						Backend: backend("kuard", 8080),
+						Rules: []v1beta1.IngressRule{{
+							Host: "omg.example.com",
+							IngressRuleValue: v1beta1.IngressRuleValue{
+								HTTP: &v1beta1.HTTPIngressRuleValue{
+									Paths: []v1beta1.HTTPIngressPath{{
+										Backend: *backend("kuard", 8080),
+									}},
+								},
+							},
+						}},
 					},
 				},
 				tlssecret("default", "secret", secretdata("cert", "key")),
@@ -218,7 +245,16 @@ func TestSecretVisit(t *testing.T) {
 							Hosts:      []string{"whatever.example.com"},
 							SecretName: "secret-a",
 						}},
-						Backend: backend("kuard", 8080),
+						Rules: []v1beta1.IngressRule{{
+							Host: "whatever.example.com",
+							IngressRuleValue: v1beta1.IngressRuleValue{
+								HTTP: &v1beta1.HTTPIngressRuleValue{
+									Paths: []v1beta1.HTTPIngressPath{{
+										Backend: *backend("kuard", 80),
+									}},
+								},
+							},
+						}},
 					},
 				},
 				&v1beta1.Ingress{
@@ -231,7 +267,16 @@ func TestSecretVisit(t *testing.T) {
 							Hosts:      []string{"omg.example.com"},
 							SecretName: "secret-b",
 						}},
-						Backend: backend("kuard", 8080),
+						Rules: []v1beta1.IngressRule{{
+							Host: "omg.example.com",
+							IngressRuleValue: v1beta1.IngressRuleValue{
+								HTTP: &v1beta1.HTTPIngressRuleValue{
+									Paths: []v1beta1.HTTPIngressPath{{
+										Backend: *backend("kuard", 80),
+									}},
+								},
+							},
+						}},
 					},
 				},
 				tlssecret("default", "secret-a", secretdata("cert-a", "key-a")),

--- a/internal/e2e/lds_test.go
+++ b/internal/e2e/lds_test.go
@@ -172,10 +172,19 @@ func TestTLSListener(t *testing.T) {
 			Namespace: "default",
 		},
 		Spec: v1beta1.IngressSpec{
-			Backend: backend("backend", intstr.FromInt(80)),
 			TLS: []v1beta1.IngressTLS{{
 				Hosts:      []string{"kuard.example.com"},
 				SecretName: "secret",
+			}},
+			Rules: []v1beta1.IngressRule{{
+				Host: "kuard.example.com",
+				IngressRuleValue: v1beta1.IngressRuleValue{
+					HTTP: &v1beta1.HTTPIngressRuleValue{
+						Paths: []v1beta1.HTTPIngressPath{{
+							Backend: *backend("backend", intstr.FromInt(80)),
+						}},
+					},
+				},
 			}},
 		},
 	}
@@ -241,10 +250,19 @@ func TestTLSListener(t *testing.T) {
 			},
 		},
 		Spec: v1beta1.IngressSpec{
-			Backend: backend("backend", intstr.FromInt(80)),
 			TLS: []v1beta1.IngressTLS{{
 				Hosts:      []string{"kuard.example.com"},
 				SecretName: "secret",
+			}},
+			Rules: []v1beta1.IngressRule{{
+				Host: "kuard.example.com",
+				IngressRuleValue: v1beta1.IngressRuleValue{
+					HTTP: &v1beta1.HTTPIngressRuleValue{
+						Paths: []v1beta1.HTTPIngressPath{{
+							Backend: *backend("backend", intstr.FromInt(80)),
+						}},
+					},
+				},
 			}},
 		},
 	}
@@ -482,10 +500,19 @@ func TestLDSFilter(t *testing.T) {
 			Namespace: "default",
 		},
 		Spec: v1beta1.IngressSpec{
-			Backend: backend("backend", intstr.FromInt(80)),
 			TLS: []v1beta1.IngressTLS{{
 				Hosts:      []string{"kuard.example.com"},
 				SecretName: "secret",
+			}},
+			Rules: []v1beta1.IngressRule{{
+				Host: "kuard.example.com",
+				IngressRuleValue: v1beta1.IngressRuleValue{
+					HTTP: &v1beta1.HTTPIngressRuleValue{
+						Paths: []v1beta1.HTTPIngressPath{{
+							Backend: *backend("backend", intstr.FromInt(80)),
+						}},
+					},
+				},
 			}},
 		},
 	}
@@ -586,13 +613,36 @@ func TestLDSTLSMinimumProtocolVersion(t *testing.T) {
 			Namespace: "default",
 		},
 		Spec: v1beta1.IngressSpec{
-			Backend: backend("backend", intstr.FromInt(80)),
 			TLS: []v1beta1.IngressTLS{{
 				Hosts:      []string{"kuard.example.com"},
 				SecretName: "secret",
 			}},
+			Rules: []v1beta1.IngressRule{{
+				Host: "kuard.example.com",
+				IngressRuleValue: v1beta1.IngressRuleValue{
+					HTTP: &v1beta1.HTTPIngressRuleValue{
+						Paths: []v1beta1.HTTPIngressPath{{
+							Backend: *backend("backend", intstr.FromInt(80)),
+						}},
+					},
+				},
+			}},
 		},
 	}
+
+	rh.OnAdd(&v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "backend",
+			Namespace: "default",
+		},
+		Spec: v1.ServiceSpec{
+			Ports: []v1.ServicePort{{
+				Name:     "http",
+				Protocol: "TCP",
+				Port:     80,
+			}},
+		},
+	})
 
 	rh.OnAdd(i1)
 
@@ -623,10 +673,19 @@ func TestLDSTLSMinimumProtocolVersion(t *testing.T) {
 			},
 		},
 		Spec: v1beta1.IngressSpec{
-			Backend: backend("backend", intstr.FromInt(80)),
 			TLS: []v1beta1.IngressTLS{{
 				Hosts:      []string{"kuard.example.com"},
 				SecretName: "secret",
+			}},
+			Rules: []v1beta1.IngressRule{{
+				Host: "kuard.example.com",
+				IngressRuleValue: v1beta1.IngressRuleValue{
+					HTTP: &v1beta1.HTTPIngressRuleValue{
+						Paths: []v1beta1.HTTPIngressPath{{
+							Backend: *backend("backend", intstr.FromInt(80)),
+						}},
+					},
+				},
 			}},
 		},
 	}
@@ -743,10 +802,19 @@ func TestLDSIngressHTTPSUseProxyProtocol(t *testing.T) {
 			Namespace: "default",
 		},
 		Spec: v1beta1.IngressSpec{
-			Backend: backend("backend", intstr.FromInt(80)),
 			TLS: []v1beta1.IngressTLS{{
 				Hosts:      []string{"kuard.example.com"},
 				SecretName: "secret",
+			}},
+			Rules: []v1beta1.IngressRule{{
+				Host: "kuard.example.com",
+				IngressRuleValue: v1beta1.IngressRuleValue{
+					HTTP: &v1beta1.HTTPIngressRuleValue{
+						Paths: []v1beta1.HTTPIngressPath{{
+							Backend: *backend("backend", intstr.FromInt(80)),
+						}},
+					},
+				},
 			}},
 		},
 	}
@@ -839,10 +907,19 @@ func TestLDSCustomAddressAndPort(t *testing.T) {
 			Namespace: "default",
 		},
 		Spec: v1beta1.IngressSpec{
-			Backend: backend("backend", intstr.FromInt(80)),
 			TLS: []v1beta1.IngressTLS{{
 				Hosts:      []string{"kuard.example.com"},
 				SecretName: "secret",
+			}},
+			Rules: []v1beta1.IngressRule{{
+				Host: "kuard.example.com",
+				IngressRuleValue: v1beta1.IngressRuleValue{
+					HTTP: &v1beta1.HTTPIngressRuleValue{
+						Paths: []v1beta1.HTTPIngressPath{{
+							Backend: *backend("backend", intstr.FromInt(80)),
+						}},
+					},
+				},
 			}},
 		},
 	}
@@ -932,10 +1009,19 @@ func TestLDSCustomAccessLogPaths(t *testing.T) {
 			Namespace: "default",
 		},
 		Spec: v1beta1.IngressSpec{
-			Backend: backend("backend", intstr.FromInt(80)),
 			TLS: []v1beta1.IngressTLS{{
 				Hosts:      []string{"kuard.example.com"},
 				SecretName: "secret",
+			}},
+			Rules: []v1beta1.IngressRule{{
+				Host: "kuard.example.com",
+				IngressRuleValue: v1beta1.IngressRuleValue{
+					HTTP: &v1beta1.HTTPIngressRuleValue{
+						Paths: []v1beta1.HTTPIngressPath{{
+							Backend: *backend("backend", intstr.FromInt(80)),
+						}},
+					},
+				},
 			}},
 		},
 	}


### PR DESCRIPTION
Updates #1165

The logic for a TLS enabled v1beta1.Ingress says that each path must
have a hostname. This means that a `spec.backend` cannot be served over
HTTPS, even at / because it lacks a hostname to match it up with its
companion `spec.tls.hostname`.

The internal/dag tests correctly tested for this, however due to #1165
the fixtures in internal/contour and internal/e2e used `spec.backend`
incorrectly. These created virtualhosts _with_ a child secret, but no
routes. These virtualhosts would be filtered out before reaching the RDS
tables, however they were correct enough to trigger the behaviour we
wanted to test in SDS and LDS.

This PR corrects the fixtures to use the correct `spec.rule.host` form.
The next PR will address #1165.

Signed-off-by: Dave Cheney <dave@cheney.net>