### PR TITLE
Use Envoy's /ready endpoint for readiness probes

### DIFF
--- a/examples/contour/03-envoy.yaml
+++ b/examples/contour/03-envoy.yaml
@@ -56,7 +56,7 @@ spec:
           protocol: TCP
         readinessProbe:
           httpGet:
-            path: /healthz
+            path: /ready
             port: 8002
           initialDelaySeconds: 3
           periodSeconds: 3

--- a/examples/deployment-grpc-v2/02-contour.yaml
+++ b/examples/deployment-grpc-v2/02-contour.yaml
@@ -69,7 +69,7 @@ spec:
               fieldPath: metadata.name
         readinessProbe:
           httpGet:
-            path: /healthz
+            path: /ready
             port: 8002
           initialDelaySeconds: 3
           periodSeconds: 3

--- a/examples/ds-grpc-v2/02-contour.yaml
+++ b/examples/ds-grpc-v2/02-contour.yaml
@@ -70,7 +70,7 @@ spec:
               fieldPath: metadata.name
         readinessProbe:
           httpGet:
-            path: /healthz
+            path: /ready
             port: 8002
           initialDelaySeconds: 3
           periodSeconds: 3

--- a/examples/ds-hostnet-split-httploadbalancer/03-envoy.yaml
+++ b/examples/ds-hostnet-split-httploadbalancer/03-envoy.yaml
@@ -56,7 +56,7 @@ spec:
           protocol: TCP
         readinessProbe:
           httpGet:
-            path: /healthz
+            path: /ready
             port: 8002
           initialDelaySeconds: 3
           periodSeconds: 3

--- a/examples/ds-hostnet-split/03-envoy.yaml
+++ b/examples/ds-hostnet-split/03-envoy.yaml
@@ -56,7 +56,7 @@ spec:
           protocol: TCP
         readinessProbe:
           httpGet:
-            path: /healthz
+            path: /ready
             port: 8002
           initialDelaySeconds: 3
           periodSeconds: 3

--- a/examples/ds-hostnet/02-contour.yaml
+++ b/examples/ds-hostnet/02-contour.yaml
@@ -74,7 +74,7 @@ spec:
               fieldPath: metadata.name
         readinessProbe:
           httpGet:
-            path: /healthz
+            path: /ready
             port: 8002
           initialDelaySeconds: 3
           periodSeconds: 3

--- a/examples/render/contour.yaml
+++ b/examples/render/contour.yaml
@@ -715,7 +715,7 @@ spec:
           protocol: TCP
         readinessProbe:
           httpGet:
-            path: /healthz
+            path: /ready
             port: 8002
           initialDelaySeconds: 3
           periodSeconds: 3

--- a/examples/render/daemonset-rbac.yaml
+++ b/examples/render/daemonset-rbac.yaml
@@ -419,7 +419,7 @@ spec:
               fieldPath: metadata.name
         readinessProbe:
           httpGet:
-            path: /healthz
+            path: /ready
             port: 8002
           initialDelaySeconds: 3
           periodSeconds: 3

--- a/examples/render/deployment-rbac.yaml
+++ b/examples/render/deployment-rbac.yaml
@@ -418,7 +418,7 @@ spec:
               fieldPath: metadata.name
         readinessProbe:
           httpGet:
-            path: /healthz
+            path: /ready
             port: 8002
           initialDelaySeconds: 3
           periodSeconds: 3

--- a/internal/envoy/stats.go
+++ b/internal/envoy/stats.go
@@ -17,7 +17,6 @@ import (
 	v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2/listener"
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
-	health_check "github.com/envoyproxy/go-control-plane/envoy/config/filter/http/health_check/v2"
 	http "github.com/envoyproxy/go-control-plane/envoy/config/filter/network/http_connection_manager/v2"
 	"github.com/envoyproxy/go-control-plane/pkg/util"
 	"github.com/gogo/protobuf/types"
@@ -74,19 +73,6 @@ func StatsListener(address string, port int) *v2.Listener {
 							},
 						},
 						HttpFilters: []*http.HttpFilter{{
-							Name: util.HealthCheck,
-							ConfigType: &http.HttpFilter_TypedConfig{
-								TypedConfig: any(&health_check.HealthCheck{
-									PassThroughMode: &types.BoolValue{Value: false},
-									Headers: []*route.HeaderMatcher{{
-										Name: ":path",
-										HeaderMatchSpecifier: &route.HeaderMatcher_ExactMatch{
-											ExactMatch: "/healthz",
-										},
-									}},
-								}),
-							},
-						}, {
 							Name: util.Router,
 						}},
 						NormalizePath: &types.BoolValue{Value: true},

