### PR TITLE
Rename CRD / Fix metada name

### DIFF
--- a/examples/common/httpproxy.yaml
+++ b/examples/common/httpproxy.yaml
@@ -1,7 +1,7 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: httpproxy.projectcontour.io
+  name: httpproxies.projectcontour.io
   labels:
     component: httpproxy
 spec:


### PR DESCRIPTION
Updates #1479 to rename `httploadbalancer.yaml` --> `httpproxy.yaml`. Also, fixes k8s api issue where CRD name must be plural:

```
The CustomResourceDefinition "httpproxy.projectcontour.io" is invalid: metadata.name: Invalid value: "httpproxy.projectcontour.io": must be spec.names.plural+"."+spec.group
```

Signed-off-by: Steve Sloka <slokas@vmware.com>