### PR TITLE
internal/dag: introduce HealthCheckPolicy

### DIFF
--- a/internal/dag/builder.go
+++ b/internal/dag/builder.go
@@ -18,6 +18,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/api/extensions/v1beta1"
@@ -626,12 +627,12 @@ func healthCheckPolicy(hc *ingressroutev1.HealthCheck) *HealthCheckPolicy {
 		return nil
 	}
 	return &HealthCheckPolicy{
-		Path:                    hc.Path,
-		Host:                    hc.Host,
-		IntervalSeconds:         hc.IntervalSeconds,
-		TimeoutSeconds:          hc.TimeoutSeconds,
-		UnhealthyThresholdCount: hc.UnhealthyThresholdCount,
-		HealthyThresholdCount:   hc.HealthyThresholdCount,
+		Path:               hc.Path,
+		Host:               hc.Host,
+		Interval:           time.Duration(hc.IntervalSeconds) * time.Second,
+		Timeout:            time.Duration(hc.TimeoutSeconds) * time.Second,
+		UnhealthyThreshold: int(hc.UnhealthyThresholdCount),
+		HealthyThreshold:   int(hc.HealthyThresholdCount),
 	}
 }
 

--- a/internal/dag/builder.go
+++ b/internal/dag/builder.go
@@ -574,7 +574,7 @@ func (b *Builder) processRoutes(ir *ingressroutev1.IngressRoute, prefixMatch str
 					Upstream:             s,
 					LoadBalancerStrategy: service.Strategy,
 					Weight:               service.Weight,
-					HealthCheck:          service.HealthCheck,
+					HealthCheckPolicy:    healthCheckPolicy(service.HealthCheck),
 					UpstreamValidation:   uv,
 				})
 			}
@@ -619,6 +619,20 @@ func (b *Builder) processRoutes(ir *ingressroutev1.IngressRoute, prefixMatch str
 	}
 
 	b.setStatus(Status{Object: ir, Status: StatusValid, Description: "valid IngressRoute", Vhost: host})
+}
+
+func healthCheckPolicy(hc *ingressroutev1.HealthCheck) *HealthCheckPolicy {
+	if hc == nil {
+		return nil
+	}
+	return &HealthCheckPolicy{
+		Path:                    hc.Path,
+		Host:                    hc.Host,
+		IntervalSeconds:         hc.IntervalSeconds,
+		TimeoutSeconds:          hc.TimeoutSeconds,
+		UnhealthyThresholdCount: hc.UnhealthyThresholdCount,
+		HealthyThresholdCount:   hc.HealthyThresholdCount,
+	}
 }
 
 // TODO(dfc) needs unit tests; we should pass in some kind of context object that encasulates all the properties we need for reporting