--- a/internal/envoy/stats.go
+++ b/internal/envoy/stats.go
@@ -40,20 +40,36 @@ func StatsListener(address string, port int) *v2.Listener {
 								VirtualHosts: []*route.VirtualHost{{
 									Name:    "backend",
 									Domains: []string{"*"},
-									Routes: []*route.Route{{
-										Match: &route.RouteMatch{
-											PathSpecifier: &route.RouteMatch_Prefix{
-												Prefix: "/stats",
+									Routes: []*route.Route{
+										{
+											Match: &route.RouteMatch{
+												PathSpecifier: &route.RouteMatch_Prefix{
+													Prefix: "/ready",
+												},
 											},
-										},
-										Action: &route.Route_Route{
-											Route: &route.RouteAction{
-												ClusterSpecifier: &route.RouteAction_Cluster{
-													Cluster: "service-stats",
+											Action: &route.Route_Route{
+												Route: &route.RouteAction{
+													ClusterSpecifier: &route.RouteAction_Cluster{
+														Cluster: "service-stats",
+													},
 												},
 											},
 										},
-									}},
+										{
+											Match: &route.RouteMatch{
+												PathSpecifier: &route.RouteMatch_Prefix{
+													Prefix: "/stats",
+												},
+											},
+											Action: &route.Route_Route{
+												Route: &route.RouteAction{
+													ClusterSpecifier: &route.RouteAction_Cluster{
+														Cluster: "service-stats",
+													},
+												},
+											},
+										},
+									},
 								}},
 							},
 						},

--- a/internal/envoy/stats_test.go
+++ b/internal/envoy/stats_test.go
@@ -19,7 +19,6 @@ import (
 	v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2/listener"
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
-	health_check "github.com/envoyproxy/go-control-plane/envoy/config/filter/http/health_check/v2"
 	http "github.com/envoyproxy/go-control-plane/envoy/config/filter/network/http_connection_manager/v2"
 	"github.com/envoyproxy/go-control-plane/pkg/util"
 	"github.com/gogo/protobuf/types"
@@ -83,19 +82,6 @@ func TestStatsListener(t *testing.T) {
 									},
 								},
 								HttpFilters: []*http.HttpFilter{{
-									Name: util.HealthCheck,
-									ConfigType: &http.HttpFilter_TypedConfig{
-										TypedConfig: any(&health_check.HealthCheck{
-											PassThroughMode: &types.BoolValue{Value: false},
-											Headers: []*route.HeaderMatcher{{
-												Name: ":path",
-												HeaderMatchSpecifier: &route.HeaderMatcher_ExactMatch{
-													ExactMatch: "/healthz",
-												},
-											}},
-										}),
-									},
-								}, {
 									Name: util.Router,
 								}},
 								NormalizePath: &types.BoolValue{Value: true},

--- a/internal/envoy/stats_test.go
+++ b/internal/envoy/stats_test.go
@@ -49,20 +49,36 @@ func TestStatsListener(t *testing.T) {
 										VirtualHosts: []*route.VirtualHost{{
 											Name:    "backend",
 											Domains: []string{"*"},
-											Routes: []*route.Route{{
-												Match: &route.RouteMatch{
-													PathSpecifier: &route.RouteMatch_Prefix{
-														Prefix: "/stats",
+											Routes: []*route.Route{
+												{
+													Match: &route.RouteMatch{
+														PathSpecifier: &route.RouteMatch_Prefix{
+															Prefix: "/ready",
+														},
 													},
-												},
-												Action: &route.Route_Route{
-													Route: &route.RouteAction{
-														ClusterSpecifier: &route.RouteAction_Cluster{
-															Cluster: "service-stats",
+													Action: &route.Route_Route{
+														Route: &route.RouteAction{
+															ClusterSpecifier: &route.RouteAction_Cluster{
+																Cluster: "service-stats",
+															},
 														},
 													},
 												},
-											}},
+												{
+													Match: &route.RouteMatch{
+														PathSpecifier: &route.RouteMatch_Prefix{
+															Prefix: "/stats",
+														},
+													},
+													Action: &route.Route_Route{
+														Route: &route.RouteAction{
+															ClusterSpecifier: &route.RouteAction_Cluster{
+																Cluster: "service-stats",
+															},
+														},
+													},
+												},
+											},
 										}},
 									},
 								},


### PR DESCRIPTION
This PR enables Envoy's 1.11+ `/ready` endpoint for readiness probes.

Closes #1277