### PR TITLE
internal/contour: filter EDS notifications

### DIFF
--- a/internal/contour/cluster.go
+++ b/internal/contour/cluster.go
@@ -26,30 +26,9 @@ import (
 
 // ClusterCache manages the contents of the gRPC CDS cache.
 type ClusterCache struct {
-	mu      sync.Mutex
-	values  map[string]*v2.Cluster
-	waiters []chan int
-	last    int
-}
-
-// Register registers ch to receive a value when Notify is called.
-// The value of last is the count of the times Notify has been called on this Cache.
-// It functions of a sequence counter, if the value of last supplied to Register
-// is less than the Cache's internal counter, then the caller has missed at least
-// one notification and will fire immediately.
-//
-// Sends by the broadcaster to ch must not block, therefor ch must have a capacity
-// of at least 1.
-func (c *ClusterCache) Register(ch chan int, last int) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-
-	if last < c.last {
-		// notify this channel immediately
-		ch <- c.last
-		return
-	}
-	c.waiters = append(c.waiters, ch)
+	mu     sync.Mutex
+	values map[string]*v2.Cluster
+	Cond
 }
 
 // Update replaces the contents of the cache with the supplied map.
@@ -57,13 +36,8 @@ func (c *ClusterCache) Update(v map[string]*v2.Cluster) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	c.last++
 	c.values = v
-
-	for _, ch := range c.waiters {
-		ch <- c.last
-	}
-	c.waiters = c.waiters[:0]
+	c.Cond.Notify()
 }
 
 // Contents returns a copy of the cache's contents.

--- a/internal/contour/route.go
+++ b/internal/contour/route.go
@@ -28,30 +28,9 @@ import (
 
 // RouteCache manages the contents of the gRPC RDS cache.
 type RouteCache struct {
-	mu      sync.Mutex
-	values  map[string]*v2.RouteConfiguration
-	waiters []chan int
-	last    int
-}
-
-// Register registers ch to receive a value when Notify is called.
-// The value of last is the count of the times Notify has been called on this Cache.
-// It functions of a sequence counter, if the value of last supplied to Register
-// is less than the Cache's internal counter, then the caller has missed at least
-// one notification and will fire immediately.
-//
-// Sends by the broadcaster to ch must not block, therefor ch must have a capacity
-// of at least 1.
-func (c *RouteCache) Register(ch chan int, last int) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-
-	if last < c.last {
-		// notify this channel immediately
-		ch <- c.last
-		return
-	}
-	c.waiters = append(c.waiters, ch)
+	mu     sync.Mutex
+	values map[string]*v2.RouteConfiguration
+	Cond
 }
 
 // Update replaces the contents of the cache with the supplied map.
@@ -59,13 +38,8 @@ func (c *RouteCache) Update(v map[string]*v2.RouteConfiguration) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	c.last++
 	c.values = v
-
-	for _, ch := range c.waiters {
-		ch <- c.last
-	}
-	c.waiters = c.waiters[:0]
+	c.Cond.Notify()
 }
 
 // Contents returns a copy of the cache's contents.

--- a/internal/contour/secret.go
+++ b/internal/contour/secret.go
@@ -26,30 +26,9 @@ import (
 
 // SecretCache manages the contents of the gRPC SDS cache.
 type SecretCache struct {
-	mu      sync.Mutex
-	values  map[string]*auth.Secret
-	waiters []chan int
-	last    int
-}
-
-// Register registers ch to receive a value when Notify is called.
-// The value of last is the count of the times Notify has been called on this Cache.
-// It functions of a sequence counter, if the value of last supplied to Register
-// is less than the Cache's internal counter, then the caller has missed at least
-// one notification and will fire immediately.
-//
-// Sends by the broadcaster to ch must not block, therefor ch must have a capacity
-// of at least 1.
-func (c *SecretCache) Register(ch chan int, last int) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-
-	if last < c.last {
-		// notify this channel immediately
-		ch <- c.last
-		return
-	}
-	c.waiters = append(c.waiters, ch)
+	mu     sync.Mutex
+	values map[string]*auth.Secret
+	Cond
 }
 
 // Update replaces the contents of the cache with the supplied map.
@@ -57,13 +36,8 @@ func (c *SecretCache) Update(v map[string]*auth.Secret) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	c.last++
 	c.values = v
-
-	for _, ch := range c.waiters {
-		ch <- c.last
-	}
-	c.waiters = c.waiters[:0]
+	c.Cond.Notify()
 }
 
 // Contents returns a copy of the cache's contents.

