### PR TITLE
internal/dag: move TCPProxy to SecureVirtualHost

### DIFF
--- a/internal/contour/listener.go
+++ b/internal/contour/listener.go
@@ -318,9 +318,9 @@ func (v *listenerVisitor) visit(vertex dag.Vertex) {
 			envoy.HTTPConnectionManager(ENVOY_HTTPS_LISTENER, v.httpsAccessLog()),
 		)
 		alpnProtos := []string{"h2", "http/1.1"}
-		if vh.VirtualHost.TCPProxy != nil {
+		if vh.TCPProxy != nil {
 			filters = envoy.Filters(
-				envoy.TCPProxy(ENVOY_HTTPS_LISTENER, vh.VirtualHost.TCPProxy, v.httpsAccessLog()),
+				envoy.TCPProxy(ENVOY_HTTPS_LISTENER, vh.TCPProxy, v.httpsAccessLog()),
 			)
 			alpnProtos = nil // do not offer ALPN
 		}

--- a/internal/contour/visitor_test.go
+++ b/internal/contour/visitor_test.go
@@ -41,19 +41,19 @@ func TestVisitClusters(t *testing.T) {
 					&dag.SecureVirtualHost{
 						VirtualHost: dag.VirtualHost{
 							Name: "www.example.com",
-							TCPProxy: &dag.TCPProxy{
-								Clusters: []*dag.Cluster{{
-									Upstream: &dag.TCPService{
-										Name:      "example",
-										Namespace: "default",
-										ServicePort: &v1.ServicePort{
-											Protocol:   "TCP",
-											Port:       443,
-											TargetPort: intstr.FromInt(8443),
-										},
+						},
+						TCPProxy: &dag.TCPProxy{
+							Clusters: []*dag.Cluster{{
+								Upstream: &dag.TCPService{
+									Name:      "example",
+									Namespace: "default",
+									ServicePort: &v1.ServicePort{
+										Protocol:   "TCP",
+										Port:       443,
+										TargetPort: intstr.FromInt(8443),
 									},
-								}},
-							},
+								},
+							}},
 						},
 						Secret: new(dag.Secret),
 					},
@@ -111,9 +111,9 @@ func TestVisitListeners(t *testing.T) {
 				VirtualHosts: virtualhosts(
 					&dag.SecureVirtualHost{
 						VirtualHost: dag.VirtualHost{
-							Name:     "tcpproxy.example.com",
-							TCPProxy: p1,
+							Name: "tcpproxy.example.com",
 						},
+						TCPProxy: p1,
 						Secret: &dag.Secret{
 							Object: &v1.Secret{
 								ObjectMeta: metav1.ObjectMeta{
@@ -168,19 +168,19 @@ func TestVisitSecrets(t *testing.T) {
 					&dag.SecureVirtualHost{
 						VirtualHost: dag.VirtualHost{
 							Name: "www.example.com",
-							TCPProxy: &dag.TCPProxy{
-								Clusters: []*dag.Cluster{{
-									Upstream: &dag.TCPService{
-										Name:      "example",
-										Namespace: "default",
-										ServicePort: &v1.ServicePort{
-											Protocol:   "TCP",
-											Port:       443,
-											TargetPort: intstr.FromInt(8443),
-										},
+						},
+						TCPProxy: &dag.TCPProxy{
+							Clusters: []*dag.Cluster{{
+								Upstream: &dag.TCPService{
+									Name:      "example",
+									Namespace: "default",
+									ServicePort: &v1.ServicePort{
+										Protocol:   "TCP",
+										Port:       443,
+										TargetPort: intstr.FromInt(8443),
 									},
-								}},
-							},
+								},
+							}},
 						},
 						Secret: &dag.Secret{
 							Object: &v1.Secret{

--- a/internal/dag/builder.go
+++ b/internal/dag/builder.go
@@ -674,7 +674,7 @@ func (b *Builder) processTCPProxy(ir *ingressroutev1.IngressRoute, visited []*in
 				LoadBalancerStrategy: service.Strategy,
 			})
 		}
-		b.lookupSecureVirtualHost(host).VirtualHost.TCPProxy = &proxy
+		b.lookupSecureVirtualHost(host).TCPProxy = &proxy
 		b.setStatus(Status{Object: ir, Status: StatusValid, Description: "valid IngressRoute", Vhost: host})
 		return
 	}

--- a/internal/dag/builder_test.go
+++ b/internal/dag/builder_test.go
@@ -1990,11 +1990,11 @@ func TestDAGInsert(t *testing.T) {
 						&SecureVirtualHost{
 							VirtualHost: VirtualHost{
 								Name: "kuard.example.com",
-								TCPProxy: &TCPProxy{
-									Clusters: clusters(
-										tcpService(s1),
-									),
-								},
+							},
+							TCPProxy: &TCPProxy{
+								Clusters: clusters(
+									tcpService(s1),
+								),
 							},
 							Secret:          secret(sec1),
 							MinProtoVersion: auth.TlsParameters_TLSv1_1,
@@ -2014,11 +2014,11 @@ func TestDAGInsert(t *testing.T) {
 						&SecureVirtualHost{
 							VirtualHost: VirtualHost{
 								Name: "kuard.example.com",
-								TCPProxy: &TCPProxy{
-									Clusters: clusters(
-										tcpService(s1),
-									),
-								},
+							},
+							TCPProxy: &TCPProxy{
+								Clusters: clusters(
+									tcpService(s1),
+								),
 							},
 						},
 					),
@@ -2037,11 +2037,11 @@ func TestDAGInsert(t *testing.T) {
 						&SecureVirtualHost{
 							VirtualHost: VirtualHost{
 								Name: "kuard.example.com",
-								TCPProxy: &TCPProxy{
-									Clusters: clusters(
-										tcpService(s6),
-									),
-								},
+							},
+							TCPProxy: &TCPProxy{
+								Clusters: clusters(
+									tcpService(s6),
+								),
 							},
 						},
 					),

--- a/internal/dag/dag.go
+++ b/internal/dag/dag.go
@@ -133,9 +133,6 @@ type VirtualHost struct {
 	Name string
 
 	routes map[string]Vertex
-
-	// Service to TCP proxy all incoming connections.
-	*TCPProxy
 }
 
 func (v *VirtualHost) addRoute(route Vertex) {
@@ -156,15 +153,11 @@ func (v *VirtualHost) Visit(f func(Vertex)) {
 	for _, r := range v.routes {
 		f(r)
 	}
-	if v.TCPProxy != nil {
-		f(v.TCPProxy)
-	}
 }
 
 func (v *VirtualHost) Valid() bool {
-	// A VirtualHost is valid if it has at least one route,
-	// or tcp proxy is not nil.
-	return len(v.routes) > 0 || v.TCPProxy != nil
+	// A VirtualHost is valid if it has at least one route.
+	return len(v.routes) > 0
 }
 
 // A SecureVirtualHost represents a HTTP host protected by TLS.
@@ -176,10 +169,16 @@ type SecureVirtualHost struct {
 
 	// The cert and key for this host.
 	Secret *Secret
+
+	// Service to TCP proxy all incoming connections.
+	*TCPProxy
 }
 
 func (s *SecureVirtualHost) Visit(f func(Vertex)) {
 	s.VirtualHost.Visit(f)
+	if s.TCPProxy != nil {
+		f(s.TCPProxy)
+	}
 	if s.Secret != nil {
 		f(s.Secret) // secret is not required if vhost is using tls passthrough
 	}

--- a/internal/dag/dag_test.go
+++ b/internal/dag/dag_test.go
@@ -29,11 +29,6 @@ func TestVirtualHostValid(t *testing.T) {
 		},
 	}
 	assert.True(vh.Valid())
-
-	vh = VirtualHost{
-		TCPProxy: new(TCPProxy),
-	}
-	assert.True(vh.Valid())
 }
 
 func TestSecureVirtualHostValid(t *testing.T) {
@@ -67,17 +62,13 @@ func TestSecureVirtualHostValid(t *testing.T) {
 	assert.True(vh.Valid())
 
 	vh = SecureVirtualHost{
-		VirtualHost: VirtualHost{
-			TCPProxy: new(TCPProxy),
-		},
+		TCPProxy: new(TCPProxy),
 	}
 	assert.True(vh.Valid())
 
 	vh = SecureVirtualHost{
-		Secret: new(Secret),
-		VirtualHost: VirtualHost{
-			TCPProxy: new(TCPProxy),
-		},
+		Secret:   new(Secret),
+		TCPProxy: new(TCPProxy),
 	}
 	assert.True(vh.Valid())
 }


### PR DESCRIPTION
Fixes #1374

Contour only supports tcp proxying on port 443. Adjust the DAG data
model so that it is not possible to create a DAG that has a tcpproxy on
a non secure port.

Signed-off-by: Dave Cheney <dave@cheney.net>