### PR TITLE
internal/dag: reject delegations from any ingressroute to a root

### DIFF
--- a/internal/dag/builder.go
+++ b/internal/dag/builder.go
@@ -596,6 +596,12 @@ func (b *Builder) processRoutes(ir *ingressroutev1.IngressRoute, prefixMatch str
 		}
 
 		if dest, ok := b.Source.ingressroutes[Meta{name: route.Delegate.Name, namespace: namespace}]; ok {
+			if dest.Spec.VirtualHost != nil {
+				description := fmt.Sprintf("root ingressroute cannot delegate to another root ingressroute")
+				b.setStatus(Status{Object: ir, Status: StatusInvalid, Description: description, Vhost: host})
+				return
+			}
+
 			// dest is not an orphaned ingress route, as there is an IR that points to it
 			delete(b.orphaned, Meta{name: dest.Name, namespace: dest.Namespace})
 


### PR DESCRIPTION
Fixes #865

Since 0.6 we've had a method called `dag.Builder.validIngressRoutes`
which excluded all but the IngressRoute roots. However we didn't have a
check at delegation point that the delegate was not itself a root. This
PR fixes that and adds some belt and braces tests to assert it won't
happen.

Adjust status tests to deal with the various order of delegation checks
vs other status checks.

Signed-off-by: Dave Cheney <dave@cheney.net>