### PR TITLE
Update leader election in prep for changing to multi-read, single-write

### DIFF
--- a/cmd/contour/serve.go
+++ b/cmd/contour/serve.go
@@ -113,7 +113,7 @@ func registerServe(app *kingpin.Application) (*kingpin.CmdClause, *serveContext)
 	serve.Flag("envoy-service-https-port", "Kubernetes Service port for HTTPS requests").IntVar(&ctx.httpsPort)
 	serve.Flag("use-proxy-protocol", "Use PROXY protocol for all listeners").BoolVar(&ctx.useProxyProto)
 
-	serve.Flag("enable-leader-election", "Enable leader election mechanism").BoolVar(&ctx.EnableLeaderElection)
+	serve.Flag("disable-leader-election", "Enable leader election mechanism").BoolVar(&ctx.DisableLeaderElection)
 	return serve, ctx
 }
 
@@ -300,10 +300,9 @@ func doServe(log logrus.FieldLogger, ctx *serveContext) error {
 	// managing the close process when the other goroutines are closed.
 	g.AddContext(func(electionCtx context.Context) {
 		log := log.WithField("context", "leaderelection")
-		if !ctx.EnableLeaderElection {
+		if ctx.DisableLeaderElection {
 			log.Info("Leader election disabled")
-			// if leader election is disabled, signal the gRPC goroutine
-			// to start serving and finsh up this context.
+			// if leader election is disabled, send the go signal.
 			// The Workgroup will handle leaving this running until everything
 			// else closes down.
 			close(leaderOK)
@@ -353,33 +352,26 @@ func doServe(log logrus.FieldLogger, ctx *serveContext) error {
 		}
 		opts := ctx.grpcOptions()
 		s := cgrpc.NewAPI(log, resources, opts...)
-		select {
-		case <-stop:
-			// shut down
-			return nil
-		case <-leaderOK:
-			// we've become leader, open the listening socket
-			addr := net.JoinHostPort(ctx.xdsAddr, strconv.Itoa(ctx.xdsPort))
-			l, err := net.Listen("tcp", addr)
-			if err != nil {
-				return err
-			}
-
-			log = log.WithField("address", addr)
-			if ctx.PermitInsecureGRPC {
-				log = log.WithField("insecure", true)
-			}
-
-			log.Info("started")
-			defer log.Info("stopped")
-
-			go func() {
-				<-stop
-				s.Stop()
-			}()
-
-			return s.Serve(l)
+		addr := net.JoinHostPort(ctx.xdsAddr, strconv.Itoa(ctx.xdsPort))
+		l, err := net.Listen("tcp", addr)
+		if err != nil {
+			return err
 		}
+
+		log = log.WithField("address", addr)
+		if ctx.PermitInsecureGRPC {
+			log = log.WithField("insecure", true)
+		}
+
+		log.Info("started")
+		defer log.Info("stopped")
+
+		go func() {
+			<-stop
+			s.Stop()
+		}()
+
+		return s.Serve(l)
 	})
 
 	// step 15. Setup SIGTERM handler

--- a/cmd/contour/servecontext.go
+++ b/cmd/contour/servecontext.go
@@ -80,7 +80,7 @@ type serveContext struct {
 	// permitInsecure field in IngressRoute.
 	DisablePermitInsecure bool `yaml:"disablePermitInsecure,omitempty"`
 
-	// DisableLeaderElection should only be set by command line flag.
+	// DisableLeaderElection can only be set by command line flag.
 	DisableLeaderElection bool `yaml:"-"`
 
 	// LeaderElectionConfig can be set in the config file.

--- a/cmd/contour/servecontext.go
+++ b/cmd/contour/servecontext.go
@@ -80,8 +80,8 @@ type serveContext struct {
 	// permitInsecure field in IngressRoute.
 	DisablePermitInsecure bool `yaml:"disablePermitInsecure,omitempty"`
 
-	// EnableLeaderElection should only be set by command line flag.
-	EnableLeaderElection bool `yaml:"-"`
+	// DisableLeaderElection should only be set by command line flag.
+	DisableLeaderElection bool `yaml:"-"`
 
 	// LeaderElectionConfig can be set in the config file.
 	LeaderElectionConfig `yaml:"leaderelection,omitempty"`
@@ -108,13 +108,13 @@ func newServeContext() *serveContext {
 		httpsPort:             8443,
 		PermitInsecureGRPC:    false,
 		DisablePermitInsecure: false,
-		EnableLeaderElection:  false,
+		DisableLeaderElection: false,
 		LeaderElectionConfig: LeaderElectionConfig{
 			LeaseDuration: time.Second * 15,
 			RenewDeadline: time.Second * 10,
 			RetryPeriod:   time.Second * 2,
 			Namespace:     "heptio-contour",
-			Name:          "contour",
+			Name:          "leader-elect",
 		},
 	}
 }

--- a/cmd/contour/servecontext_test.go
+++ b/cmd/contour/servecontext_test.go
@@ -119,7 +119,7 @@ func TestConfigFileDefaultOverrideImport(t *testing.T) {
 incluster: false
 disablePermitInsecure: false
 leaderelection:
-  configmap-name: contour
+  configmap-name: leader-elect
   configmap-namespace: heptio-contour
   lease-duration: 15s
   renew-deadline: 10s

--- a/examples/common/contour-config.yaml
+++ b/examples/common/contour-config.yaml
@@ -19,5 +19,5 @@ data:
     # The following config shows the defaults for the leader election.
     # leaderelection:
       # configmap-name: contour
-      # configmap-namespace: heptio-contour
+      # configmap-namespace: leader-elect
 ---

--- a/examples/common/rbac.yaml
+++ b/examples/common/rbac.yaml
@@ -67,6 +67,15 @@ rules:
   - put
   - post
   - patch
+- apiGroups: ["projectcontour.io"]
+  resources: ["httploadbalancers", "tlscertificatedelegations"]
+  verbs:
+  - get
+  - list
+  - watch
+  - put
+  - post
+  - patch
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: Role

--- a/examples/common/rbac.yaml
+++ b/examples/common/rbac.yaml
@@ -67,15 +67,6 @@ rules:
   - put
   - post
   - patch
-- apiGroups: ["projectcontour.io"]
-  resources: ["httploadbalancers", "tlscertificatedelegations"]
-  verbs:
-  - get
-  - list
-  - watch
-  - put
-  - post
-  - patch
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: Role

--- a/examples/contour/03-contour.yaml
+++ b/examples/contour/03-contour.yaml
@@ -33,7 +33,6 @@ spec:
       - args:
         - serve
         - --incluster
-        - --enable-leader-election
         - --xds-address=0.0.0.0
         - --xds-port=8001
         - --envoy-service-http-port=80

--- a/examples/render/contour.yaml
+++ b/examples/render/contour.yaml
@@ -346,7 +346,7 @@ data:
     # The following config shows the defaults for the leader election.
     # leaderelection:
       # configmap-name: contour
-      # configmap-namespace: heptio-contour
+      # configmap-namespace: leader-elect
 ---
 ---
 apiVersion: v1
@@ -481,6 +481,15 @@ rules:
   - put
   - post
   - patch
+- apiGroups: ["projectcontour.io"]
+  resources: ["httploadbalancers", "tlscertificatedelegations"]
+  verbs:
+  - get
+  - list
+  - watch
+  - put
+  - post
+  - patch
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: Role
@@ -594,7 +603,6 @@ spec:
       - args:
         - serve
         - --incluster
-        - --enable-leader-election
         - --xds-address=0.0.0.0
         - --xds-port=8001
         - --envoy-service-http-port=80

--- a/examples/render/contour.yaml
+++ b/examples/render/contour.yaml
@@ -481,15 +481,6 @@ rules:
   - put
   - post
   - patch
-- apiGroups: ["projectcontour.io"]
-  resources: ["httploadbalancers", "tlscertificatedelegations"]
-  verbs:
-  - get
-  - list
-  - watch
-  - put
-  - post
-  - patch
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: Role

--- a/examples/render/daemonset-rbac.yaml
+++ b/examples/render/daemonset-rbac.yaml
@@ -346,7 +346,7 @@ data:
     # The following config shows the defaults for the leader election.
     # leaderelection:
       # configmap-name: contour
-      # configmap-namespace: heptio-contour
+      # configmap-namespace: leader-elect
 ---
 apiVersion: apps/v1
 kind: DaemonSet
@@ -521,6 +521,15 @@ rules:
   - watch
 - apiGroups: ["contour.heptio.com"]
   resources: ["ingressroutes", "tlscertificatedelegations"]
+  verbs:
+  - get
+  - list
+  - watch
+  - put
+  - post
+  - patch
+- apiGroups: ["projectcontour.io"]
+  resources: ["httploadbalancers", "tlscertificatedelegations"]
   verbs:
   - get
   - list

--- a/examples/render/daemonset-rbac.yaml
+++ b/examples/render/daemonset-rbac.yaml
@@ -537,15 +537,6 @@ rules:
   - put
   - post
   - patch
-- apiGroups: ["projectcontour.io"]
-  resources: ["httploadbalancers", "tlscertificatedelegations"]
-  verbs:
-  - get
-  - list
-  - watch
-  - put
-  - post
-  - patch
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: Role

--- a/examples/render/deployment-rbac.yaml
+++ b/examples/render/deployment-rbac.yaml
@@ -547,15 +547,6 @@ rules:
   - put
   - post
   - patch
-- apiGroups: ["projectcontour.io"]
-  resources: ["httploadbalancers", "tlscertificatedelegations"]
-  verbs:
-  - get
-  - list
-  - watch
-  - put
-  - post
-  - patch
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: Role

--- a/examples/render/deployment-rbac.yaml
+++ b/examples/render/deployment-rbac.yaml
@@ -346,7 +346,7 @@ data:
     # The following config shows the defaults for the leader election.
     # leaderelection:
       # configmap-name: contour
-      # configmap-namespace: heptio-contour
+      # configmap-namespace: leader-elect
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -531,6 +531,15 @@ rules:
   - watch
 - apiGroups: ["contour.heptio.com"]
   resources: ["ingressroutes", "tlscertificatedelegations"]
+  verbs:
+  - get
+  - list
+  - watch
+  - put
+  - post
+  - patch
+- apiGroups: ["projectcontour.io"]
+  resources: ["httploadbalancers", "tlscertificatedelegations"]
   verbs:
   - get
   - list


### PR DESCRIPTION
Updates #1385 

- Leader election on by default.
- Leader election configmap now `leader-elect` not `contour` (will be created if it doesn't exist)
- Added RBAC for HttpLoadBalancer CRDs.
- Updated `contour` deployment.

Signed-off-by: Nick Young <ynick@vmware.com>