### PR TITLE
internal/dag: permit combining non tls routing with tcp proxy

### DIFF
--- a/internal/dag/builder_test.go
+++ b/internal/dag/builder_test.go
@@ -719,13 +719,6 @@ func TestDAGInsert(t *testing.T) {
 					SecretName: sec1.Name,
 				},
 			},
-			Routes: []ingressroutev1.Route{{
-				Match: "/",
-				Services: []ingressroutev1.Service{{
-					Name: "kuard",
-					Port: 8080,
-				}},
-			}},
 			TCPProxy: &ingressroutev1.TCPProxy{
 				Services: []ingressroutev1.Service{{
 					Name: "kuard",
@@ -1315,7 +1308,6 @@ func TestDAGInsert(t *testing.T) {
 			}},
 		},
 	}
-
 	s5 := &v1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "blog-admin",
@@ -1486,6 +1478,57 @@ func TestDAGInsert(t *testing.T) {
 				Protocol: "TCP",
 				Port:     80,
 			}},
+		},
+	}
+
+	s10 := &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "tls-passthrough",
+			Namespace: "default",
+		},
+		Spec: v1.ServiceSpec{
+			Ports: []v1.ServicePort{{
+				Name:       "https",
+				Protocol:   "TCP",
+				Port:       443,
+				TargetPort: intstr.FromInt(443),
+			}, {
+				Name:       "http",
+				Protocol:   "TCP",
+				Port:       80,
+				TargetPort: intstr.FromInt(80),
+			}},
+		},
+	}
+
+	// ir18 tcp forwards traffic to by TLS pass-throughing
+	// it. It also exposes non HTTP traffic to the the non secure port of the
+	// application so it can give an informational message
+	ir18 := &ingressroutev1.IngressRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "kuard-tcp",
+			Namespace: s10.Namespace,
+		},
+		Spec: ingressroutev1.IngressRouteSpec{
+			VirtualHost: &projcontour.VirtualHost{
+				Fqdn: "kuard.example.com",
+				TLS: &projcontour.TLS{
+					Passthrough: true,
+				},
+			},
+			Routes: []ingressroutev1.Route{{
+				Match: "/",
+				Services: []ingressroutev1.Service{{
+					Name: s10.Name,
+					Port: 80, // proxy non secure traffic to port 80
+				}},
+			}},
+			TCPProxy: &ingressroutev1.TCPProxy{
+				Services: []ingressroutev1.Service{{
+					Name: s10.Name,
+					Port: 443, // ssl passthrough to secure port
+				}},
+			},
 		},
 	}
 
@@ -2683,7 +2726,43 @@ func TestDAGInsert(t *testing.T) {
 				},
 			),
 		},
-
+		"insert ingressroute routing and tcpproxying": {
+			objs: []interface{}{
+				s10, ir18,
+			},
+			want: listeners(
+				&Listener{
+					Port: 80,
+					VirtualHosts: virtualhosts(
+						virtualhost(ir18.Spec.VirtualHost.Fqdn,
+							routeCluster("/",
+								&Cluster{
+									Upstream: &Service{
+										Name:        s10.Name,
+										Namespace:   s10.Namespace,
+										ServicePort: &s10.Spec.Ports[1],
+									},
+								},
+							),
+						),
+					),
+				},
+				&Listener{
+					Port: 443,
+					VirtualHosts: virtualhosts(
+						&SecureVirtualHost{
+							VirtualHost: VirtualHost{
+								Name: ir18.Spec.VirtualHost.Fqdn,
+							},
+							TCPProxy: &TCPProxy{
+								Clusters: clusters(service(s10)),
+							},
+							MinProtoVersion: auth.TlsParameters_TLS_AUTO, // tls passthrough does not specify a TLS version; that's the domain of the backend
+						},
+					),
+				},
+			),
+		},
 		"insert root ingress route and delegate ingress route": {
 			objs: []interface{}{
 				ir5, s4, ir4, s5, ir3,

--- a/internal/dag/status_test.go
+++ b/internal/dag/status_test.go
@@ -654,6 +654,54 @@ func TestDAGIngressRouteStatus(t *testing.T) {
 		},
 	}
 
+	s10 := &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "tls-passthrough",
+			Namespace: "roots",
+		},
+		Spec: v1.ServiceSpec{
+			Ports: []v1.ServicePort{{
+				Name:       "https",
+				Protocol:   "TCP",
+				Port:       443,
+				TargetPort: intstr.FromInt(443),
+			}, {
+				Name:       "http",
+				Protocol:   "TCP",
+				Port:       80,
+				TargetPort: intstr.FromInt(80),
+			}},
+		},
+	}
+
+	ir27 := &ingressroutev1.IngressRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "kuard-tcp",
+			Namespace: s10.Namespace,
+		},
+		Spec: ingressroutev1.IngressRouteSpec{
+			VirtualHost: &projcontour.VirtualHost{
+				Fqdn: "kuard.example.com",
+				TLS: &projcontour.TLS{
+					Passthrough: true,
+				},
+			},
+			Routes: []ingressroutev1.Route{{
+				Match: "/",
+				Services: []ingressroutev1.Service{{
+					Name: s10.Name,
+					Port: 80, // proxy non secure traffic to port 80
+				}},
+			}},
+			TCPProxy: &ingressroutev1.TCPProxy{
+				Services: []ingressroutev1.Service{{
+					Name: s10.Name,
+					Port: 443, // ssl passthrough to secure port
+				}},
+			},
+		},
+	}
+
 	tests := map[string]struct {
 		objs []interface{}
 		want map[Meta]Status
@@ -871,6 +919,21 @@ func TestDAGIngressRouteStatus(t *testing.T) {
 					Object:      ir26,
 					Status:      StatusInvalid,
 					Description: sec2.Namespace + "/" + sec2.Name + ": certificate delegation not permitted",
+				},
+			},
+		},
+		// issue 910
+		"non tls routes can be combined with tcp proxy": {
+			objs: []interface{}{
+				s10,
+				ir27,
+			},
+			want: map[Meta]Status{
+				{name: ir27.Name, namespace: ir27.Namespace}: {
+					Object:      ir27,
+					Status:      StatusValid,
+					Description: `valid IngressRoute`,
+					Vhost:       ir27.Spec.VirtualHost.Fqdn,
 				},
 			},
 		},


### PR DESCRIPTION
Fixes #910

The use case is for a service offering tls passthrough on port 443, the
same service may wish to offer a non tls port which informs users they
need to connect over port 443. Presumably port 443 is not HTTPS but some
other protocol, the port 80 fallback is a convenience for people typing
the address into their browsers.

Signed-off-by: Dave Cheney <dave@cheney.net>