### PR TITLE
examples: Update HTTPLoadBalancer CRD to have a shortname & be versioned

### DIFF
--- a/examples/common/httploadbalancer.yaml
+++ b/examples/common/httploadbalancer.yaml
@@ -6,11 +6,17 @@ metadata:
     component: httploadbalancer
 spec:
   group: projectcontour.io
-  version: v1alpha1
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
   scope: Namespaced
   names:
     plural: httploadbalancers
+    singular: httploadbalancer
     kind: HTTPLoadBalancer
+    shortNames:
+      - httplb
   additionalPrinterColumns:
     - name: FQDN
       type: string
@@ -43,8 +49,13 @@ spec:
   group: projectcontour.io
   version: v1alpha1
   scope: Namespaced
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
   names:
     plural: tlscertificatedelegations
+    singular: tlscertificatdelegation
     kind: TLSCertificateDelegation
   validation:
     openAPIV3Schema:
@@ -63,4 +74,3 @@ spec:
                     type: string
                   targetNamespaces:
                     type: array
-

--- a/examples/ds-hostnet-split-httploadbalancer/01-common.yaml
+++ b/examples/ds-hostnet-split-httploadbalancer/01-common.yaml
@@ -83,257 +83,17 @@ metadata:
     component: httploadbalancer
 spec:
   group: projectcontour.io
-  version: v1alpha1
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
   scope: Namespaced
   names:
     plural: httploadbalancers
+    singular: httploadbalancer
     kind: HTTPLoadBalancer
