### PR TITLE
internal/dag: ignore service account token secrets

### DIFF
--- a/internal/dag/cache.go
+++ b/internal/dag/cache.go
@@ -54,6 +54,10 @@ type Meta struct {
 func (kc *KubernetesCache) Insert(obj interface{}) bool {
 	switch obj := obj.(type) {
 	case *v1.Secret:
+		if obj.Type == v1.SecretTypeServiceAccountToken {
+			// ignore service account tokens, see #1419
+			return false
+		}
 		if _, hasCA := obj.Data["ca.crt"]; obj.Type != v1.SecretTypeTLS && !hasCA {
 			// ignore everything but kubernetes.io/tls secrets
 			// and secrets with a ca.crt key.


### PR DESCRIPTION
Updates #1419

Service account tokens frequently have a `ca.crt` key which trips up our
filtering logic for CA certs for upstream TLS delegation. As a short
term fix, filter these out explicitly, however we should probably
enforce a known Secret.Type to avoid this weak detection logic.

Signed-off-by: Dave Cheney <dave@cheney.net>