--- a/internal/e2e/eds_test.go
+++ b/internal/e2e/eds_test.go
@@ -52,7 +52,7 @@ func TestAddRemoveEndpoints(t *testing.T) {
 
 	// check that it's been translated correctly.
 	assertEqual(t, &v2.DiscoveryResponse{
-		VersionInfo: "1",
+		VersionInfo: "2",
 		Resources: resources(t,
 			envoy.ClusterLoadAssignment(
 				"super-long-namespace-name-oh-boy/what-a-descriptive-service-name-you-must-be-so-proud/http",
@@ -66,17 +66,17 @@ func TestAddRemoveEndpoints(t *testing.T) {
 			),
 		),
 		TypeUrl: endpointType,
-		Nonce:   "1",
+		Nonce:   "2",
 	}, streamEDS(t, cc))
 
 	// remove e1 and check that the EDS cache is now empty.
 	rh.OnDelete(e1)
 
 	assertEqual(t, &v2.DiscoveryResponse{
-		VersionInfo: "2",
+		VersionInfo: "4",
 		Resources:   resources(t),
 		TypeUrl:     endpointType,
-		Nonce:       "2",
+		Nonce:       "4",
 	}, streamEDS(t, cc))
 }
 
@@ -112,7 +112,7 @@ func TestAddEndpointComplicated(t *testing.T) {
 	rh.OnAdd(e1)
 
 	assertEqual(t, &v2.DiscoveryResponse{
-		VersionInfo: "1",
+		VersionInfo: "2",
 		Resources: resources(t,
 			envoy.ClusterLoadAssignment(
 				"default/kuard/admin",
@@ -125,7 +125,7 @@ func TestAddEndpointComplicated(t *testing.T) {
 			),
 		),
 		TypeUrl: endpointType,
-		Nonce:   "1",
+		Nonce:   "2",
 	}, streamEDS(t, cc))
 }
 
@@ -163,7 +163,7 @@ func TestEndpointFilter(t *testing.T) {
 	rh.OnAdd(e1)
 
 	assertEqual(t, &v2.DiscoveryResponse{
-		VersionInfo: "1",
+		VersionInfo: "2",
 		Resources: resources(t,
 			envoy.ClusterLoadAssignment(
 				"default/kuard/foo",
@@ -171,16 +171,16 @@ func TestEndpointFilter(t *testing.T) {
 			),
 		),
 		TypeUrl: endpointType,
-		Nonce:   "1",
+		Nonce:   "2",
 	}, streamEDS(t, cc, "default/kuard/foo"))
 
 	assertEqual(t, &v2.DiscoveryResponse{
-		VersionInfo: "1",
+		VersionInfo: "2",
 		TypeUrl:     endpointType,
 		Resources: resources(t,
 			envoy.ClusterLoadAssignment("default/kuard/bar"),
 		),
-		Nonce: "1",
+		Nonce: "2",
 	}, streamEDS(t, cc, "default/kuard/bar"))
 
 }

--- a/internal/grpc/xds.go
+++ b/internal/grpc/xds.go
@@ -35,7 +35,7 @@ type Resource interface {
 	Query(names []string) []proto.Message
 
 	// Register registers ch to receive a value when Notify is called.
-	Register(chan int, int)
+	Register(chan int, int, ...string)
 
 	// TypeURL returns the typeURL of messages returned from Values.
 	TypeURL() string
@@ -109,7 +109,7 @@ func (xh *xdsHandler) stream(st grpcStream) (err error) {
 
 		// now we wait for a notification, if this is the first request received on this
 		// connection last will be less than zero and that will trigger a response immediately.
-		r.Register(ch, last)
+		r.Register(ch, last, req.ResourceNames...)
 		select {
 		case last = <-ch:
 			// boom, something in the cache has changed.

--- a/internal/grpc/xds_test.go
+++ b/internal/grpc/xds_test.go
@@ -167,10 +167,10 @@ type mockResource struct {
 	typeurl  func() string
 }
 
-func (m *mockResource) Contents() []proto.Message            { return m.contents() }
-func (m *mockResource) Query(names []string) []proto.Message { return m.query(names) }
-func (m *mockResource) Register(ch chan int, last int)       { m.register(ch, last) }
-func (m *mockResource) TypeURL() string                      { return m.typeurl() }
+func (m *mockResource) Contents() []proto.Message                       { return m.contents() }
+func (m *mockResource) Query(names []string) []proto.Message            { return m.query(names) }
+func (m *mockResource) Register(ch chan int, last int, hints ...string) { m.register(ch, last) }
+func (m *mockResource) TypeURL() string                                 { return m.typeurl() }
 
 func TestCounterNext(t *testing.T) {
 	var c counter


### PR DESCRIPTION
Updates #426 
Updates #499 

This PR consolidates all the `internal/contour` caches on the `Cond` type. The `Cond` type has been taught to send notifications to only those who register for those notification. At the moment this is only used for EDS however CDS and SDS may be possible. LDS and RDS are not useful as they only contain two entries each. 