### PR TITLE
internal/contour: move IngressRouteStatus to EventHandler

### DIFF
--- a/cmd/contour/serve.go
+++ b/cmd/contour/serve.go
@@ -150,12 +150,12 @@ func doServe(log logrus.FieldLogger, ctx *serveContext) error {
 			},
 			ListenerCache: contour.NewListenerCache(ctx.statsAddr, ctx.statsPort),
 			FieldLogger:   log.WithField("context", "CacheHandler"),
-			IngressRouteStatus: &k8s.IngressRouteStatus{
-				Client: contourClient,
-			},
 		},
 		HoldoffDelay:    100 * time.Millisecond,
 		HoldoffMaxDelay: 500 * time.Millisecond,
+		IngressRouteStatus: &k8s.IngressRouteStatus{
+			Client: contourClient,
+		},
 		Builder: dag.Builder{
 			Source: dag.KubernetesCache{
 				IngressRouteRootNamespaces: ctx.ingressRouteRootNamespaces(),

--- a/internal/e2e/e2e.go
+++ b/internal/e2e/e2e.go
@@ -77,9 +77,6 @@ func setup(t *testing.T, opts ...func(*contour.EventHandler)) (cache.ResourceEve
 
 	r := prometheus.NewRegistry()
 	ch := &contour.CacheHandler{
-		IngressRouteStatus: &k8s.IngressRouteStatus{
-			Client: fake.NewSimpleClientset(),
-		},
 		Metrics:       metrics.NewMetrics(r),
 		ListenerCache: contour.NewListenerCache(statsAddress, statsPort),
 		FieldLogger:   log,
@@ -88,7 +85,10 @@ func setup(t *testing.T, opts ...func(*contour.EventHandler)) (cache.ResourceEve
 	rand.Seed(time.Now().Unix())
 
 	eh := &contour.EventHandler{
-		CacheHandler:    ch,
+		CacheHandler: ch,
+		IngressRouteStatus: &k8s.IngressRouteStatus{
+			Client: fake.NewSimpleClientset(),
+		},
 		Metrics:         ch.Metrics,
 		FieldLogger:     log,
 		Sequence:        make(chan int, 1),


### PR DESCRIPTION
Updates #1425

Move the k8s.IngressRouteStatus object from the CacheHandler to the
EventHandler. In doing so the CacheHandler is only responsible for
updating itself via its visitors when presented with a new DAG.

Signed-off-by: Dave Cheney <dave@cheney.net>