### PR TITLE
internal/dag: fix build

### DIFF
--- a/internal/dag/status_test.go
+++ b/internal/dag/status_test.go
@@ -1143,7 +1143,7 @@ func TestDAGHTTPProxyStatus(t *testing.T) {
 		},
 	}
 
-	// proxy7 delegates to proxy8, which is invalid because proxy8 delegates back to proxy7
+	// proxy7 delegates to proxy8, which is invalid because proxy8 delegates back to proxy8
 	proxy7 := &projcontour.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "parent",
@@ -1170,7 +1170,7 @@ func TestDAGHTTPProxyStatus(t *testing.T) {
 		},
 		Spec: projcontour.HTTPProxySpec{
 			Includes: []projcontour.Include{{
-				Name:      "parent",
+				Name:      "child",
 				Namespace: "roots",
 				Condition: projcontour.Condition{
 					Prefix: "/foo",
@@ -1549,7 +1549,7 @@ func TestDAGHTTPProxyStatus(t *testing.T) {
 				{name: proxy6.Name, namespace: proxy6.Namespace}: {
 					Object:      proxy6,
 					Status:      "invalid",
-					Description: "include creates a delegation cycle: roots/self -> roots/self",
+					Description: "root httpproxy cannot delegate to another root httpproxy",
 					Vhost:       "example.com",
 				},
 			},
@@ -1566,7 +1566,7 @@ func TestDAGHTTPProxyStatus(t *testing.T) {
 				{name: proxy8.Name, namespace: proxy8.Namespace}: {
 					Object:      proxy8,
 					Status:      "invalid",
-					Description: "include creates a delegation cycle: roots/parent -> roots/child -> roots/parent",
+					Description: "include creates a delegation cycle: roots/parent -> roots/child -> roots/child",
 					Vhost:       "example.com",
 				},
 			},

--- a/internal/e2e/rds_test.go
+++ b/internal/e2e/rds_test.go
@@ -3968,7 +3968,7 @@ func TestRDSHTTPProxyRootCannotDelegateToAnotherRoot(t *testing.T) {
 	child := &projcontour.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "blog",
-			Namespace: "marketing",
+			Namespace: svc1.Namespace,
 		},
 		Spec: projcontour.HTTPProxySpec{
 			VirtualHost: &projcontour.VirtualHost{


### PR DESCRIPTION
Fix e2e/rds test failure caused by virtual host that shouldn't be there
because it was part of an invalid delegation chain.

The fix required moving the check for delegation from a root to another
root earlier in the process which required changing some fixtures.
Specifically a non root can never delegate to a root, either directly or
indirectly so we can't use that as a test fixture.

Signed-off-by: Dave Cheney <dave@cheney.net>