-  additionalPrinterColumns:
-    - name: FQDN
-      type: string
-      description: Fully qualified domain name
-      JSONPath: .spec.virtualhost.fqdn
-    - name: TLS Secret
-      type: string
-      description: Secret with TLS credentials
-      JSONPath: .spec.virtualhost.tls.secretName
-    - name: First route
-      type: string
-      description: First routes defined
-      JSONPath: .spec.routes[0].match
-    - name: Status
-      type: string
-      description: The current status of the IngressRoute
-      JSONPath: .status.currentStatus
-    - name: Status Description
-      type: string
-      description: Description of the current status
-      JSONPath: .status.description
-  validation:
-    openAPIV3Schema:
-      properties:
-        spec:
-          properties:
-            virtualhost:
-              properties:
-                fqdn:
-                  type: string
-                  # This regex handles two cases:
-                  # 1. A reasonably well-formed FQDN, which is allowed
-                  #    a hyphen in the top-level label (not usually
-                  #    the case for TLDs.) This fixes https://github.com/heptio/contour/issues/1117
-                  #    This is the first option in the regex.
-                  # 2. A bareword containing a hyphen, no periods. This fixes 
-                  #    https://github.com/heptio/contour/issues/755 and is the
-                  #    second option in the regex
-                  pattern: ^([a-zA-Z0-9]+(-[a-zA-Z0-9]+)*\.)+[\-a-z0-9]{2,}|[\-a-z0-9]+$
-                tls:
-                  properties:
-                    secretName:
-                      type: string
-                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?([\.\/][a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
-                    minimumProtocolVersion:
-                      type: string
-                      enum:
-                        - "1.3"
-                        - "1.2"
-                        - "1.1"
-            strategy:
-              type: string
-              enum:
-                - RoundRobin
-                - WeightedLeastRequest
-                - Random
-                - Cookie
-            healthCheck:
-              type: object
-              required:
-                - path
-              properties:
-                path:
-                  type: string
-                  pattern: ^\/.*$
-                intervalSeconds:
-                  type: integer
-                timeoutSeconds:
-                  type: integer
-                unhealthyThresholdCount:
-                  type: integer
-                healthyThresholdCount:
-                  type: integer
-            tcpproxy:
-              type: object
-              properties:
-                services:
-                  type: array
-                  items:
-                    type: object
-                    required:
-                      - name
-                      - port
-                    properties:
-                      name:
-                        type: string
-                        pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$ # DNS-1035 label
-                      port:
-                        type: integer
-                      weight:
-                        type: integer
-                      strategy:
-                        type: string
-                        enum:
-                          - RoundRobin
-                          - WeightedLeastRequest
-                          - Random
-                          - Cookie
-                      healthCheck:
-                        type: object
-                        required:
-                          - path
-                        properties:
-                          path:
-                            type: string
-                            pattern: ^\/.*$
-                          intervalSeconds:
-                            type: integer
-                          timeoutSeconds:
-                            type: integer
-                          unhealthyThresholdCount:
-                            type: integer
-                          healthyThresholdCount:
-                            type: integer
-                delegate:
-                  type: object
-                  required:
-                    - name
-                  properties:
-                    name:
-                      type: string
-                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$ # DNS-1123 subdomain
-                    namespace:
-                      type: string
-                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$ # DNS-1123 label
-            includes:
-              type: array
-              items:
-                properties:
-                  name:
-                    type: string
-                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$ # DNS-1123 subdomain
-                  namespace:
-                        type: string
-                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$ # DNS-1123 label
-                  conditions:
-                    type: array
-                    items:
-                      prefix:
-                        type: string
-                        pattern: ^\/.*$
-                      headersMatch:
-                        items:
-            routes:
-              type: array
-              items:
-                required:
-                  - match
-                properties:
-                  match:
-                    type: string
-                    pattern: ^\/.*$
-                  delegate:
-                    type: object
-                    required:
-                      - name
-                    properties:
-                      name:
-                        type: string
-                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$ # DNS-1123 subdomain
-                      namespace:
-                        type: string
-                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$ # DNS-1123 label
-                  services:
-                    type: array
-                    items:
-                      type: object
-                      required:
-                        - name
-                        - port
-                      properties:
-                        name:
-                          type: string
-                          pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$ # DNS-1035 label
-                        port:
-                          type: integer
-                        weight:
-                          type: integer
-                        strategy:
-                          type: string
-                          enum:
-                            - RoundRobin
-                            - WeightedLeastRequest
-                            - Random
-                            - Cookie
-                        healthCheck:
-                          type: object
-                          required:
-                            - path
-                          properties:
-                            path:
-                              type: string
-                              pattern: ^\/.*$
-                            intervalSeconds:
-                              type: integer
-                            timeoutSeconds:
-                              type: integer
-                            unhealthyThresholdCount:
-                              type: integer
-                            healthyThresholdCount:
-                              type: integer
----
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  name: tlscertificatedelegations.projectcontour.io
-  labels:
-    component: tlscertificatedelegation
-spec:
-  group: projectcontour.io
-  version: v1alpha1
-  scope: Namespaced
-  names:
-    plural: tlscertificatedelegations
-    kind: TLSCertificateDelegation
-  validation:
-    openAPIV3Schema:
-      properties:
-        spec:
-          properties:
-            delegations:
-              type: array
-              items:
-                type: object
-                required:
-                  - secretName
-                  - targetNamespaces
-                properties:
-                  match:
-                    type: string
-                  targetNamespaces:
-                    type: array
----
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  name: httploadbalancers.projectcontour.io
-  labels:
-    component: httploadbalancer
-spec:
-  group: projectcontour.io
-  version: v1alpha1
-  scope: Namespaced
-  names:
-    plural: httploadbalancers
-    kind: HTTPLoadBalancer
+    shortNames:
+      - httplb
   additionalPrinterColumns:
     - name: FQDN
       type: string
@@ -366,8 +126,13 @@ spec:
   group: projectcontour.io
   version: v1alpha1
   scope: Namespaced
+  versions:
+   - name: v1alpha1
+     served: true
+     storage: true
   names:
     plural: tlscertificatedelegations
+    singular: tlscertificatdelegation
     kind: TLSCertificateDelegation
   validation:
     openAPIV3Schema:


### PR DESCRIPTION
Updates the HTTPLoadBalancer CRD to have a shortname. Additionally, changed the spec so that it can be versioned as it progresses to v1.

Signed-off-by: Steve Sloka <steve@stevesloka.com>