### PR TITLE
internal/dag: filter out secure virtual hosts without routes

### DIFF
--- a/internal/dag/builder_test.go
+++ b/internal/dag/builder_test.go
@@ -1642,14 +1642,7 @@ func TestDAGInsert(t *testing.T) {
 				sec1,
 				i3,
 			},
-			want: listeners(
-				&Listener{
-					Port: 443,
-					VirtualHosts: virtualhosts(
-						securevirtualhost("kuard.example.com", sec1),
-					),
-				},
-			),
+			want: listeners(),
 		},
 		"insert service, secret then ingress w/ tls": {
 			objs: []interface{}{

--- a/internal/dag/dag.go
+++ b/internal/dag/dag.go
@@ -186,8 +186,10 @@ func (s *SecureVirtualHost) Visit(f func(Vertex)) {
 }
 
 func (s *SecureVirtualHost) Valid() bool {
-	// A SecureVirtualHost is valid if it has a Secret or a TCPProxy.
-	return s.Secret != nil || s.TCPProxy != nil
+	// A SecureVirtualHost is valid if either
+	// 1. it has a secret and at least one route.
+	// 2. it has a tcpproxy, because the tcpproxy backend may negotiate TLS itself.
+	return (s.Secret != nil && len(s.routes) > 0) || s.TCPProxy != nil
 }
 
 type Visitable interface {

--- a/internal/dag/dag_test.go
+++ b/internal/dag/dag_test.go
@@ -45,7 +45,7 @@ func TestSecureVirtualHostValid(t *testing.T) {
 	vh = SecureVirtualHost{
 		Secret: new(Secret),
 	}
-	assert.True(vh.Valid())
+	assert.False(vh.Valid())
 
 	vh = SecureVirtualHost{
 		VirtualHost: VirtualHost{

--- a/internal/e2e/sds_test.go
+++ b/internal/e2e/sds_test.go
@@ -84,12 +84,10 @@ func TestSDSVisibility(t *testing.T) {
 	}
 	rh.OnAdd(i1)
 
-	// TODO(dfc) #1165: secret should not be present if the ingress does not
-	// have any valid routes.
 	// i1 has a default route to backend:80, but there is no matching service.
 	c.Request(secretType).Equals(&v2.DiscoveryResponse{
 		VersionInfo: "1",
-		Resources:   resources(t, secret(s1)),
+		Resources:   resources(t),
 		TypeUrl:     secretType,
 		Nonce:       "1",
 	})


### PR DESCRIPTION
Fixes #1165

Filter out SecureVirtualHost objects that have a secret but no routes.
This will exclude the secret attached to those objects from SDS until
there are valid routes for that vhost.

Signed-off-by: Dave Cheney <dave@cheney.net>