--- a/internal/dag/builder_test.go
+++ b/internal/dag/builder_test.go
@@ -1953,7 +1953,7 @@ func TestDAGInsert(t *testing.T) {
 						virtualhost("example.com",
 							routeCluster("/", &Cluster{
 								Upstream: httpService(s1),
-								HealthCheck: &ingressroutev1.HealthCheck{
+								HealthCheckPolicy: &HealthCheckPolicy{
 									Path: "/healthz",
 								},
 							}),

--- a/internal/dag/dag.go
+++ b/internal/dag/dag.go
@@ -353,10 +353,10 @@ func (s *Secret) toMeta() Meta {
 
 // Cluster health check policy.
 type HealthCheckPolicy struct {
-	Path                    string
-	Host                    string
-	IntervalSeconds         int64
-	TimeoutSeconds          int64
-	UnhealthyThresholdCount uint32
-	HealthyThresholdCount   uint32
+	Path               string
+	Host               string
+	Interval           time.Duration
+	Timeout            time.Duration
+	UnhealthyThreshold int
+	HealthyThreshold   int
 }

--- a/internal/dag/dag.go
+++ b/internal/dag/dag.go
@@ -20,7 +20,6 @@ import (
 	"time"
 
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2/auth"
-	ingressroutev1 "github.com/heptio/contour/apis/contour/v1beta1"
 	v1 "k8s.io/api/core/v1"
 )
 
@@ -302,7 +301,8 @@ type Cluster struct {
 	// See https://www.envoyproxy.io/docs/envoy/latest/api-v2/api/v2/cds.proto#envoy-api-enum-cluster-lbpolicy
 	LoadBalancerStrategy string
 
-	HealthCheck *ingressroutev1.HealthCheck
+	// Cluster health check policy.
+	*HealthCheckPolicy
 }
 
 func (c Cluster) Visit(f func(Vertex)) {
@@ -349,4 +349,14 @@ func (s *Secret) toMeta() Meta {
 		name:      s.Name(),
 		namespace: s.Namespace(),
 	}
+}
+
+// Cluster health check policy.
+type HealthCheckPolicy struct {
+	Path                    string
+	Host                    string
+	IntervalSeconds         int64
+	TimeoutSeconds          int64
+	UnhealthyThresholdCount uint32
+	HealthyThresholdCount   uint32
 }

--- a/internal/envoy/cluster.go
+++ b/internal/envoy/cluster.go
@@ -180,17 +180,17 @@ func Clustername(cluster *dag.Cluster) string {
 	}
 	buf := cluster.LoadBalancerStrategy
 	if hc := cluster.HealthCheckPolicy; hc != nil {
-		if hc.TimeoutSeconds > 0 {
-			buf += (time.Duration(hc.TimeoutSeconds) * time.Second).String()
+		if hc.Timeout > 0 {
+			buf += hc.Timeout.String()
 		}
-		if hc.IntervalSeconds > 0 {
-			buf += (time.Duration(hc.IntervalSeconds) * time.Second).String()
+		if hc.Interval > 0 {
+			buf += hc.Interval.String()
 		}
-		if hc.UnhealthyThresholdCount > 0 {
-			buf += strconv.Itoa(int(hc.UnhealthyThresholdCount))
+		if hc.UnhealthyThreshold > 0 {
+			buf += strconv.Itoa(hc.UnhealthyThreshold)
 		}
-		if hc.HealthyThresholdCount > 0 {
-			buf += strconv.Itoa(int(hc.HealthyThresholdCount))
+		if hc.HealthyThreshold > 0 {
+			buf += strconv.Itoa(hc.HealthyThreshold)
 		}
 		buf += hc.Path
 	}

--- a/internal/envoy/cluster.go
+++ b/internal/envoy/cluster.go
@@ -98,7 +98,7 @@ func cluster(cluster *dag.Cluster, service *dag.TCPService) *v2.Cluster {
 	}
 
 	// Drain connections immediately if using healthchecks and the endpoint is known to be removed
-	if cluster.HealthCheck != nil {
+	if cluster.HealthCheckPolicy != nil {
 		c.DrainConnectionsOnHostRemoval = true
 	}
 
@@ -159,7 +159,7 @@ func lbPolicy(strategy string) v2.Cluster_LbPolicy {
 }
 
 func edshealthcheck(c *dag.Cluster) []*core.HealthCheck {
-	if c.HealthCheck == nil {
+	if c.HealthCheckPolicy == nil {
 		return nil
 	}
 	return []*core.HealthCheck{
@@ -179,7 +179,7 @@ func Clustername(cluster *dag.Cluster) string {
 		panic(fmt.Sprintf("unsupported upstream type: %T", s))
 	}
 	buf := cluster.LoadBalancerStrategy
-	if hc := cluster.HealthCheck; hc != nil {
+	if hc := cluster.HealthCheckPolicy; hc != nil {
 		if hc.TimeoutSeconds > 0 {
 			buf += (time.Duration(hc.TimeoutSeconds) * time.Second).String()
 		}

--- a/internal/envoy/cluster_test.go
+++ b/internal/envoy/cluster_test.go
@@ -395,8 +395,8 @@ func TestCluster(t *testing.T) {
 				CommonLbConfig:                ClusterCommonLBConfig(),
 				DrainConnectionsOnHostRemoval: true,
 				HealthChecks: []*core.HealthCheck{{
-					Timeout:            secondsOrDefault(0, hcTimeout),
-					Interval:           secondsOrDefault(0, hcInterval),
+					Timeout:            durationOrDefault(0, hcTimeout),
+					Interval:           durationOrDefault(0, hcInterval),
 					UnhealthyThreshold: countOrDefault(0, hcUnhealthyThreshold),
 					HealthyThreshold:   countOrDefault(0, hcHealthyThreshold),
 					HealthChecker: &core.HealthCheck_HttpHealthCheck_{
@@ -469,11 +469,11 @@ func TestClustername(t *testing.T) {
 				},
 				LoadBalancerStrategy: "Random",
 				HealthCheckPolicy: &dag.HealthCheckPolicy{
-					Path:                    "/healthz",
-					IntervalSeconds:         5,
-					TimeoutSeconds:          30,
-					UnhealthyThresholdCount: 3,
-					HealthyThresholdCount:   1,
+					Path:               "/healthz",
+					Interval:           5 * time.Second,
+					Timeout:            30 * time.Second,
+					UnhealthyThreshold: 3,
+					HealthyThreshold:   1,
 				},
 			},
 			want: "default/backend/80/5c26077e1d",

--- a/internal/envoy/cluster_test.go
+++ b/internal/envoy/cluster_test.go
@@ -23,7 +23,6 @@ import (
 	envoy_type "github.com/envoyproxy/go-control-plane/envoy/type"
 	"github.com/gogo/protobuf/types"
 	"github.com/google/go-cmp/cmp"
-	ingressroutev1 "github.com/heptio/contour/apis/contour/v1beta1"
 	"github.com/heptio/contour/internal/dag"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -379,7 +378,7 @@ func TestCluster(t *testing.T) {
 					Name: s1.Name, Namespace: s1.Namespace,
 					ServicePort: &s1.Spec.Ports[0],
 				},
-				HealthCheck: &ingressroutev1.HealthCheck{
+				HealthCheckPolicy: &dag.HealthCheckPolicy{
 					Path: "/healthz",
 				},
 			},
@@ -469,7 +468,7 @@ func TestClustername(t *testing.T) {
 					},
 				},
 				LoadBalancerStrategy: "Random",
-				HealthCheck: &ingressroutev1.HealthCheck{
+				HealthCheckPolicy: &dag.HealthCheckPolicy{
 					Path:                    "/healthz",
 					IntervalSeconds:         5,
 					TimeoutSeconds:          30,

--- a/internal/envoy/healthcheck.go
+++ b/internal/envoy/healthcheck.go
@@ -41,10 +41,10 @@ func healthCheck(cluster *dag.Cluster) *core.HealthCheck {
 	// TODO(dfc) why do we need to specify our own default, what is the default
 	// that envoy applies if these fields are left nil?
 	return &core.HealthCheck{
-		Timeout:            secondsOrDefault(hc.TimeoutSeconds, hcTimeout),
-		Interval:           secondsOrDefault(hc.IntervalSeconds, hcInterval),
-		UnhealthyThreshold: countOrDefault(hc.UnhealthyThresholdCount, hcUnhealthyThreshold),
-		HealthyThreshold:   countOrDefault(hc.HealthyThresholdCount, hcHealthyThreshold),
+		Timeout:            durationOrDefault(hc.Timeout, hcTimeout),
+		Interval:           durationOrDefault(hc.Interval, hcInterval),
+		UnhealthyThreshold: countOrDefault(hc.UnhealthyThreshold, hcUnhealthyThreshold),
+		HealthyThreshold:   countOrDefault(hc.HealthyThreshold, hcHealthyThreshold),
 		HealthChecker: &core.HealthCheck_HttpHealthCheck_{
 			HttpHealthCheck: &core.HealthCheck_HttpHealthCheck{
 				Path: hc.Path,
@@ -54,19 +54,18 @@ func healthCheck(cluster *dag.Cluster) *core.HealthCheck {
 	}
 }
 
-func secondsOrDefault(seconds int64, def time.Duration) *time.Duration {
-	if seconds != 0 {
-		t := time.Duration(seconds) * time.Second
-		return &t
+func durationOrDefault(duration, def time.Duration) *time.Duration {
+	if duration != 0 {
+		return &duration
 	}
 	return &def
 }
 
-func countOrDefault(count uint32, def int) *types.UInt32Value {
+func countOrDefault(count int, def int) *types.UInt32Value {
 	switch count {
 	case 0:
 		return u32(def)
 	default:
-		return u32(int(count))
+		return u32(count)
 	}
 }

--- a/internal/envoy/healthcheck.go
+++ b/internal/envoy/healthcheck.go
@@ -32,7 +32,7 @@ const (
 
 // healthCheck returns a *core.HealthCheck value.
 func healthCheck(cluster *dag.Cluster) *core.HealthCheck {
-	hc := cluster.HealthCheck
+	hc := cluster.HealthCheckPolicy
 	host := hcHost
 	if hc.Host != "" {
 		host = hc.Host

--- a/internal/envoy/healthcheck_test.go
+++ b/internal/envoy/healthcheck_test.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 	"github.com/google/go-cmp/cmp"
-	ingressroutev1 "github.com/heptio/contour/apis/contour/v1beta1"
 	"github.com/heptio/contour/internal/dag"
 )
 
@@ -32,7 +31,7 @@ func TestHealthCheck(t *testing.T) {
 		// when hc is nil, so if hc is not nil, at least one of the parameters on it must be set.
 		"blank healthcheck": {
 			cluster: &dag.Cluster{
-				HealthCheck: new(ingressroutev1.HealthCheck),
+				HealthCheckPolicy: new(dag.HealthCheckPolicy),
 			},
 			want: &core.HealthCheck{
 				Timeout:            duration(hcTimeout),
@@ -49,7 +48,7 @@ func TestHealthCheck(t *testing.T) {
 		},
 		"healthcheck path only": {
 			cluster: &dag.Cluster{
-				HealthCheck: &ingressroutev1.HealthCheck{
+				HealthCheckPolicy: &dag.HealthCheckPolicy{
 					Path: "/healthy",
 				},
 			},
@@ -68,7 +67,7 @@ func TestHealthCheck(t *testing.T) {
 		},
 		"explicit healthcheck": {
 			cluster: &dag.Cluster{
-				HealthCheck: &ingressroutev1.HealthCheck{
+				HealthCheckPolicy: &dag.HealthCheckPolicy{
 					Host:                    "foo-bar-host",
 					Path:                    "/healthy",
 					TimeoutSeconds:          99,

--- a/internal/envoy/healthcheck_test.go
+++ b/internal/envoy/healthcheck_test.go
@@ -68,12 +68,12 @@ func TestHealthCheck(t *testing.T) {
 		"explicit healthcheck": {
 			cluster: &dag.Cluster{
 				HealthCheckPolicy: &dag.HealthCheckPolicy{
-					Host:                    "foo-bar-host",
-					Path:                    "/healthy",
-					TimeoutSeconds:          99,
-					IntervalSeconds:         98,
-					UnhealthyThresholdCount: 97,
-					HealthyThresholdCount:   96,
+					Host:               "foo-bar-host",
+					Path:               "/healthy",
+					Timeout:            99 * time.Second,
+					Interval:           98 * time.Second,
+					UnhealthyThreshold: 97,
+					HealthyThreshold:   96,
 				},
 			},
 			want: &core.HealthCheck{


### PR DESCRIPTION
This PR is a cherry-pick from #1424.

Introduce a `dag.HealthCheckPolicy` type to normalise health check
policy parameters across IngressRoute and HTTPLoadBalancer.

Signed-off-by: Dave Cheney <dave@cheney.net>